### PR TITLE
Fix anegostudios/VintageStory-Issues#3250 and metal plate related stuff

### DIFF
--- a/Item/ItemIngot.cs
+++ b/Item/ItemIngot.cs
@@ -91,7 +91,11 @@ namespace Vintagestory.GameContent
                     return null;
                 }
 
-                AddVoxelsFromIngot(api, ref beAnvil.Voxels);
+                if (AddVoxelsFromIngot(api, ref beAnvil.Voxels) == 0)
+                {
+                    if (api.Side == EnumAppSide.Client) (api as ICoreClientAPI).TriggerIngameError(this, "requireshammering", Lang.Get("Try hammering down before adding additional voxels"));
+                    return null;
+                }
             }
 
             return workItemStack;
@@ -127,8 +131,9 @@ namespace Vintagestory.GameContent
             }
         }
 
-        public static void AddVoxelsFromIngot(ICoreAPI api, ref byte[,,] voxels, bool isBlisterSteel = false)
+        public static int AddVoxelsFromIngot(ICoreAPI api, ref byte[,,] voxels, bool isBlisterSteel = false)
         {
+            int totalAdded = 0;
             for (int x = 0; x < 7; x++)
             {
                 for (int z = 0; z < 3; z++)
@@ -141,6 +146,7 @@ namespace Vintagestory.GameContent
                         {
                             voxels[4 + x, y, 6 + z] = (byte)EnumVoxelMaterial.Metal;
                             added++;
+                            totalAdded++;
                         }
 
                         y++;
@@ -159,6 +165,8 @@ namespace Vintagestory.GameContent
                     }
                 }
             }
+
+            return totalAdded;
         }
 
         public ItemStack GetBaseMaterial(ItemStack stack)

--- a/Item/ItemMetalPlate.cs
+++ b/Item/ItemMetalPlate.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Vintagestory.API.Client;
 using Vintagestory.API.Common;
+using Vintagestory.API.Config;
 
 namespace Vintagestory.GameContent
 {
@@ -69,6 +71,13 @@ namespace Vintagestory.GameContent
             }
             else
             {
+                IAnvilWorkable workable = beAnvil.WorkItemStack.Collectible as IAnvilWorkable;
+                if (!workable.GetBaseMaterial(beAnvil.WorkItemStack).Equals(api.World, GetBaseMaterial(stack), GlobalConstants.IgnoredStackAttributes))
+                {
+                    if (api.Side == EnumAppSide.Client) (api as ICoreClientAPI).TriggerIngameError(this, "notequal", Lang.Get("Must be the same metal to add voxels"));
+                    return null;
+                }
+
                 AddVoxels(ref beAnvil.Voxels);
             }
 

--- a/Item/ItemMetalPlate.cs
+++ b/Item/ItemMetalPlate.cs
@@ -79,7 +79,11 @@ namespace Vintagestory.GameContent
                     return null;
                 }
 
-                AddVoxels(ref beAnvil.Voxels);
+                if (AddVoxels(ref beAnvil.Voxels) == 0)
+                {
+                    if (api.Side == EnumAppSide.Client) (api as ICoreClientAPI).TriggerIngameError(this, "requireshammering", Lang.Get("Try hammering down before adding additional voxels"));
+                    return null;
+                }
             }
 
             return workItemStack;
@@ -103,8 +107,9 @@ namespace Vintagestory.GameContent
             }
         }
 
-        public static void AddVoxels(ref byte[,,] voxels)
+        public static int AddVoxels(ref byte[,,] voxels)
         {
+            int totalAdded = 0;
             for (int x = 0; x < 9; x++)
             {
                 for (int z = 0; z < 9; z++)
@@ -117,12 +122,15 @@ namespace Vintagestory.GameContent
                         {
                             voxels[3 + x, y, 3 + z] = (byte)EnumVoxelMaterial.Metal;
                             added++;
+                            totalAdded++;
                         }
 
                         y++;
                     }
                 }
             }
+
+            return totalAdded;
         }
 
         public ItemStack GetBaseMaterial(ItemStack stack)

--- a/Item/ItemMetalPlate.cs
+++ b/Item/ItemMetalPlate.cs
@@ -40,6 +40,7 @@ namespace Vintagestory.GameContent
 
             return api.GetSmithingRecipes()
                 .Where(r => r.Ingredient.SatisfiesAsIngredient(basemat))
+                .Where(r => r.Output.ResolvedItemstack.Collectible.Code != stack.Collectible.Code)
                 .OrderBy(r => r.Output.ResolvedItemstack.Collectible.Code) // Cannot sort by name, thats language dependent!
                 .ToList()
             ;


### PR DESCRIPTION
This PR has several fixes:

- Fixed being able to add a metal plate to any type of metal
- Removed metal plate from smithing recipes displayed for it
- Fixed anegostudios/VintageStory-Issues#3250

The latest fix requires your review. I am ready to correct/rewrite it.

There is also a code in `ItemIngot.AddVoxelsFromIngot`  that seem unnecessary
```c#
...
if (isBlisterSteel && y < 6)
{
    if (api.World.Rand.NextDouble() < 0.5)
    {
        voxels[4 + x, y + 1, 6 + z] = (byte)EnumVoxelMaterial.Metal;
    }
    if (api.World.Rand.NextDouble() < 0.5)
    {
        voxels[4 + x, y + 1, 6 + z] = (byte)EnumVoxelMaterial.Slag;
    }
}
...
```
due to the code in `ItemIngot.TryPlaceOn`
```c#
...
{
    if (isBlisterSteel) return null;

    IAnvilWorkable workable = beAnvil.WorkItemStack.Collectible as IAnvilWorkable;
...
```