### PR TITLE
Fix Berry Bush Animal Harvesting and Pruning Reset Bugs

### DIFF
--- a/BlockBehavior/BehaviorHarvestable.cs
+++ b/BlockBehavior/BehaviorHarvestable.cs
@@ -14,7 +14,6 @@ namespace Vintagestory.GameContent
 
         AssetLocation harvestedBlockCode;
         Block harvestedBlock;
-        bool exchangeBlock;
         string interactionHelpCode;
 
         public BlockBehaviorHarvestable(Block block) : base(block)
@@ -28,7 +27,6 @@ namespace Vintagestory.GameContent
             interactionHelpCode = properties["harvestTime"].AsString("blockhelp-harvetable-harvest");
             harvestTime = properties["harvestTime"].AsFloat(0);
             harvestedStack = properties["harvestedStack"].AsObject<BlockDropItemStack>(null);
-            exchangeBlock = properties["exchangeBlock"].AsBool(false);
 
             string code = properties["harvestingSound"].AsString("game:sounds/block/leafy-picking");
             if (code != null) {
@@ -124,14 +122,8 @@ namespace Vintagestory.GameContent
 
                 if (harvestedBlock != null)
                 {
-                    if (!exchangeBlock)
-                    {
-                        world.BlockAccessor.SetBlock(harvestedBlock.BlockId, blockSel.Position);
-                    }
-                    else
-                    {
-                        world.BlockAccessor.ExchangeBlock(harvestedBlock.BlockId, blockSel.Position);
-                    }
+                    if (!properties["exchangeBlock"].AsBool(false)) world.BlockAccessor.SetBlock(harvestedBlock.BlockId, blockSel.Position);
+                    else world.BlockAccessor.ExchangeBlock(harvestedBlock.BlockId, blockSel.Position);
                 }
 
                 world.PlaySoundAt(harvestingSound, blockSel.Position.X, blockSel.Position.Y, blockSel.Position.Z, byPlayer);

--- a/BlockBehavior/BehaviorHarvestable.cs
+++ b/BlockBehavior/BehaviorHarvestable.cs
@@ -8,6 +8,7 @@ namespace Vintagestory.GameContent
     public class BlockBehaviorHarvestable : BlockBehavior
     {
         float harvestTime;
+        bool exchangeBlock;
         public BlockDropItemStack harvestedStack;
 
         public AssetLocation harvestingSound;
@@ -27,6 +28,7 @@ namespace Vintagestory.GameContent
             interactionHelpCode = properties["harvestTime"].AsString("blockhelp-harvetable-harvest");
             harvestTime = properties["harvestTime"].AsFloat(0);
             harvestedStack = properties["harvestedStack"].AsObject<BlockDropItemStack>(null);
+            exchangeBlock = properties["exchangeBlock"].AsBool(false);
 
             string code = properties["harvestingSound"].AsString("game:sounds/block/leafy-picking");
             if (code != null) {
@@ -122,7 +124,7 @@ namespace Vintagestory.GameContent
 
                 if (harvestedBlock != null)
                 {
-                    if (!properties["exchangeBlock"].AsBool(false)) world.BlockAccessor.SetBlock(harvestedBlock.BlockId, blockSel.Position);
+                    if (!exchangeBlock) world.BlockAccessor.SetBlock(harvestedBlock.BlockId, blockSel.Position);
                     else world.BlockAccessor.ExchangeBlock(harvestedBlock.BlockId, blockSel.Position);
                 }
 

--- a/BlockBehavior/BehaviorHarvestable.cs
+++ b/BlockBehavior/BehaviorHarvestable.cs
@@ -14,6 +14,7 @@ namespace Vintagestory.GameContent
 
         AssetLocation harvestedBlockCode;
         Block harvestedBlock;
+        bool exchangeBlock;
         string interactionHelpCode;
 
         public BlockBehaviorHarvestable(Block block) : base(block)
@@ -27,6 +28,7 @@ namespace Vintagestory.GameContent
             interactionHelpCode = properties["harvestTime"].AsString("blockhelp-harvetable-harvest");
             harvestTime = properties["harvestTime"].AsFloat(0);
             harvestedStack = properties["harvestedStack"].AsObject<BlockDropItemStack>(null);
+            exchangeBlock = properties["exchangeBlock"].AsBool(false);
 
             string code = properties["harvestingSound"].AsString("game:sounds/block/leafy-picking");
             if (code != null) {
@@ -122,7 +124,14 @@ namespace Vintagestory.GameContent
 
                 if (harvestedBlock != null)
                 {
-                    world.BlockAccessor.SetBlock(harvestedBlock.BlockId, blockSel.Position);
+                    if (!exchangeBlock)
+                    {
+                        world.BlockAccessor.SetBlock(harvestedBlock.BlockId, blockSel.Position);
+                    }
+                    else
+                    {
+                        world.BlockAccessor.ExchangeBlock(harvestedBlock.BlockId, blockSel.Position);
+                    }
                 }
 
                 world.PlaySoundAt(harvestingSound, blockSel.Position.X, blockSel.Position.Y, blockSel.Position.Z, byPlayer);

--- a/BlockEntity/BEBerryBush.cs
+++ b/BlockEntity/BEBerryBush.cs
@@ -98,8 +98,9 @@ namespace Vintagestory.GameContent
                 return;
             }
 
-            // In case this block was imported from another older world. In that case lastCheckAtTotalDays would be a future date.
+            // In case this block was imported from another older world. In that case lastCheckAtTotalDays and LastPrunedTotalDays would be a future date.
             lastCheckAtTotalDays = Math.Min(lastCheckAtTotalDays, Api.World.Calendar.TotalDays);
+            LastPrunedTotalDays = Math.Min(LastPrunedTotalDays, Api.World.Calendar.TotalDays);
 
 
             // We don't need to check more than one year because it just begins to loop then
@@ -175,10 +176,14 @@ namespace Vintagestory.GameContent
                     continue;
                 }
 
+                if (Pruned && Api.World.Calendar.TotalDays - LastPrunedTotalDays > Api.World.Calendar.DaysPerYear)
+                {
+                    Pruned = false;
+                }
+
                 if (transitionHoursLeft <= 0)
                 {
                     if (!DoGrow()) return;
-                    transitionHoursLeft = GetHoursForNextStage();
                 }
             }
 
@@ -188,6 +193,7 @@ namespace Vintagestory.GameContent
         public override void OnExchanged(Block block)
         {
             base.OnExchanged(block);
+            transitionHoursLeft = GetHoursForNextStage();
             if (Api?.Side == EnumAppSide.Server) UpdateTransitionsFromBlock();
         }
 
@@ -230,11 +236,6 @@ namespace Vintagestory.GameContent
 
         bool DoGrow()
         {
-            if (Api.World.Calendar.TotalDays - LastPrunedTotalDays > Api.World.Calendar.DaysPerYear)
-            {
-                Pruned = false;
-            }
-
             Block block = Api.World.BlockAccessor.GetBlock(Pos);
             string nowCodePart = block.LastCodePart();
             string nextCodePart = (nowCodePart == "empty") ? "flowering" : ((nowCodePart == "flowering") ? "ripe" : "empty");

--- a/BlockEntity/BEBerryBush.cs
+++ b/BlockEntity/BEBerryBush.cs
@@ -75,7 +75,7 @@ namespace Vintagestory.GameContent
             }
         }
 
-        internal void Prune()
+        public void Prune()
         {
             Pruned = true;
             LastPrunedTotalDays = Api.World.Calendar.TotalDays;


### PR DESCRIPTION
Fixed a anegostudios/VintageStory-Issues#4034 and anegostudios/VintageStory-Issues#3811 as well as adding a proper interaction tip for pruning.  A new `exchangeBlock: true` attribute entry needs to be added to Harvest behavior in the smallberrybush and largeberrybush JSON files to go along with this, to make sure it works fully.