### PR TITLE
Fix crock not losing sealing in some cases

### DIFF
--- a/Block/BlockCookedContainerBase.cs
+++ b/Block/BlockCookedContainerBase.cs
@@ -275,7 +275,7 @@ namespace Vintagestory.GameContent
             (mealblock as IBlockMealContainer).SetContents(ownRecipeCode, stack, stacks, servingsToTransfer);
 
             SetServingsMaybeEmpty(world, potslot, quantityServings - servingsToTransfer);
-
+            potslot.Itemstack.Attributes.RemoveAttribute("sealed");
             potslot.MarkDirty();
 
             bowlSlot.Itemstack = stack;


### PR DESCRIPTION
Fixes cases when you grab food from crock with bowl and it doesn't remove "sealed" attribute from crock.

Test mod compiled for 1.19.5-rc.1: [TestMod.zip](https://github.com/anegostudios/vssurvivalmod/files/14562438/TestMod.zip)

Video demonstration of bug:
https://github.com/anegostudios/vssurvivalmod/assets/69315569/c78fb840-c5ca-44c8-a853-2cc9ece295dc

Video demonstration with changes that adds this pull request:
https://github.com/anegostudios/vssurvivalmod/assets/69315569/aec469fb-c47a-4861-8a22-f23f674fc599

You can clearly see on the first video that it doesn't lose "sealed" attribute, and it loses it on the second video.

Fixes https://github.com/anegostudios/VintageStory-Issues/issues/2901 and https://github.com/anegostudios/VintageStory-Issues/issues/852