### PR TITLE
Make clay oven more moddable

### DIFF
--- a/Systems/Cooking/Clayoven/BEClayOven.cs
+++ b/Systems/Cooking/Clayoven/BEClayOven.cs
@@ -816,7 +816,13 @@ namespace Vintagestory.GameContent
                 MeshData mesh = getMesh(stack);
                 if (mesh != null) return mesh;
 
-                var loc = AssetLocation.Create(Block.Attributes["ovenFuelShape"].AsString(), Block.Code.Domain).WithPathPrefixOnce("shapes/").WithPathAppendixOnce(".json");
+                string shapeLoc = this.Block.Attributes["ovenFuelShape"].AsString();
+                if (this.FuelSlot?.Itemstack?.Collectible.Attributes.KeyExists("ovenFuelShape") == true)
+                {
+                    shapeLoc = this.FuelSlot.Itemstack.Collectible.Attributes["ovenFuelShape"].AsString();
+                }   
+
+                var loc = AssetLocation.Create(shapeLoc, Block.Code.Domain).WithPathPrefixOnce("shapes/").WithPathAppendixOnce(".json");
                 nowTesselatingShape = Shape.TryGet(capi, loc);
                 nowTesselatingObj = stack.Collectible;
 


### PR DESCRIPTION
Don't hardcode contents model (`ovenFuelShape`), get `ovenFuelShape` from collectible attributes of containing item instead.

In this example I made peat brick a suitable fuel for clay oven. by adding this to attributes in blocktypes/soil/peatbrick.json:
```
isClayOvenFuel: true,
ovenFuelShape: "block/peatbrick",
```
and this to textures:
```
"0": {base: "block/soil/peat"},
```


![image](https://github.com/anegostudios/vssurvivalmod/assets/69315569/35b3a609-8414-48df-9a38-df26f2d41f60)
