### PR TITLE
Add ability for cooking vessels "cookingContainerSlots" attribute to specify number of cooking container slots

### DIFF
--- a/Gui/GuiDialogBlockEntityFirepit.cs
+++ b/Gui/GuiDialogBlockEntityFirepit.cs
@@ -4,6 +4,7 @@ using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Common;
 using Vintagestory.API.Config;
+using System;
 
 namespace Vintagestory.GameContent
 {
@@ -82,7 +83,7 @@ namespace Vintagestory.GameContent
 
             ElementBounds stoveBounds = ElementBounds.Fixed(0, 0, 210, 250);
 
-            cookingSlotsSlotBounds = ElementStdBounds.SlotGrid(EnumDialogArea.None, 0, 30 + 45, 4, qCookingSlots / 4);
+            cookingSlotsSlotBounds = ElementStdBounds.SlotGrid(EnumDialogArea.None, 0, 30 + 45, 4, (int)Math.Ceiling(qCookingSlots / 4f));
             cookingSlotsSlotBounds.fixedHeight += 10;
 
             double top = cookingSlotsSlotBounds.fixedHeight + cookingSlotsSlotBounds.fixedY;

--- a/Inventory/InventorySmelting.cs
+++ b/Inventory/InventorySmelting.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Vintagestory.API.Common;
 using Vintagestory.API.Config;
 using Vintagestory.API.Datastructures;
@@ -17,7 +18,7 @@ namespace Vintagestory.GameContent
         public BlockPos pos;
         int defaultStorageType = (int)(EnumItemStorageFlags.General | EnumItemStorageFlags.Agriculture | EnumItemStorageFlags.Alchemy | EnumItemStorageFlags.Jewellery | EnumItemStorageFlags.Metallurgy | EnumItemStorageFlags.Outfit);
 
-        public ItemSlot[] CookingSlots { get { return HaveCookingContainer ? cookingSlots : new ItemSlot[0]; } }
+        public ItemSlot[] CookingSlots { get { return HaveCookingContainer ? cookingSlots.Take(slots[1].Itemstack.ItemAttributes["cookingContainerSlots"].AsInt(4)).ToArray() : new ItemSlot[0]); } }
 
         /// <summary>
         /// Returns the cooking slots
@@ -64,16 +65,16 @@ namespace Vintagestory.GameContent
             // slot 1 = input
             // slot 2 = output
             // slot 3,4,5,6 = extra input slots with crucible in input
-            slots = GenEmptySlots(7);
-            cookingSlots = new ItemSlot[] { slots[3], slots[4], slots[5], slots[6] };
+            slots = GenEmptySlots(11);
+            cookingSlots = new ItemSlot[] { slots[3], slots[4], slots[5], slots[6], slots[7], slots[8], slots[9], slots[10] };
             baseWeight = 4f;
             
         }
 
         public InventorySmelting(string className, string instanceID, ICoreAPI api) : base(className, instanceID, api)
         {
-            slots = GenEmptySlots(7);
-            cookingSlots = new ItemSlot[] { slots[3], slots[4], slots[5], slots[6] };
+            slots = GenEmptySlots(11);
+            cookingSlots = new ItemSlot[] { slots[3], slots[4], slots[5], slots[6], slots[7], slots[8], slots[9], slots[10] };
             baseWeight = 4f;
         }
 

--- a/Inventory/InventorySmelting.cs
+++ b/Inventory/InventorySmelting.cs
@@ -18,7 +18,7 @@ namespace Vintagestory.GameContent
         public BlockPos pos;
         int defaultStorageType = (int)(EnumItemStorageFlags.General | EnumItemStorageFlags.Agriculture | EnumItemStorageFlags.Alchemy | EnumItemStorageFlags.Jewellery | EnumItemStorageFlags.Metallurgy | EnumItemStorageFlags.Outfit);
 
-        public ItemSlot[] CookingSlots { get { return HaveCookingContainer ? cookingSlots.Take(slots[1].Itemstack.ItemAttributes["cookingContainerSlots"].AsInt(4)).ToArray() : new ItemSlot[0]); } }
+        public ItemSlot[] CookingSlots { get { return HaveCookingContainer ? cookingSlots.Take(slots[1].Itemstack.ItemAttributes["cookingContainerSlots"].AsInt(4)).ToArray() : new ItemSlot[0]; } }
 
         /// <summary>
         /// Returns the cooking slots


### PR DESCRIPTION
Current vanilla implementation ignores the value set by the objects attribute and always creates a grid of 4 slots regardless of the attributes value.

PR is for a basic implementation/adjustment to expand the num of cooking slots in a smeltingInventory to 8 maximum, with the "cookingContainerSlots" attribute adjusting the range of available slots returned by the CookingSlots getter.

A minor adjustment to the Firepit Gui was added to support quantity of slots non-divisible cleanly by 4 to still adjust the bounds of the cookingSlotsSlotBounds correctly for the amount of rows needed. This does not adjust the firepit heating graphic currently which gets cut off by the expanded bounds when the cookingSlot rows exceed 1.