### PR TITLE
Make it so that terminus teleporter has no fuel by default

### DIFF
--- a/Systems/JonasDevices/BlockCorpseReturnTeleporter.cs
+++ b/Systems/JonasDevices/BlockCorpseReturnTeleporter.cs
@@ -16,7 +16,7 @@ namespace Vintagestory.GameContent
     {
         public ILoadedSound translocatingSound;
 
-        bool HasFuel = true;
+        bool HasFuel = false;
         BlockCorpseReturnTeleporter ownBlock;
         bool canTeleport = false;
         long somebodyIsTeleportingReceivedTotalMs;


### PR DESCRIPTION
This PR makes it so that terminus teleporter has no fuel by default. So that it cannot be "recharged" by breaking it and placing it again.

Discord report: https://discord.com/channels/302152934249070593/1134930277173567499