### PR TITLE
Fix support beam functionality

### DIFF
--- a/Systems/SupportBeams/ModSystemSupportBeamPlacer.cs
+++ b/Systems/SupportBeams/ModSystemSupportBeamPlacer.cs
@@ -491,7 +491,7 @@ namespace Vintagestory.GameContent
             }
             else
             {
-                sbdata = chunk.GetModdata<SupportBeamsData>("supportbeams");
+                chunk.LiveModData["supportbeams"] = sbdata = chunk.GetModdata<SupportBeamsData>("supportbeams");
             }
 
             if (sbdata == null)


### PR DESCRIPTION
Adding or removing support beams doesn't have effect when you load a game that already has support beams in a given chunk. Whoops!

This doesn't address any problems that players will have on loading worlds where the physical support beams don't match the SBD structure, as will happen after being affected by this bug, so this may want to also do some amount of rechecking the physical blocks.

Consider this my job interview, then contract me to fix the support beam code, imo 😄