### PR TITLE
Add support for multiple parts itemcode for ItemPlantableSeed

### DIFF
--- a/Item/ItemPlantableSeed.cs
+++ b/Item/ItemPlantableSeed.cs
@@ -45,13 +45,18 @@ namespace Vintagestory.GameContent
             });
         }
 
+        public static string GetCodeWithoutFirstPart(ItemSlot itemslot)
+        {
+            return itemslot.Itemstack.Collectible.CodeEndWithoutParts(1);
+        }
+
         public override void OnHeldInteractStart(ItemSlot itemslot, EntityAgent byEntity, BlockSelection blockSel, EntitySelection entitySel, bool firstEvent, ref EnumHandHandling handHandling)
         {
             if (blockSel == null) return;
 
             BlockPos pos = blockSel.Position;
 
-            string lastCodePart = itemslot.Itemstack.Collectible.LastCodePart();
+            string lastCodePart = GetCodeWithoutFirstPart(itemslot);
 
             if (lastCodePart == "bellpepper") return;
 
@@ -86,7 +91,7 @@ namespace Vintagestory.GameContent
         {
             base.GetHeldItemInfo(inSlot, dsc, world, withDebugInfo);
 
-            Block cropBlock = world.GetBlock(CodeWithPath("crop-" + inSlot.Itemstack.Collectible.LastCodePart() + "-1"));
+            Block cropBlock = world.GetBlock(CodeWithPath("crop-" + GetCodeWithoutFirstPart(inSlot) + "-1"));
             if (cropBlock == null || cropBlock.CropProps == null) return;
 
             dsc.AppendLine(Lang.Get("soil-nutrition-requirement") + cropBlock.CropProps.RequiredNutrient);


### PR DESCRIPTION
Currently it supports only seeds itemtype with `xxx-yyy` itemcode, with this change it will support seeds itemtype with any amount of parts as well, for example `xxx-yyy-yyy` or `xxx-yyy-yyy-yyy`. 

Shouldn't break anything since last code part only matters in `crop-yyy-stage` blockcode to check for current stage.