### PR TITLE
(Ground Storage) Fix pile creating when holding Ctrl

### DIFF
--- a/BlockEntity/BEGroundStorage.cs
+++ b/BlockEntity/BEGroundStorage.cs
@@ -709,7 +709,9 @@ namespace Vintagestory.GameContent
 
             if (invSlot.Empty)
             {
-                if (hotbarSlot.TryPutInto(Api.World, invSlot, TransferQuantity) > 0)
+                bool putBulk = player.Entity.Controls.CtrlKey;
+
+                if (hotbarSlot.TryPutInto(Api.World, invSlot, putBulk ? BulkTransferQuantity : TransferQuantity) > 0)
                 {
                     Api.World.PlaySoundAt(StorageProps.PlaceRemoveSound.WithPathPrefixOnce("sounds/"), Pos.X, Pos.Y, Pos.Z, null, 0.88f + (float)Api.World.Rand.NextDouble() * 0.24f, 16);
                 }


### PR DESCRIPTION
Uses `BulkTransferQuantity` instead `TransferQuantity` when holding Ctrl when creating pile, thus placing for example 4+4+4... instead 1+4+4...

Fixes https://github.com/anegostudios/VintageStory-Issues/issues/2946

~~Peat bricks should be GroundStorable to get this fix as well, it is the only pile that wasn't converted to GroundStorable~~

Video demonstration:
https://github.com/anegostudios/vssurvivalmod/assets/69315569/5dd3169f-4bee-440a-b9ff-73329d29175b

