### PR TITLE
Overhaul Fruitpress to Fix Bugs and Improve Use

### DIFF
--- a/Block/BlockFruitpressTop.cs
+++ b/Block/BlockFruitpressTop.cs
@@ -14,6 +14,8 @@ namespace Vintagestory.GameContent
         {
             base.OnLoaded(api);
 
+            PlacedPriorityInteract = true;
+
             interactions = ObjectCacheUtil.GetOrCreate(api, "fruitPressInteractionsTop", () =>
             {
                 List<ItemStack> juiceableStacks = new List<ItemStack>();
@@ -33,6 +35,7 @@ namespace Vintagestory.GameContent
                     new WorldInteraction()
                     {
                         ActionLangCode = "blockhelp-fruitpress-press",
+                        HotKeyCode = "ctrl",
                         MouseButton = EnumMouseButton.Right,
                         ShouldApply = (wi, bs, es) =>
                         {

--- a/BlockEntity/BEFruitpress.cs
+++ b/BlockEntity/BEFruitpress.cs
@@ -1,5 +1,6 @@
 ﻿using ProtoBuf;
 using System;
+using System.Collections.Generic;
 using System.Text;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
@@ -26,11 +27,19 @@ namespace Vintagestory.GameContent
         Screw
     }
 
+    public enum EnumFruitPressAnimState
+    {
+        ScrewStart,
+        Unscrew,
+        ScrewContinue
+    }
+
     [ProtoContract(ImplicitFields = ImplicitFields.AllPublic)]
     public class FruitPressAnimPacket
     {
-        public bool AnimationActive;
+        public EnumFruitPressAnimState AnimationState;
         public float AnimationSpeed;
+        public float CurrentFrame = 0;
     }
 
 
@@ -90,10 +99,17 @@ namespace Vintagestory.GameContent
             EaseInSpeed = 3
         };
 
+        float? loadedFrame;
+        bool serverListenerActive;
 
         long listenerId;
         double juiceableLitresCapacity = 10;
+        double screwPercent;
+        double squeezedLitresLeft;
+        double pressSqueezeRel;
         bool squeezeSoundPlayed;
+        bool squeezedJuiceLeft;
+        int dryStackSize = 0;
 
         public ItemSlot MashSlot => inv[0];
         public ItemSlot BucketSlot => inv[1];
@@ -115,7 +131,7 @@ namespace Vintagestory.GameContent
         {
             get
             {
-                return mashStack.Attributes.GetDouble("juiceableLitresTransfered");
+                return mashStack?.Attributes?.GetDouble("juiceableLitresTransfered") ?? 0;
             }
             set
             {
@@ -134,8 +150,8 @@ namespace Vintagestory.GameContent
         public bool CompressAnimActive => animUtil.activeAnimationsByAnimCode.ContainsKey("compress") || animUtil.animator.GetAnimationState("compress")?.Active == true;
 
 
-        public bool CanScrew => !CompressAnimActive || compressAnimMeta.AnimationSpeed == 0;
-        public bool CanUnscrew => CompressAnimFinished;
+        public bool CanScrew => !CompressAnimFinished;
+        public bool CanUnscrew => CompressAnimFinished || CompressAnimActive;
         public bool CanFillRemoveItems => !CompressAnimActive;
 
         public BlockEntityFruitPress()
@@ -171,6 +187,11 @@ namespace Vintagestory.GameContent
                     renderer.reloadMeshes(getJuiceableProps(mashStack), true);
                     genBucketMesh();
                 }
+                else if (serverListenerActive)
+                {
+                    animUtil.StartAnimation(compressAnimMeta);
+                    if (listenerId == 0) listenerId = RegisterGameTickListener(onTick100msServer, 25);
+                }
             }
         }
 
@@ -180,8 +201,9 @@ namespace Vintagestory.GameContent
         private void onTick25msClient(float dt)
         {
             double squeezeRel = mashStack?.Attributes.GetDouble("squeezeRel", 1) ?? 1;
+            float selfHeight = (float)(juiceableLitresTransfered + juiceableLitresLeft) / 10f;
 
-            if (MashSlot.Empty || renderer.juiceTexPos == null || squeezeRel >= 1) return;
+            if (MashSlot.Empty || renderer.juiceTexPos == null || squeezeRel >= 1 || pressSqueezeRel > squeezeRel || squeezedLitresLeft < 0.01) return;
 
             var rand = Api.World.Rand;
 
@@ -198,7 +220,7 @@ namespace Vintagestory.GameContent
 
                 minPos.Mul(8 / 16f);
                 maxPos.Mul(8 / 16f);
-                maxPos.Y = 5 / 16f - (1 - squeezeRel) * 0.25f;
+                maxPos.Y = 5 / 16f - (1 - squeezeRel + Math.Max(0, 0.9f - selfHeight)) * 0.5f;
 
                 minPos.Add(face.Normalf.X * 1.2f / 16f, 0, face.Normalf.Z * 1.2f / 16f);
                 maxPos.Add(face.Normalf.X * 1.2f / 16f, 0, face.Normalf.Z * 1.2f / 16f);
@@ -224,23 +246,39 @@ namespace Vintagestory.GameContent
 
         private void onTick100msServer(float dt)
         {
+            RunningAnimation anim = animUtil.animator.GetAnimationState("compress");
+            if (serverListenerActive)
+            {
+                anim.CurrentFrame = loadedFrame ?? 0;
+                updateSqueezeRel(animUtil.animator.GetAnimationState("compress"));
+                serverListenerActive = false;
+                loadedFrame = null;
+                return;
+            }
+            else if (CompressAnimActive) (Api as ICoreServerAPI)?.Network.BroadcastBlockEntityPacket(Pos, PacketIdAnimUpdate, new FruitPressAnimPacket() { AnimationState = EnumFruitPressAnimState.ScrewContinue, AnimationSpeed = compressAnimMeta.AnimationSpeed, CurrentFrame = anim.CurrentFrame });
             if (MashSlot.Empty) return;
 
             var juiceProps = getJuiceableProps(mashStack);
             double totalHours = Api.World.Calendar.TotalHours;
 
             double squeezeRel = mashStack.Attributes.GetDouble("squeezeRel", 1);
-            double litresToTransfer = Math.Min(juiceableLitresLeft, (totalHours - lastLiquidTransferTotalHours) * 50f);
 
-            if (Api.Side == EnumAppSide.Server && squeezeRel < 1 && !squeezeSoundPlayed && juiceableLitresLeft > 0)
+            // First we need to calculate how squeezed down the mash has been and therefore how much we're allowed to take
+            squeezedLitresLeft = Math.Max(Math.Max(0, squeezedLitresLeft), juiceableLitresLeft - ((juiceableLitresLeft + juiceableLitresTransfered) * screwPercent));
+            double litresToTransfer = Math.Min(squeezedLitresLeft, Math.Round((totalHours - lastLiquidTransferTotalHours) * (CompressAnimActive ? GameMath.Clamp(squeezedLitresLeft * (1 - squeezeRel) * 500f, 25f, 100f) : 5f), 2));
+
+            if (Api.Side == EnumAppSide.Server && CompressAnimActive && squeezeRel < 1 && pressSqueezeRel <= squeezeRel && !squeezeSoundPlayed && juiceableLitresLeft > 0)
             {
                 Api.World.PlaySoundAt(new AssetLocation("sounds/player/wetclothsqueeze.ogg"), Pos, 0, null, false);
                 squeezeSoundPlayed = true;
+                squeezedJuiceLeft = true;
             }
 
             BlockLiquidContainerBase cntBlock = BucketSlot?.Itemstack?.Collectible as BlockLiquidContainerBase;
 
-            if (Api.Side == EnumAppSide.Server && squeezeRel < 1 && totalHours - lastLiquidTransferTotalHours > 0.01)
+            // Since the sound only plays once when the screw touches the mash we can reuse the variable here to make
+            // sure this runs as long as there is still juice left to drip out, even if the player releases the screw
+            if (Api.Side == EnumAppSide.Server && squeezedLitresLeft > 0 && squeezedJuiceLeft)
             {
                 ItemStack liquidStack = juiceProps.LiquidStack.ResolvedItemstack;
                 liquidStack.StackSize = 999999;
@@ -263,28 +301,16 @@ namespace Vintagestory.GameContent
                 }
 
                 juiceableLitresLeft -= actuallyTransfered;
+                squeezedLitresLeft -= pressSqueezeRel <= squeezeRel ? actuallyTransfered : (actuallyTransfered * 20); // Let the mash drain less if screw is released.
                 juiceableLitresTransfered += actuallyTransfered;
                 lastLiquidTransferTotalHours = totalHours;
                 MarkDirty(true);
             }
-
-
-            if (juiceableLitresLeft <= 0.01)
+            else if (Api.Side == EnumAppSide.Server && (!CompressAnimActive || juiceableLitresLeft <= 0))
             {
-                // Hack to fix rounding errors
-                if (cntBlock != null)
-                {
-                    float litres = cntBlock.GetCurrentLitres(BucketSlot.Itemstack);
-                    cntBlock.SetCurrentLitres(BucketSlot.Itemstack, (float)Math.Round(100 * litres) / 100f);
-                }
-
+                squeezedJuiceLeft = false;
                 UnregisterGameTickListener(listenerId);
                 listenerId = 0;
-
-                int stacksize = GameMath.RoundRandom(Api.World.Rand, (float)juiceableLitresTransfered);
-                mashStack.Attributes.RemoveAttribute("juiceableLitresTransfered");
-                mashStack.Attributes.RemoveAttribute("juiceableLitresLeft");
-                mashStack.StackSize = (int)(stacksize * juiceProps.PressedDryRatio);
 
                 MarkDirty(true);
             }
@@ -301,11 +327,11 @@ namespace Vintagestory.GameContent
         {
             firstEvent |= Api.Side == EnumAppSide.Server;
 
-            if (section == EnumFruitPressSection.MashContainer)
+            if (section == EnumFruitPressSection.MashContainer && firstEvent)
             {
                 return InteractMashContainer(byPlayer, blockSel);
             }
-            if (section == EnumFruitPressSection.Ground)
+            if (section == EnumFruitPressSection.Ground && firstEvent)
             {
                 return InteractGround(byPlayer, blockSel);
             }
@@ -322,36 +348,26 @@ namespace Vintagestory.GameContent
             if (Api.Side == EnumAppSide.Server) return true; // We let the client control this
 
             // Start
-            if (!CompressAnimActive && firstEvent)
+            if (!CompressAnimActive && byPlayer.Entity.Controls.CtrlKey && firstEvent)
             {
-                compressAnimMeta.AnimationSpeed = 0.5f;
-                animUtil.StartAnimation(compressAnimMeta);
-                squeezeSoundPlayed = false;
-
                 (Api as ICoreClientAPI).Network.SendBlockEntityPacket(Pos, PacketIdScrewStart);
-
-                if (listenerId == 0)
-                {
-                    listenerId = RegisterGameTickListener(onTick25msClient, 25);
-                }
 
                 return true;
             }
 
             // Unscrew
-            if (CanUnscrew && firstEvent)
+            if (CanUnscrew && !byPlayer.Entity.Controls.CtrlKey && firstEvent)
             {
-                compressAnimMeta.AnimationSpeed = 1.5f;
-                animUtil.StopAnimation("compress");
                 (Api as ICoreClientAPI).Network.SendBlockEntityPacket(Pos, PacketIdUnscrew);
+
                 return true;
             }
 
             // Continue
-            if (compressAnimMeta.AnimationSpeed == 0)
+            if (compressAnimMeta.AnimationSpeed == 0 && byPlayer.Entity.Controls.CtrlKey)
             {
-                compressAnimMeta.AnimationSpeed = 0.5f;
                 (Api as ICoreClientAPI).Network.SendBlockEntityPacket(Pos, PacketIdScrewContinue);
+
                 return true;
             }
 
@@ -376,9 +392,27 @@ namespace Vintagestory.GameContent
                 var hprops = getJuiceableProps(handStack);
                 if (hprops == null) return false;
 
-                var pressedStack = hprops.PressedStack.ResolvedItemstack.Clone();
-                if (MashSlot.Empty) MashSlot.Itemstack = pressedStack;
-                else if (mashStack.StackSize >= 10)
+                // Don't try to put dry mash back into the machine
+                if (hprops.LitresPerItem == null && !handStack.Attributes.HasAttribute("juiceableLitresLeft")) return false;
+
+                var pressedStack = hprops.LitresPerItem != null ? hprops.PressedStack.ResolvedItemstack.Clone() : handStack.GetEmptyClone();
+                if (MashSlot.Empty)
+                {
+                    MashSlot.Itemstack = pressedStack;
+
+                    // Directly transfer the fruit mash to the machine if it's empty, but only one if it's a stack
+                    if (hprops.LitresPerItem == null)
+                    {
+                        mashStack.StackSize = 1;
+                        dryStackSize = (int)(GameMath.RoundRandom(Api.World.Rand, (float)juiceableLitresLeft + (float)juiceableLitresTransfered) * getJuiceableProps(mashStack).PressedDryRatio);
+                        handslot.TakeOut(1);
+                        MarkDirty(true);
+                        renderer?.reloadMeshes(hprops, true);
+                        (byPlayer as IClientPlayer)?.TriggerFpAnimation(EnumHandInteract.HeldItemInteract);
+                        return true;
+                    }
+                }
+                else if (juiceableLitresLeft + juiceableLitresTransfered >= juiceableLitresCapacity)
                 {
                     (Api as ICoreClientAPI)?.TriggerIngameError(this, "fullcontainer", Lang.Get("Container is full, press out juice and remove the mash before adding more"));
                     return false;
@@ -390,25 +424,58 @@ namespace Vintagestory.GameContent
                     return false;
                 }
 
-
-                float transferableLitres;
+                float transferableLitres = (float)handStack.Attributes.GetDecimal("juiceableLitresLeft");
+                float usedLitres = (float)handStack.Attributes.GetDecimal("juiceableLitresTransfered");
                 int removeItems;
                 if (hprops.LitresPerItem == null)
                 {
-                    var availableLitres = (float)handStack.Attributes.GetDecimal("juiceableLitresLeft");
-                    transferableLitres = (float)Math.Min(availableLitres, juiceableLitresCapacity - juiceableLitresLeft);
-                    // the juiceableLitresLeft is per item if we have a stack of multiple
-                    // so we only remove one item and add the liters for one
+                    // the juiceableLitresLeft and juiceableLitresTransfered are per item if we have a stack of multiple
+                    // so we check if the press is full and only remove and add the liters for one item at a time
+                    if (juiceableLitresLeft + juiceableLitresTransfered + transferableLitres + usedLitres > juiceableLitresCapacity)
+                    {
+                        (Api as ICoreClientAPI)?.TriggerIngameError(this, "fullcontainer", Lang.Get("Container is full, press out juice and remove the mash before adding more"));
+                        return false;
+                    }
+
+                    // If we're adding mash we want to average the spoiling so players can't keep it fresh forever
+                    TransitionState[] sourceTransitionStates = handStack.Collectible.UpdateAndGetTransitionStates(Api.World, handslot);
+                    TransitionState[] targetTransitionStates = mashStack.Collectible.UpdateAndGetTransitionStates(Api.World, MashSlot);
+
+                    Dictionary<EnumTransitionType, TransitionState> targetStatesByType = null;
+
+                    targetStatesByType = new Dictionary<EnumTransitionType, TransitionState>();
+                    foreach (var state in targetTransitionStates) targetStatesByType[state.Props.Type] = state;
+
+                    // We're mixing based on total litres because we don't really have a stack size to compare
+                    float t = (transferableLitres + usedLitres) / (transferableLitres + usedLitres + (float)juiceableLitresLeft + (float)juiceableLitresTransfered);
+
+                    foreach (var sourceState in sourceTransitionStates)
+                    {
+                        TransitionState targetState = targetStatesByType[sourceState.Props.Type];
+                        mashStack.Collectible.SetTransitionState(mashStack, sourceState.Props.Type, sourceState.TransitionedHours * t + targetState.TransitionedHours * (1 - t));
+                    }
+
                     removeItems = 1;
                 } else
                 {
-                    float desiredTransferSizeLitres = byPlayer.Entity.Controls.ShiftKey ? (float)hprops.LitresPerItem : Math.Min(handStack.StackSize, 4) * (float)hprops.LitresPerItem;
-                    transferableLitres = (float)Math.Min(desiredTransferSizeLitres, juiceableLitresCapacity - juiceableLitresLeft);
+                    // In order to make sure we're always giving exactly the amount of juice that's appropriate for the
+                    // number of items we take out of the inventory we start by counting up how many the player wants to
+                    // add, be it 1, 4, or 32, and then subtracting 1 from that total until we have an amount that can fit
+                    int desiredTransferAmount = Math.Min(handStack.StackSize, byPlayer.Entity.Controls.ShiftKey ? 1 : byPlayer.Entity.Controls.CtrlKey ? 32 : 4);
 
-                    removeItems = (int)(transferableLitres / hprops.LitresPerItem);
+                    while (desiredTransferAmount * (float)hprops.LitresPerItem + juiceableLitresLeft + juiceableLitresTransfered > juiceableLitresCapacity) desiredTransferAmount -= 1;
+
+                    if (desiredTransferAmount <= 0)
+                    {
+                        (Api as ICoreClientAPI)?.TriggerIngameError(this, "fullcontainer", Lang.Get("Container is full, press out juice and remove the mash before adding more"));
+                        return false;
+                    }
+
+                    transferableLitres = desiredTransferAmount * (float)hprops.LitresPerItem;
+                    removeItems = desiredTransferAmount;
                 }
 
-                if (transferableLitres > 0)
+                if (removeItems > 0)
                 {
                     var stackCode = handslot.Itemstack.Collectible.Code;
                     handslot.TakeOut(removeItems);
@@ -422,7 +489,13 @@ namespace Vintagestory.GameContent
                     );
 
                     mashStack.Attributes.SetDouble("juiceableLitresLeft", juiceableLitresLeft += transferableLitres);
+                    mashStack.Attributes.SetDouble("juiceableLitresTransfered", juiceableLitresTransfered += usedLitres);
                     mashStack.StackSize = 1;
+
+                    // Calculate how large the stack of dry mash will be here so we can tell the player that amount is in
+                    // the machine later and not have a random mismatch due to the use of RoundRandom in the calculation
+                    dryStackSize = (int)(GameMath.RoundRandom(Api.World.Rand, (float)juiceableLitresLeft + (float)juiceableLitresTransfered) * getJuiceableProps(mashStack).PressedDryRatio);
+
                     handslot.MarkDirty();
                     MarkDirty(true);
                     renderer?.reloadMeshes(hprops, true);
@@ -434,6 +507,8 @@ namespace Vintagestory.GameContent
 
             // Take out mash
             if (MashSlot.Empty) return false;
+
+            convertDryMash();
 
             if (!byPlayer.InventoryManager.TryGiveItemstack(mashStack, true))
             {
@@ -505,38 +580,25 @@ namespace Vintagestory.GameContent
         {
             if (section != EnumFruitPressSection.Screw) return false;
 
-            if (mashStack != null)
-            {
-                RunningAnimation anim = animUtil.animator.GetAnimationState("compress");
-                if (anim != null)
-                {
-                    udpateSqueezeRel(anim);
-                }
-            }
+            if (mashStack != null) updateSqueezeRel(animUtil.animator.GetAnimationState("compress"));
 
-            return CompressAnimActive && secondsUsed < 4f;
+            return CompressAnimActive;
         }
 
 
         public void OnBlockInteractStop(float secondsUsed, IPlayer byPlayer)
         {
-            RunningAnimation anim = animUtil.animator.GetAnimationState("compress");
-            udpateSqueezeRel(anim);
+            updateSqueezeRel(animUtil.animator.GetAnimationState("compress"));
 
             if (!CompressAnimActive) return;
 
-            if (secondsUsed >= 4.8f)
-            {
-                compressAnimMeta.AnimationSpeed = 0f;
-                // Fast forward the server
-                anim.CurrentFrame = anim.Animation.QuantityFrames - 1;
-
-                (Api as ICoreServerAPI)?.Network.BroadcastBlockEntityPacket(Pos, PacketIdAnimUpdate, new FruitPressAnimPacket() { AnimationActive = true, AnimationSpeed = 0f });
-            }
+            compressAnimMeta.AnimationSpeed = 0f;
+            (Api as ICoreServerAPI)?.Network.BroadcastBlockEntityPacket(Pos, PacketIdAnimUpdate, new FruitPressAnimPacket() { AnimationState = EnumFruitPressAnimState.ScrewContinue, AnimationSpeed = 0f });
         }
 
-
-        private void udpateSqueezeRel(RunningAnimation anim)
+        // Here we will calculate various things, like how squeezed down the mash is, how far down the screw is,
+        // and a copy of squeezeRel for the press itself so that it can tell if the screw is touching the mash yet
+        private void updateSqueezeRel(RunningAnimation anim)
         {
             if (anim == null || mashStack==null) return;
 
@@ -544,21 +606,36 @@ namespace Vintagestory.GameContent
             float selfHeight = (float)(juiceableLitresTransfered + juiceableLitresLeft) / 10f;
 
             squeezeRel += Math.Max(0, 0.9f - selfHeight);
+            pressSqueezeRel = GameMath.Clamp(squeezeRel, 0.1f, 1f);
             squeezeRel = GameMath.Clamp(Math.Min(mashStack.Attributes.GetDouble("squeezeRel", 1), squeezeRel), 0.1f, 1f);
 
             mashStack.Attributes.SetDouble("squeezeRel", squeezeRel);
+
+            screwPercent = GameMath.Clamp(1f - anim.CurrentFrame / (anim.Animation.QuantityFrames - 1), 0, 1f) / selfHeight;
+        }
+
+
+        private void convertDryMash()
+        {
+            if (juiceableLitresLeft < 0.01 && mashStack.Collectible.Code.Path != "rot")
+            {
+                mashStack.Attributes.RemoveAttribute("juiceableLitresTransfered");
+                mashStack.Attributes.RemoveAttribute("juiceableLitresLeft");
+                mashStack.Attributes.RemoveAttribute("squeezeRel");
+                mashStack.StackSize = dryStackSize;
+                dryStackSize = 0;
+            }
         }
 
 
         public bool OnBlockInteractCancel(float secondsUsed, IPlayer byPlayer)
         {
-            RunningAnimation anim = animUtil.animator.GetAnimationState("compress");
-            udpateSqueezeRel(anim);
+            updateSqueezeRel(animUtil.animator.GetAnimationState("compress"));
 
             if (CompressAnimActive)
             {
                 compressAnimMeta.AnimationSpeed = 0f;
-                (Api as ICoreServerAPI)?.Network.BroadcastBlockEntityPacket(Pos, PacketIdAnimUpdate, new FruitPressAnimPacket() { AnimationActive = true, AnimationSpeed = 0f });
+                (Api as ICoreServerAPI)?.Network.BroadcastBlockEntityPacket(Pos, PacketIdAnimUpdate, new FruitPressAnimPacket() { AnimationState = EnumFruitPressAnimState.ScrewContinue, AnimationSpeed = 0f });
             }
 
             return true;
@@ -570,21 +647,22 @@ namespace Vintagestory.GameContent
             switch (packetid)
             {
                 case PacketIdScrewStart:
-                    compressAnimMeta.AnimationSpeed = 1f; // This is supposed to be 0.5f, but for some reason, the server runs animations at half the speed?!
+                    compressAnimMeta.AnimationSpeed = 0.5f;
                     animUtil.StartAnimation(compressAnimMeta);
                     squeezeSoundPlayed = false;
                     lastLiquidTransferTotalHours = Api.World.Calendar.TotalHours;
                     if (listenerId == 0) listenerId = RegisterGameTickListener(onTick100msServer, 25);
-                    (Api as ICoreServerAPI)?.Network.BroadcastBlockEntityPacket(Pos, PacketIdAnimUpdate, new FruitPressAnimPacket() { AnimationActive = true, AnimationSpeed = 0.5f });
+                    (Api as ICoreServerAPI)?.Network.BroadcastBlockEntityPacket(Pos, PacketIdAnimUpdate, new FruitPressAnimPacket() { AnimationState = EnumFruitPressAnimState.ScrewStart, AnimationSpeed = 0.5f });
                     break;
                 case PacketIdScrewContinue:
-                    compressAnimMeta.AnimationSpeed = 1f; // This is supposed to be 0.5f, but for some reason, the server runs animations at half the speed?!
-                    (Api as ICoreServerAPI)?.Network.BroadcastBlockEntityPacket(Pos, PacketIdAnimUpdate, new FruitPressAnimPacket() { AnimationActive = true, AnimationSpeed = 0.5f });
+                    compressAnimMeta.AnimationSpeed = 0.5f;
+                    (Api as ICoreServerAPI)?.Network.BroadcastBlockEntityPacket(Pos, PacketIdAnimUpdate, new FruitPressAnimPacket() { AnimationState = EnumFruitPressAnimState.ScrewContinue, AnimationSpeed = 0.5f });
                     break;
                 case PacketIdUnscrew:
                     compressAnimMeta.AnimationSpeed = 1.5f;
                     animUtil.StopAnimation("compress");
-                    (Api as ICoreServerAPI)?.Network.BroadcastBlockEntityPacket(Pos, PacketIdAnimUpdate, new FruitPressAnimPacket() { AnimationActive = false, AnimationSpeed = 1.5f });
+                    (Api as ICoreServerAPI)?.Network.BroadcastBlockEntityPacket(Pos, PacketIdAnimUpdate, new FruitPressAnimPacket() { AnimationState = EnumFruitPressAnimState.Unscrew, AnimationSpeed = 1.5f });
+                    animUtil.animator.GetAnimationState("compress").Stop(); // Without this the player is occasionally told to unscrew a second time
                     break;
             }
 
@@ -599,17 +677,46 @@ namespace Vintagestory.GameContent
 
                 compressAnimMeta.AnimationSpeed = packet.AnimationSpeed;
 
-                if (packet.AnimationActive)
+                if (packet.AnimationState == EnumFruitPressAnimState.ScrewStart)
                 {
-                    if (!MashSlot.Empty && juiceableLitresLeft > 0 && !CompressAnimActive)
-                    {
-                        Api.World.PlaySoundAt(new AssetLocation("sounds/player/wetclothsqueeze.ogg"), Pos, 0, null, false);
-                    }
-
                     animUtil.StartAnimation(compressAnimMeta);
+                    squeezeSoundPlayed = false;
+                    lastLiquidTransferTotalHours = Api.World.Calendar.TotalHours;
                     if (listenerId == 0) listenerId = RegisterGameTickListener(onTick25msClient, 25);
                 }
-                else
+                else if (packet.AnimationState == EnumFruitPressAnimState.ScrewContinue)
+                {
+                    // Since the game isn't set up to synchronize BlockEntity animations and the game logic of
+                    // the fruit press relies on the animation progress we have to do something a little hacky
+                    // to get the client to properly synchronize the visual animation with the server, so first
+                    // we have to get the animation running for a moment if it hasn't been already
+                    RunningAnimation anim = animUtil.animator.GetAnimationState("compress");
+                    if (anim.CurrentFrame <= 0)
+                    {
+                        compressAnimMeta.AnimationSpeed = 0.0001f;
+                        animUtil.StartAnimation(compressAnimMeta);
+                    }
+
+                    // Then we have to fast forward the animation to the correct spot so the client will visually
+                    // match where the server is in the animation. We do this by setting the speed very low and
+                    // then progressing one step at a time in a while loop before resetting the speed back to
+                    // where it was before we performed this action. We also make sure we don't do this unless
+                    // the CurrentFrame is > 0 to make sure that the client is fully loaded and capable of playing
+                    // animations otherwise it will crash with a null pointer exception
+                    if (anim.CurrentFrame > 0 && anim.CurrentFrame < packet.CurrentFrame)
+                    {
+                        compressAnimMeta.AnimationSpeed = 0.0001f;
+                        while (anim.CurrentFrame < packet.CurrentFrame) anim.Progress(1f, 1f);
+                        compressAnimMeta.AnimationSpeed = packet.AnimationSpeed;
+                        anim.CurrentFrame = packet.CurrentFrame;
+
+                        MarkDirty(true);
+                        updateSqueezeRel(anim);
+                    }
+
+                    if (listenerId == 0) listenerId = RegisterGameTickListener(onTick25msClient, 25);
+                }
+                else if (packet.AnimationState == EnumFruitPressAnimState.Unscrew)
                 {
                     animUtil.StopAnimation("compress");
                     if (listenerId != 0) { UnregisterGameTickListener(listenerId); listenerId = 0; }
@@ -631,6 +738,8 @@ namespace Vintagestory.GameContent
 
         public override void OnBlockBroken(IPlayer byPlayer = null)
         {
+            if (!MashSlot.Empty) convertDryMash();
+
             base.OnBlockBroken();
         }
 
@@ -656,6 +765,11 @@ namespace Vintagestory.GameContent
             ItemStack beforeStack = mashStack;
 
             base.FromTreeAttributes(tree, worldForResolving);
+            squeezedLitresLeft = tree.GetDouble("squeezedLitresLeft");
+            squeezeSoundPlayed = tree.GetBool("squeezeSoundPlayed");
+            squeezedJuiceLeft = tree.GetBool("squeezedJuiceLeft");
+            dryStackSize = tree.GetInt("dryStackSize");
+            lastLiquidTransferTotalHours = tree.GetDouble("lastLiquidTransferTotalHours");
 
             if (worldForResolving.Side == EnumAppSide.Client)
             {
@@ -667,11 +781,35 @@ namespace Vintagestory.GameContent
                 renderer?.reloadMeshes(getJuiceableProps(mashStack), wasEmpty != Inventory.Empty || (beforeStack != null && mashStack != null && !beforeStack.Equals(Api.World, mashStack, GlobalConstants.IgnoredStackAttributes)));
                 genBucketMesh();
             }
+            else
+            {
+                if (listenerId == 0) serverListenerActive = tree.GetBool("ServerListenerActive");
+                if (listenerId != 0 || serverListenerActive)
+                {
+                    loadedFrame = tree.GetFloat("CurrentFrame");
+                    compressAnimMeta.AnimationSpeed = tree.GetFloat("AnimationSpeed", compressAnimMeta.AnimationSpeed);
+                }
+            }
         }
 
         public override void ToTreeAttributes(ITreeAttribute tree)
         {
             base.ToTreeAttributes(tree);
+            tree.SetDouble("squeezedLitresLeft", squeezedLitresLeft);
+            tree.SetBool("squeezeSoundPlayed", squeezeSoundPlayed);
+            tree.SetBool("squeezedJuiceLeft", squeezedJuiceLeft);
+            tree.SetInt("dryStackSize", dryStackSize);
+            tree.SetDouble("lastLiquidTransferTotalHours", lastLiquidTransferTotalHours);
+
+            if (Api.Side == EnumAppSide.Server)
+            {
+                if (listenerId != 0) tree.SetBool("ServerListenerActive", true);
+                if (CompressAnimActive)
+                {
+                    tree.SetFloat("CurrentFrame", animUtil.animator.GetAnimationState("compress").CurrentFrame);
+                    tree.SetFloat("AnimationSpeed", compressAnimMeta.AnimationSpeed);
+                }
+            }
         }
 
         public override bool OnTesselation(ITerrainMeshPool mesher, ITesselatorAPI tessThreadTesselator)
@@ -703,12 +841,17 @@ namespace Vintagestory.GameContent
 
             if (!MashSlot.Empty)
             {
+                // Using the precalculated dryStackSize we fake the number of dry mash in the slot without converting,
+                // and that means we don't have to worry about someone adding fruit to the machine when it still has
+                // dry mash inside and overwriting the total stack size, making them lose some of their dry mash
+                int stacksize = mashStack.Collectible.Code.Path != "rot" ? dryStackSize : MashSlot.StackSize;
+
                 if (juiceableLitresLeft > 0)
                 {
                     dsc.AppendLine(Lang.Get("Mash produces {0:0.##} litres of juice when squeezed", juiceableLitresLeft));
                 } else
                 {
-                    dsc.AppendLine(Lang.Get("Dry Mash"));
+                    dsc.AppendLine(Lang.Get("{0}x {1}", stacksize, MashSlot.GetStackName()));
                 }
             }
         }

--- a/BlockEntityRenderer/FruitpressContentsRenderer.cs
+++ b/BlockEntityRenderer/FruitpressContentsRenderer.cs
@@ -75,8 +75,6 @@ namespace Vintagestory.GameContent
             this.befruitpress = befruitpress;
         }
 
-        public int heightMode = 0;
-
         public void reloadMeshes(JuiceableProperties props, bool mustReload)
         {
             if (befruitpress.Inventory.Empty)
@@ -98,9 +96,10 @@ namespace Vintagestory.GameContent
             int y;
             if (stack.Collectible.Code.Path == "rot")
             {
-                textureLocation = new AssetLocation("block/rot/rot");
-                y = GameMath.Clamp(stack.StackSize / 4, 1, 9);
-            } else
+                textureLocation = new AssetLocation("block/wood/barrel/rot");
+                y = GameMath.Clamp(stack.StackSize / 2, 1, 9);
+            }
+            else
             {
                 var tex = props.PressedStack.ResolvedItemstack.Item.Textures.First();
                 textureLocation = tex.Value.Base;
@@ -109,12 +108,8 @@ namespace Vintagestory.GameContent
                 {
                     float availableLitres = (float)stack.Attributes.GetDecimal("juiceableLitresLeft") + (float)stack.Attributes.GetDecimal("juiceableLitresTransfered");
                     y = (int)GameMath.Clamp(availableLitres, 1, 9);
-                    heightMode = 0;
-                } else
-                {
-                    y = (int)GameMath.Clamp(stack.StackSize, 1, 9);
-                    heightMode = 1;
                 }
+                else y = GameMath.Clamp(stack.StackSize, 1, 9);
             }
 
 

--- a/Item/ItemPressedMash.cs
+++ b/Item/ItemPressedMash.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Vintagestory.API.Common;
 using Vintagestory.API.Config;
+using Vintagestory.API.MathTools;
 
 namespace Vintagestory.GameContent
 {
@@ -15,6 +16,14 @@ namespace Vintagestory.GameContent
             return Lang.GetMatching(Code?.Domain + AssetLocation.LocationSeparator + type + "-" + Code?.Path + "-" + ap);
         }
 
+        public override ItemStack OnTransitionNow(ItemSlot slot, TransitionableProperties props)
+        {
+            float pressedDryRatio = slot.Itemstack.ItemAttributes["juiceableProperties"]["pressedDryRatio"].AsFloat(1);
+            double juiceableLitresTotal = slot.Itemstack.Attributes.GetDouble("juiceableLitresLeft") + slot.Itemstack.Attributes.GetDouble("juiceableLitresTransfered");
 
+            if (juiceableLitresTotal > 0) props.TransitionRatio = (int)(GameMath.RoundRandom(api.World.Rand, (float)juiceableLitresTotal) * pressedDryRatio);
+
+            return base.OnTransitionNow(slot, props);
+        }
     }
 }


### PR DESCRIPTION
This is a slight rewrite of how the Fruitpress functions, fixing a few small bugs like anegostudios/VintageStory-Issues#3868 (producing dry mash that won’t properly stack), or allowing you to add dry mash that you would then lose forever.  It also makes it a little easier to use and feel a little more responsive, like making it so you can stop squeezing the fruit halfway through and it will actually stop squeezing at that amount.  You could probably increase the speed of squeezing much higher than 50f on line 238 and have it feel like the juice squeezed out in time with your cranking, so letting go of the mouse button would immediately stop, as well, if that were desired.

I’ve added copious comments so it’s obvious what all the added lines are meant to do, in case there’s a desire to change some part of it, as well.  It also appears that whatever issue was happening where the server would play the animation at half the speed is no longer an issue so I removed all of the code related to that and it looks much smoother now.

The main thing I couldn’t crack was how to make the crank and the mash always look like they are touching.  The selfHeight portion of the code does a good job but it’s not quite exactly right and in all my tinkering I couldn’t find a simple way to make it look more consistent without needing to program specific cases for each mash height.