### PR TITLE
Fix Chiseled Block Heat Retention Bug

### DIFF
--- a/Systems/Microblock/BlockMicroBlock.cs
+++ b/Systems/Microblock/BlockMicroBlock.cs
@@ -227,7 +227,7 @@ namespace Vintagestory.GameContent
         {
             BlockEntityMicroBlock bemc = api.World.BlockAccessor.GetBlockEntity(pos) as BlockEntityMicroBlock;
 
-            if (bemc?.BlockIds != null && (bemc.sideAlmostSolid[facing.Index] || bemc.sideAlmostSolid[facing.Opposite.Index]) && bemc.BlockIds.Length > 0 && bemc.VolumeRel >= 0.5f)
+            if (bemc?.BlockIds != null && bemc.sideAlmostSolid[facing.Index] && bemc.BlockIds.Length > 0 && bemc.VolumeRel >= 0.5f)
             {
                 Block block = api.World.GetBlock(bemc.BlockIds[0]);
                 var mat = block.BlockMaterial;


### PR DESCRIPTION
From what I can tell this code was added once upon a time to make sure that if you were essentially making a vertical slab that faced inward out of a chiseled block it would still count properly as part of the wall.  But then, seemingly to deal with slabs and stairs, a different way of fixing the problem more permanently was added to the RoomRegistry code making this code redundant and instead causing this to cause a bug that can allow you to instead create a room with a big hole in the corner ![like this](https://github.com/user-attachments/assets/c32126dd-8ced-472e-ab35-2947f15a4e0e) but have it still be valid rather than thinking it is open.