### PR TITLE
Fixed modded henboxes always converting to vanilla henboxes

### DIFF
--- a/BlockEntity/BEHenBox.cs
+++ b/BlockEntity/BEHenBox.cs
@@ -82,7 +82,7 @@ namespace Vintagestory.GameContent
             parentGenerations[eggs] = entity.WatchedAttributes.GetInt("generation", 0);
             chickNames[eggs] = chickCode == null ? null : entity.Code.CopyWithPath(chickCode);
             eggs++;
-            Block replacementBlock = Api.World.GetBlock(new AssetLocation(Block.FirstCodePart() + "-" + eggs + (eggs > 1 ? "eggs" : "egg")));
+            Block replacementBlock = Api.World.GetBlock(Block.CodeWithVariant("eggCount", eggs + ((eggs > 1) ? "eggs" : "egg")));
             if (replacementBlock == null)
             {
                 return false;


### PR DESCRIPTION
# Explaining the bug

For example, there are blocks:
```
// first variants (Vanilla):
game:henbox-empty
game:henbox-1egg
game:henbox-2eggs
game:henbox-3eggs

// second variants (Modded):
vanvar:henbox-purpleheart-empty
vanvar:henbox-purpleheart-1egg
vanvar:henbox-purpleheart-2eggs
vanvar:henbox-purpleheart-3eggs
```
With original code, if hen lays egg, then second variants will be always converted to first variants no matter what because domain will be always `game` and never `vanvar` in this specific case.


# Here is more detail explanation

So original code is:
```cs
Api.World.GetBlock(new AssetLocation(Block.FirstCodePart() + "-" + eggs + ((eggs > 1) ? "eggs" : "egg")));
```
Since here is no specified domain, AssetLocation will set it to default `game` domain.

For first and second variants, `Block.FirstCodePart()` will always give `henbox` string.

Let `eggs + ((eggs > 1) ? "eggs" : "egg")` give us `1egg` here.

Then we combine everything and we get `game:henbox-1egg`, which is totally hardcoded and not flexible at all.

# Here is solution
```cs
Api.World.GetBlock(Block.CodeWithVariant("eggCount", eggs + ((eggs > 1) ? "eggs" : "egg")));
```
`Block.CodeWithVariant()` will copy entire code including domain, e.g. `vanvar:henbox-purpleheart-empty` will always be `vanvar:henbox-purpleheart-empty`.

Then it will use its magic to find `eggCount` variant and replace it with `1egg` for example, now we get `vanvar:henbox-purpleheart-1egg`