### PR TITLE
Make BlockEntityOven public for ease in modding

### DIFF
--- a/Systems/Cooking/Clayoven/BEClayOven.cs
+++ b/Systems/Cooking/Clayoven/BEClayOven.cs
@@ -12,7 +12,7 @@ using Vintagestory.GameContent;
 
 namespace Vintagestory.GameContent
 {
-    class BlockEntityOven : BlockEntityDisplay, IHeatSource
+    public class BlockEntityOven : BlockEntityDisplay, IHeatSource
     {
         // One Vec3f object only, for performance
         static readonly Vec3f centre = new Vec3f(0.5f, 0, 0.5f);


### PR DESCRIPTION
Most block entities are public so I just assume that this was a slight oversight.

Also, seems github was insistent that line endings be updated. Feel free to cancel this change and make a commit yourself if it bothers you.