### PR TITLE
Fix glider behaviour in backpack's content

### DIFF
--- a/Item/ItemGlider.cs
+++ b/Item/ItemGlider.cs
@@ -35,7 +35,7 @@ namespace Vintagestory.GameContent
                 if (plr.Entity.Controls.Gliding)
                 {
                     glidingAccum = Math.Min(3.01f / speed, glidingAccum + dt);
-                    if (!HasGilder) plr.Entity.Controls.Gliding = false;
+                    if (!HasGlider) plr.Entity.Controls.Gliding = false;
                 }
                 else
                 {
@@ -57,7 +57,7 @@ namespace Vintagestory.GameContent
         private void Input_InWorldAction(EnumEntityAction action, bool on, ref EnumHandling handled)
         {
             var eplr = capi.World.Player.Entity;
-            if (action == EnumEntityAction.Jump && on && !eplr.OnGround && HasGilder && !eplr.Controls.IsFlying)
+            if (action == EnumEntityAction.Jump && on && !eplr.OnGround && HasGlider && !eplr.Controls.IsFlying)
             {
                 eplr.Controls.Gliding = true;
                 eplr.Controls.IsFlying = true;
@@ -70,7 +70,7 @@ namespace Vintagestory.GameContent
             }
         }
 
-        bool HasGilder {  
+        bool HasGlider {  
             get
             {
                 var inv = capi.World.Player.InventoryManager.GetOwnInventory(GlobalConstants.backpackInvClassName);

--- a/Item/ItemGlider.cs
+++ b/Item/ItemGlider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Config;
@@ -73,7 +74,7 @@ namespace Vintagestory.GameContent
             get
             {
                 var inv = capi.World.Player.InventoryManager.GetOwnInventory(GlobalConstants.backpackInvClassName);
-                foreach (var slot in inv)
+                foreach (var slot in inv.Take(4))
                 {
                     if (slot.Itemstack?.Collectible is ItemGlider)
                     {


### PR DESCRIPTION
This PR fixes the issue that caused the glider to also work while in the contents of the backpack.

There was also a typo in the name of the property. I fixed it too.

As a suggestion - maybe make `ItemSlot[] backPackSlots` and `List<ItemSlot> backPackContents` in `InventoryPlayerBackPacks.cs` public to separate the iteration by "backpack-only" slots and by the contents of backpacks?

Discord report: https://discord.com/channels/302152934249070593/1134876018763649164