### PR TITLE
Fix loading of rift ward in the off state

### DIFF
--- a/BlockEntity/BERiftWard.cs
+++ b/BlockEntity/BERiftWard.cs
@@ -111,7 +111,9 @@ namespace Vintagestory.GameContent
         }
 
         public void Deactivate()
-        {
+        {   
+            if (Api == null) return;
+            
             animUtil?.StopAnimation("on-spin");
             On = false;
             ToggleAmbientSound(false);


### PR DESCRIPTION
This PR fixes an issue with loading of rift wards in off state when loading the world.

Discord report: https://discord.com/channels/302152934249070593/1132917500720467969