### PR TITLE
Seaweedgoesinsea

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 /.gitignore
 /obj
+/.vs
+/.gitignore
+/VSSurvivalMod.csproj
+/VSSurvivalMod.sln
+/.gitignore
+/VSSurvivalMod.csproj

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,0 @@
-/.gitignore
-/obj
-/.vs
-/.gitignore
-/VSSurvivalMod.csproj
-/VSSurvivalMod.sln
-/.gitignore
-/VSSurvivalMod.csproj

--- a/Block/BlockSeaweed.cs
+++ b/Block/BlockSeaweed.cs
@@ -41,7 +41,7 @@ namespace Vintagestory.GameContent
             if (block.LiquidCode != "saltwater") return false;
 
             int depth = 1;
-            while (depth < 10)
+            while (depth < 40)
             {
                 belowPos.Down();
                 block = blockAccessor.GetBlock(belowPos);
@@ -66,7 +66,7 @@ namespace Vintagestory.GameContent
 
         private void PlaceSeaweed(IBlockAccessor blockAccessor, BlockPos pos, int depth)
         {
-            int height = Math.Min(depth-1,  1 + random.Next(3) + random.Next(3));
+            int height = Math.Min(depth-1,  1 + random.Next(15) + random.Next(15));
 
             if (blocks == null)
             {

--- a/Block/BlockSeaweed.cs
+++ b/Block/BlockSeaweed.cs
@@ -38,7 +38,7 @@ namespace Vintagestory.GameContent
             BlockPos belowPos = pos.DownCopy();
 
             Block block = blockAccessor.GetBlock(belowPos, BlockLayersAccess.Fluid);
-            if (block.LiquidCode != "water") return false;
+            if (block.LiquidCode != "saltwater") return false;
 
             int depth = 1;
             while (depth < 10)

--- a/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/BlockPatchConfig.cs
+++ b/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/BlockPatchConfig.cs
@@ -46,7 +46,7 @@ namespace Vintagestory.ServerMods.NoObf
         public bool IsPatchSuitableAt(BlockPatch patch, Block onBlock, int mapSizeY, int climate, int y, float forestRel, float shrubRel)
         {
             if ((patch.Placement == EnumBlockPatchPlacement.NearWater || patch.Placement == EnumBlockPatchPlacement.UnderWater) && onBlock.LiquidCode != "water") return false;
-            if ((patch.Placement == EnumBlockPatchPlacement.NearSeaWater || patch.Placement == EnumBlockPatchPlacement.UnderSeaWater) && onBlock.LiquidCode != "seawater") return false;
+            if ((patch.Placement == EnumBlockPatchPlacement.NearSeaWater || patch.Placement == EnumBlockPatchPlacement.UnderSeaWater) && onBlock.LiquidCode != "saltwater") return false;
 
             if (forestRel < patch.MinForest || forestRel > patch.MaxForest || shrubRel < patch.MinShrub || forestRel > patch.MaxShrub)
             {

--- a/VSSurvivalMod.csproj
+++ b/VSSurvivalMod.csproj
@@ -25,23 +25,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="cairo-sharp">
-      <HintPath>..\..\..\AppData\Roaming\Vintagestory-pre7\Lib\cairo-sharp.dll</HintPath>
-    </Reference>
-    <Reference Include="SkiaSharp">
-      <HintPath>..\..\..\AppData\Roaming\Vintagestory\Lib\SkiaSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="VintagestoryAPI">
-      <HintPath>..\..\..\AppData\Roaming\Vintagestory-pre7\VintagestoryAPI.dll</HintPath>
-    </Reference>
-    <Reference Include="VintagestoryLib">
-      <HintPath>..\..\..\AppData\Roaming\Vintagestory-pre7\VintagestoryLib.dll</HintPath>
-    </Reference>
-    <Reference Include="VSCreativeMod">
-      <HintPath>..\..\..\AppData\Roaming\Vintagestory-pre7\Mods\VSCreativeMod.dll</HintPath>
-    </Reference>
-    <Reference Include="VSEssentials">
-      <HintPath>..\..\..\AppData\Roaming\Vintagestory-pre7\Mods\VSEssentials.dll</HintPath>
-    </Reference>
+    <ProjectReference Include="..\Cairo\Cairo.csproj" />
+    <ProjectReference Include="..\VintagestoryApi\VintagestoryAPI.csproj" />
+    <ProjectReference Include="..\VSCreativeMod\VSCreativeMod.csproj" />
+    <ProjectReference Include="..\VSEssentials\VSEssentialsMod.csproj" />
   </ItemGroup>
 </Project>

--- a/VSSurvivalMod.csproj
+++ b/VSSurvivalMod.csproj
@@ -25,9 +25,23 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Cairo\Cairo.csproj" />
-    <ProjectReference Include="..\VintagestoryApi\VintagestoryAPI.csproj" />
-    <ProjectReference Include="..\VSCreativeMod\VSCreativeMod.csproj" />
-    <ProjectReference Include="..\VSEssentials\VSEssentialsMod.csproj" />
+    <Reference Include="cairo-sharp">
+      <HintPath>..\..\..\AppData\Roaming\Vintagestory-pre7\Lib\cairo-sharp.dll</HintPath>
+    </Reference>
+    <Reference Include="SkiaSharp">
+      <HintPath>..\..\..\AppData\Roaming\Vintagestory\Lib\SkiaSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="VintagestoryAPI">
+      <HintPath>..\..\..\AppData\Roaming\Vintagestory-pre7\VintagestoryAPI.dll</HintPath>
+    </Reference>
+    <Reference Include="VintagestoryLib">
+      <HintPath>..\..\..\AppData\Roaming\Vintagestory-pre7\VintagestoryLib.dll</HintPath>
+    </Reference>
+    <Reference Include="VSCreativeMod">
+      <HintPath>..\..\..\AppData\Roaming\Vintagestory-pre7\Mods\VSCreativeMod.dll</HintPath>
+    </Reference>
+    <Reference Include="VSEssentials">
+      <HintPath>..\..\..\AppData\Roaming\Vintagestory-pre7\Mods\VSEssentials.dll</HintPath>
+    </Reference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The LiquidCode checks for seaweed worldgen are incorrect. Also the seaweed is far too short when it's actually placed in the ocean. I've based the lengths and depth on giant kelp and bull kelp stats.

To have seaweed actually go in the ocean:

  {
    "file": "game:worldgen/blockpatches/other.json",
    "op": "add",
    "path": "/4/placement",
    "side": "Server",
    "value": "UnderSeaWater"
  },
  {
    "file": "game:worldgen/blockpatches/other.json",
    "op": "add",
    "path": "/5/placement",
    "side": "Server",
    "value": "UnderSeaWater"
  }