### PR TITLE
(Ground Storage) Random rotation for SingleCenter layout

### DIFF
--- a/BlockEntity/BEGroundStorage.cs
+++ b/BlockEntity/BEGroundStorage.cs
@@ -464,8 +464,8 @@ namespace Vintagestory.GameContent
                     case EnumGroundStorageLayout.SingleCenter:
                         if (StorageProps.RandomizeCenterRotation)
                         {
-                            float randomX = (float)(Api.World.Rand.NextDouble() * 6.28 - 3.14);
-                            float randomZ = (float)(Api.World.Rand.NextDouble() * 6.28 - 3.14);
+                            double randomX = Api.World.Rand.NextDouble() * 6.28 - 3.14;
+                            double randomZ = Api.World.Rand.NextDouble() * 6.28 - 3.14;
                             MeshAngle = (float)Math.Atan2(randomX, randomZ);
                         }
                         ok = putOrGetItemSingle(inventory[0], player, bs);

--- a/CollectibleBehavior/BehaviorGroundStorable.cs
+++ b/CollectibleBehavior/BehaviorGroundStorable.cs
@@ -38,6 +38,7 @@ namespace Vintagestory.GameContent
         public int WallOffY = 1;
         public AssetLocation PlaceRemoveSound = new AssetLocation("sounds/player/build");
         public bool RandomizeSoundPitch;
+        public bool RandomizeCenterRotation;
         public AssetLocation StackingModel;
 
         [Obsolete("Use ModelItemsToStackSizeRatio instead, which is now a float instead of int?")]
@@ -66,6 +67,7 @@ namespace Vintagestory.GameContent
                 WallOffY = WallOffY,
                 PlaceRemoveSound = PlaceRemoveSound,
                 RandomizeSoundPitch = RandomizeSoundPitch,
+                RandomizeCenterRotation = RandomizeCenterRotation,
                 StackingCapacity = StackingCapacity,
                 StackingModel = StackingModel,
                 StackingTextures = StackingTextures,


### PR DESCRIPTION
- Added RandomizeCenterRotation to GroundStorageProperties
- Implemented RandomizeCenterRotation in BEGroundStorage when placing item in SingleCenter layout

Rotation is very similar to `Block.randomizeRotations`

Wooden pans here are ground storable
![2024-03-08_13-42-20](https://github.com/anegostudios/vssurvivalmod/assets/69315569/6105f437-d788-4bc4-ab50-365dff029763)
