### PR TITLE
Remove roller logs from hotbar when placing construction site

### DIFF
--- a/Systems/Boats/ItemRoller.cs
+++ b/Systems/Boats/ItemRoller.cs
@@ -143,6 +143,12 @@ namespace Vintagestory.GameContent
                 return;
             }
 
+            if (slot.TakeOut(5) == null)
+            {
+                (api as ICoreClientAPI)?.TriggerIngameError(this, "unable", "Could not remove 5 rollers from inventory");
+                return;
+            }
+
             string material = "oak";
             int orient = GetOrient(player);
 


### PR DESCRIPTION
At the moment, they stay in your hotbar, giving you 5 more rollers if you dismantle the construction site.

Also worth noting: the construction direction is, on my system at least, 90° off the stated direction; I had to set it to West in order to place a boat on the south shore.

At this point I'm gonna stop doing any work on my VS mods until 1.20 is at least in rc, because right now the code quality is forcing me to do code reviews and QA I'm not getting paid for just to see how the new mechanics work, and I value my time more than that.