### PR TITLE
Extra interactions for sealing crock

### DIFF
--- a/Block/BlockCookedContainerBase.cs
+++ b/Block/BlockCookedContainerBase.cs
@@ -10,7 +10,7 @@ namespace Vintagestory.GameContent
 {
     public class BlockCookedContainerBase : BlockContainer, IBlockMealContainer, IContainedInteractable, IContainedCustomName
     {
-        public bool IsEmpty(ItemStack stack)
+        public bool IsPotEmpty(ItemStack stack)
         {
             ItemStack[] nonEmptyContents = GetNonEmptyContents(api.World, stack);
             if (nonEmptyContents == null || nonEmptyContents.Length == 0)
@@ -375,7 +375,7 @@ namespace Vintagestory.GameContent
                 }
 
                 if (slot.Itemstack.Collectible is BlockCrock
-                    && !IsEmpty(api.World, slot.Itemstack)
+                    && !IsPotEmpty(api.World, slot.Itemstack)
                     && !targetSlot.Empty
                     && targetSlot.Itemstack != null
                     && targetSlot.StackSize > 0

--- a/Block/BlockCookedContainerBase.cs
+++ b/Block/BlockCookedContainerBase.cs
@@ -10,6 +10,17 @@ namespace Vintagestory.GameContent
 {
     public class BlockCookedContainerBase : BlockContainer, IBlockMealContainer, IContainedInteractable, IContainedCustomName
     {
+        public bool IsEmpty(ItemStack stack)
+        {
+            ItemStack[] nonEmptyContents = GetNonEmptyContents(api.World, stack);
+            if (nonEmptyContents == null || nonEmptyContents.Length == 0)
+            {
+                return true;
+            }
+    
+            return false;
+        }
+
         public void SetContents(string recipeCode, float servings, ItemStack containerStack, ItemStack[] stacks)
         {
             base.SetContents(containerStack, stacks);
@@ -361,6 +372,21 @@ namespace Vintagestory.GameContent
                 else
                 {
                     ServeIntoStack(targetSlot, slot, api.World);
+                }
+
+                if (slot.Itemstack.Collectible is BlockCrock
+                    && !IsEmpty(api.World, slot.Itemstack)
+                    && !targetSlot.Empty
+                    && targetSlot.Itemstack != null
+                    && targetSlot.StackSize > 0
+                    && !slot.Itemstack.Attributes.HasAttribute("sealed")
+                    && targetSlot.Itemstack.Collectible.Attributes.KeyExists("canSealCrock")
+                    && targetSlot.Itemstack.Collectible.Attributes["canSealCrock"].AsBool())
+                {
+                    slot.Itemstack.Attributes.SetBool("sealed", true);
+                    targetSlot.TakeOut(1);
+                    targetSlot.MarkDirty();
+                    return true;
                 }
 
                 slot.MarkDirty();

--- a/Block/BlockCrock.cs
+++ b/Block/BlockCrock.cs
@@ -79,7 +79,7 @@ namespace Vintagestory.GameContent
 
             if (recipeCode != null && recipeCode.Length > 0)
             {
-                var code = ostCommonMealIngredient(contents);
+                var code = getMostCommonMealIngredient(contents);
                 if (code != null && (label = CodeToLabel(code)) != null)
                 {
                     return AssetLocation.Create("shapes/block/clay/crock/label-" + label + ".json", Code.Domain);


### PR DESCRIPTION
- First interaction: Right-click with fat or beeswax on crock stored in ground storage seals the crock. This interaction is very similar to what is used for moving meals between meal containers.
- Second interaction: Press 'toolmode' key allows to seal crock with fat or beeswax. This interaction is very similar to what chisel uses for adding material to chiseled block.
- Third interaction: Clicking with fat or beeswax on inventory slot with crock seals the crock. This interaction is very similar to what is used for refueling night vision mask.

`fat` and `beeswax` should have `"canSealCrock": true` collectible attribute for all these interactions to work.

I removed isEmpty() check for some demonstrations below.
Also I added temporary IsPotEmtpty() and IsCrockEmpty() methods for convenience.

Test mod compiled for 1.19.5-rc.1: [TestMod.zip](https://github.com/anegostudios/vssurvivalmod/files/14576988/TestMod.zip)

First interaction:
https://github.com/anegostudios/vssurvivalmod/assets/69315569/6e968ea0-9160-46ce-a0e7-9d51afb297f0

Second interaction:
https://github.com/anegostudios/vssurvivalmod/assets/69315569/e6045342-baae-41b1-a505-0c68188e40e1

Third interaction:
https://github.com/anegostudios/vssurvivalmod/assets/69315569/1da33b37-3d3b-4841-b5be-910accf30f4e

