### PR TITLE
Explicitly stated ":G" formatting for liquid content, which should fix the current display bug

### DIFF
--- a/Systems/Liquid/BlockLiquidContainerBase.cs
+++ b/Systems/Liquid/BlockLiquidContainerBase.cs
@@ -225,10 +225,10 @@ namespace Vintagestory.GameContent
             
             if (litres == 1)
             {
-                return Lang.Get("{0} ({1} litre of {2})", inSlot.Itemstack.GetName(), litres, incontainername);
+                return Lang.Get("{0} ({1:G} litre of {2})", inSlot.Itemstack.GetName(), litres, incontainername);
             }
 
-            return Lang.Get("{0} ({1} litres of {2})", inSlot.Itemstack.GetName(), litres, incontainername);
+            return Lang.Get("{0} ({1:G} litres of {2})", inSlot.Itemstack.GetName(), litres, incontainername);
         }
 
         public string GetContainedName(ItemSlot inSlot, int quantity)


### PR DESCRIPTION
That fixed the liquid content display for Lavoisier, I guess it should work for Vanilla too
(fixes the bug where it displays ",1 litres of water" when you have 0.16L for instance, ignoring the zero and 0.01L portions, and just displays " litres of water" with no quantity when you have less than 0.05L)

EDIT: It should probably also be in GetPlacedBlockInfo for an actual fix :D