### PR TITLE
Use CodeWithVariant and Variant where it is possible to avoid unpredictable behavior

### DIFF
--- a/Block/BlockBamboo.cs
+++ b/Block/BlockBamboo.cs
@@ -81,19 +81,19 @@ namespace Vintagestory.GameContent
                 if (overrider?.Exists == true) this.RandomDrawOffset = overrider.AsInt(1);
             }
 
-            isSegmentWithLeaves = LastCodePart() == "segment2" || LastCodePart() == "segment3";
+            isSegmentWithLeaves = Variant["part"] == "segment2" || Variant["part"] == "segment3";
         }
 
 
         public string Type()
         {
-            return LastCodePart(1);
+            return Variant["color"];
         }
 
         public Block NextSegment(IBlockAccessor blockAccess)
         {
 
-            string part = LastCodePart();
+            string part = Variant["part"];
 
             return Type() == "green" ?
                 (part == "segment1" ? greenSeg2 : (part == "segment2" ? greenSeg3 : null)) :
@@ -245,7 +245,7 @@ namespace Vintagestory.GameContent
 
         public override int GetRandomColor(ICoreClientAPI capi, BlockPos pos, BlockFacing facing, int rndIndex = -1)
         {
-            if (!this.isSegmentWithLeaves || LastCodePart() != "segment3") return base.GetRandomColor(capi, pos, facing, rndIndex);
+            if (!this.isSegmentWithLeaves || Variant["part"] != "segment3") return base.GetRandomColor(capi, pos, facing, rndIndex);
 
             if (Textures == null || Textures.Count == 0) return 0;
             CompositeTexture tex;

--- a/Block/BlockBed.cs
+++ b/Block/BlockBed.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Drawing;
+using System.Text;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Common.Entities;
@@ -16,8 +17,8 @@ namespace Vintagestory.GameContent
             BlockPos pos = new BlockPos(tree.GetInt("posx"), tree.GetInt("posy"), tree.GetInt("posz"));
             Block block = world.BlockAccessor.GetBlock(pos);
 
-            BlockFacing facing = BlockFacing.FromCode(block.LastCodePart());
-            BlockEntityBed beBed = world.BlockAccessor.GetBlockEntity(block.LastCodePart(1) == "feet" ? pos.AddCopy(facing) : pos) as BlockEntityBed;
+            BlockFacing facing = BlockFacing.FromCode(block.Variant["side"]);
+            BlockEntityBed beBed = world.BlockAccessor.GetBlockEntity(block.Variant["part"] == "feet" ? pos.AddCopy(facing) : pos) as BlockEntityBed;
 
             return beBed;
         }
@@ -41,10 +42,10 @@ namespace Vintagestory.GameContent
 
                 string code = horVer[0].Opposite.Code;
 
-                Block orientedBlock = world.BlockAccessor.GetBlock(CodeWithParts("head", code));
+                Block orientedBlock = world.BlockAccessor.GetBlock(CodeWithVariants(new string[] { "part", "side" }, new string[] { "head", code }));
                 orientedBlock.DoPlaceBlock(world, byPlayer, secondBlockSel, itemstack);
 
-                AssetLocation feetCode = CodeWithParts("feet", code);
+                AssetLocation feetCode = CodeWithVariants(new string[] { "part", "side" }, new string [] { "feet", code });
                 orientedBlock = world.BlockAccessor.GetBlock(feetCode);
                 orientedBlock.DoPlaceBlock(world, byPlayer, blockSel, itemstack);
                 return true;
@@ -60,8 +61,8 @@ namespace Vintagestory.GameContent
                 return false;
             }
 
-            BlockFacing facing = BlockFacing.FromCode(LastCodePart()).Opposite;
-            BlockEntityBed beBed = world.BlockAccessor.GetBlockEntity(LastCodePart(1) == "feet" ? blockSel.Position.AddCopy(facing) : blockSel.Position) as BlockEntityBed;
+            BlockFacing facing = BlockFacing.FromCode(Variant["side"]).Opposite;
+            BlockEntityBed beBed = world.BlockAccessor.GetBlockEntity(Variant["part"] == "feet" ? blockSel.Position.AddCopy(facing) : blockSel.Position) as BlockEntityBed;
 
             if (beBed == null) return false;
             if (beBed.MountedBy != null) return false;
@@ -90,10 +91,10 @@ namespace Vintagestory.GameContent
 
         public override void OnBlockRemoved(IWorldAccessor world, BlockPos pos)
         {
-            string headfoot = LastCodePart(1);
+            string headfoot = Variant["part"];
 
-            BlockFacing facing = BlockFacing.FromCode(LastCodePart());
-            if (LastCodePart(1) == "feet") facing = facing.Opposite;
+            BlockFacing facing = BlockFacing.FromCode(Variant["side"]);
+            if (headfoot == "feet") facing = facing.Opposite;
             else
             {
                 BlockEntityBed beBed = world.BlockAccessor.GetBlockEntity(pos) as BlockEntityBed;
@@ -102,7 +103,7 @@ namespace Vintagestory.GameContent
 
             Block secondPlock = world.BlockAccessor.GetBlock(pos.AddCopy(facing));
 
-            if (secondPlock is BlockBed && secondPlock.LastCodePart(1) != headfoot)
+            if (secondPlock is BlockBed && secondPlock.Variant["part"] != headfoot)
             {
                 world.BlockAccessor.SetBlock(0, pos.AddCopy(facing));
             }
@@ -117,30 +118,30 @@ namespace Vintagestory.GameContent
 
         public override ItemStack[] GetDrops(IWorldAccessor world, BlockPos pos, IPlayer byPlayer, float dropQuantityMultiplier = 1f)
         {
-            return new ItemStack[] { new ItemStack(world.BlockAccessor.GetBlock(CodeWithParts("head", "north"))) };
+            return new ItemStack[] { new ItemStack(world.BlockAccessor.GetBlock(CodeWithVariants(new string[] { "part", "side" }, new string[] { "head", "north" }))) };
         }
 
 
         public override AssetLocation GetRotatedBlockCode(int angle)
         {
-            BlockFacing beforeFacing = BlockFacing.FromCode(LastCodePart());
+            BlockFacing beforeFacing = BlockFacing.FromCode(Variant["side"]);
             int rotatedIndex = GameMath.Mod(beforeFacing.HorizontalAngleIndex - angle / 90, 4);
             BlockFacing nowFacing = BlockFacing.HORIZONTALS_ANGLEORDER[rotatedIndex];
 
-            return CodeWithParts(nowFacing.Code);
+            return CodeWithVariant("side", nowFacing.Code);
         }
 
         public override ItemStack OnPickBlock(IWorldAccessor world, BlockPos pos)
         {
-            return new ItemStack(world.BlockAccessor.GetBlock(CodeWithParts("head", "north")));
+            return new ItemStack(world.BlockAccessor.GetBlock(CodeWithVariants(new string[] { "part", "side" }, new string [] { "head", "north" })));
         }
 
         public override AssetLocation GetHorizontallyFlippedBlockCode(EnumAxis axis)
         {
-            BlockFacing facing = BlockFacing.FromCode(LastCodePart());
+            BlockFacing facing = BlockFacing.FromCode(Variant["side"]);
             if (facing.Axis == axis)
             {
-                return CodeWithParts(facing.Opposite.Code);
+                return CodeWithVariant("side", facing.Opposite.Code);
             }
             return Code;
         }

--- a/Block/BlockCactus.cs
+++ b/Block/BlockCactus.cs
@@ -29,26 +29,26 @@ namespace Vintagestory.GameContent
 
             if (blocksByHeight == null)
             {
-                topFlowering = blockAccessor.GetBlock(CodeWithParts("topflowering"));
-                topRipe = blockAccessor.GetBlock(CodeWithParts("topripe"));
+                topFlowering = blockAccessor.GetBlock(CodeWithVariant("variants", "topflowering"));
+                topRipe = blockAccessor.GetBlock(CodeWithVariant("variants", "topripe"));
 
                 blocksByHeight = new Block[][]
                 {
                     new Block[]
                     {
-                        blockAccessor.GetBlock(CodeWithParts("topempty"))
+                        blockAccessor.GetBlock(CodeWithVariant("variants", "topempty"))
                     },
                     new Block[]
                     {
-                        blockAccessor.GetBlock(CodeWithParts("segment")),
-                        blockAccessor.GetBlock(CodeWithParts("topempty"))
+                        blockAccessor.GetBlock(CodeWithVariant("variants", "segment")),
+                        blockAccessor.GetBlock(CodeWithVariant("variants", "topempty"))
 
                     },
                     new Block[]
                     {
-                        blockAccessor.GetBlock(CodeWithParts("segment")),
-                        blockAccessor.GetBlock(CodeWithParts("branchysegment")),
-                        blockAccessor.GetBlock(CodeWithParts("topempty"))
+                        blockAccessor.GetBlock(CodeWithVariant("variants", "segment")),
+                        blockAccessor.GetBlock(CodeWithVariant("variants", "branchysegment")),
+                        blockAccessor.GetBlock(CodeWithVariant("variants", "topempty"))
                     }
                 };
             }

--- a/Block/BlockChandelier.cs
+++ b/Block/BlockChandelier.cs
@@ -10,7 +10,7 @@ namespace Vintagestory.GameContent
         {
             get
             {
-                switch (LastCodePart())
+                switch (Variant["type"])
                 {
                     case "candle0":
                         return 0;

--- a/Block/BlockLantern.cs
+++ b/Block/BlockLantern.cs
@@ -211,7 +211,7 @@ namespace Vintagestory.GameContent
 
         public override ItemStack OnPickBlock(IWorldAccessor world, BlockPos pos)
         {
-            ItemStack stack = new ItemStack(world.GetBlock(CodeWithParts("up")));
+            ItemStack stack = new ItemStack(world.GetBlock(CodeWithVariant("position", "up")));
 
             BELantern be = world.BlockAccessor.GetBlockEntity(pos) as BELantern;
             if (be != null)

--- a/Block/BlockRails.cs
+++ b/Block/BlockRails.cs
@@ -34,11 +34,11 @@ namespace Vintagestory.GameContent
 
                 if (targetFacing.Axis == EnumAxis.Z)
                 {
-                    blockToPlace = world.GetBlock(CodeWithParts("flat_ns"));
+                    blockToPlace = world.GetBlock(CodeWithVariant("type", "flat_ns"));
                 }
                 else
                 {
-                    blockToPlace = world.GetBlock(CodeWithParts("flat_we"));
+                    blockToPlace = world.GetBlock(CodeWithVariant("type", "flat_we"));
                 }
             }
 

--- a/Block/BlockSign.cs
+++ b/Block/BlockSign.cs
@@ -4,6 +4,7 @@ using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Util;
 using System;
+using System.Net.Mail;
 
 namespace Vintagestory.GameContent
 {
@@ -110,7 +111,7 @@ namespace Vintagestory.GameContent
 
             if (bs.Face.IsHorizontal && (supportingBlock.CanAttachBlockAt(world.BlockAccessor, this, supportingPos, bs.Face) || supportingBlock.GetAttributes(world.BlockAccessor, supportingPos)?.IsTrue("partialAttachable") == true))
             {
-                Block wallblock = world.BlockAccessor.GetBlock(CodeWithParts("wall", bs.Face.Opposite.Code));
+                Block wallblock = world.BlockAccessor.GetBlock(CodeWithVariants(new string[] { "attachment", "side" }, new string[] { "wall", bs.Face.Opposite.Code }));
 
                 if (!wallblock.CanPlaceBlock(world, byPlayer, bs, ref failureCode))
                 {
@@ -130,7 +131,7 @@ namespace Vintagestory.GameContent
 
             BlockFacing[] horVer = SuggestedHVOrientation(byPlayer, bs);
 
-            AssetLocation blockCode = CodeWithParts(horVer[0].Code);
+            AssetLocation blockCode = CodeWithVariant("side", horVer[0].Code);
             Block block = world.BlockAccessor.GetBlock(blockCode);
             world.BlockAccessor.SetBlock(block.BlockId, bs.Position);
 
@@ -154,15 +155,15 @@ namespace Vintagestory.GameContent
 
         public override ItemStack[] GetDrops(IWorldAccessor world, BlockPos pos, IPlayer byPlayer, float dropQuantityMultiplier = 1f)
         {
-            Block block = world.BlockAccessor.GetBlock(CodeWithParts("ground", "north"));
-            if (block == null) block = world.BlockAccessor.GetBlock(CodeWithParts("wall", "north"));
+            Block block = world.BlockAccessor.GetBlock(CodeWithVariants(new string[] { "attachment", "side" }, new string[] { "ground", "north" }));
+            if (block == null) block = world.BlockAccessor.GetBlock(CodeWithVariants(new string[] { "attachment", "side" }, new string[] { "wall", "north" }));
             return new ItemStack[] { new ItemStack(block) };
         }
 
         public override ItemStack OnPickBlock(IWorldAccessor world, BlockPos pos)
         {
-            Block block = world.BlockAccessor.GetBlock(CodeWithParts("ground", "north"));
-            if (block == null) block = world.BlockAccessor.GetBlock(CodeWithParts("wall", "north"));
+            Block block = world.BlockAccessor.GetBlock(CodeWithVariants(new string[] { "attachment", "side" }, new string[] { "ground", "north" }));
+            if (block == null) block = world.BlockAccessor.GetBlock(CodeWithVariants(new string[] { "attachment", "side" }, new string[] { "wall", "north" }));
             return new ItemStack(block);
         }
 
@@ -189,10 +190,10 @@ namespace Vintagestory.GameContent
 
         public override AssetLocation GetHorizontallyFlippedBlockCode(EnumAxis axis)
         {
-            BlockFacing facing = BlockFacing.FromCode(LastCodePart());
+            BlockFacing facing = BlockFacing.FromCode(Variant["side"]);
             if (facing.Axis == axis)
             {
-                return CodeWithParts(facing.Opposite.Code);
+                return CodeWithVariant("side", facing.Opposite.Code);
             }
             return Code;
         }
@@ -204,11 +205,11 @@ namespace Vintagestory.GameContent
 
         public override AssetLocation GetRotatedBlockCode(int angle)
         {
-            BlockFacing beforeFacing = BlockFacing.FromCode(LastCodePart());
+            BlockFacing beforeFacing = BlockFacing.FromCode(Variant["side"]);
             int rotatedIndex = GameMath.Mod(beforeFacing.HorizontalAngleIndex - angle / 90, 4);
             BlockFacing nowFacing = BlockFacing.HORIZONTALS_ANGLEORDER[rotatedIndex];
 
-            return CodeWithParts(nowFacing.Code);
+            return CodeWithVariant("side", nowFacing.Code);
         }
     }
 }

--- a/Block/BlockSignPost.cs
+++ b/Block/BlockSignPost.cs
@@ -85,7 +85,7 @@ namespace Vintagestory.GameContent
             BlockFacing facing = BlockFacing.FromCode(LastCodePart());
             if (facing.Axis == axis)
             {
-                return CodeWithParts(facing.Opposite.Code);
+                return CodeWithVariant("side", facing.Opposite.Code);
             }
             return Code;
         }

--- a/Block/BlockSimpleCoating.cs
+++ b/Block/BlockSimpleCoating.cs
@@ -54,13 +54,13 @@ namespace Vintagestory.GameContent
 
         public override ItemStack[] GetDrops(IWorldAccessor world, BlockPos pos, IPlayer byPlayer, float dropQuantityMultiplier = 1f)
         {
-            Block block = world.BlockAccessor.GetBlock(CodeWithParts("down"));
+            Block block = world.BlockAccessor.GetBlock(CodeWithVariant("side", "down"));
             return new ItemStack[] { new ItemStack(block) };
         }
 
         public override ItemStack OnPickBlock(IWorldAccessor world, BlockPos pos)
         {
-            Block block = world.BlockAccessor.GetBlock(CodeWithParts("down"));
+            Block block = world.BlockAccessor.GetBlock(CodeWithVariant("side", "down"));
             return new ItemStack(block);
         }
 
@@ -81,7 +81,7 @@ namespace Vintagestory.GameContent
 
             if (block.CanAttachBlockAt(world.BlockAccessor, this, attachingBlockPos, onBlockFace))
             {
-                int blockId = world.BlockAccessor.GetBlock(CodeWithParts(oppositeFace.Code)).BlockId;
+                int blockId = world.BlockAccessor.GetBlock(CodeWithVariant("side", oppositeFace.Code)).BlockId;
                 world.BlockAccessor.SetBlock(blockId, blockpos);
                 return true;
             }
@@ -91,8 +91,7 @@ namespace Vintagestory.GameContent
 
         bool CanBlockStay(IWorldAccessor world, BlockPos pos)
         {
-            string[] parts = Code.Path.Split('-');
-            BlockFacing facing = BlockFacing.FromCode(parts[parts.Length - 1]);
+            BlockFacing facing = BlockFacing.FromCode(Variant["side"]);
             Block block = world.BlockAccessor.GetBlock(pos.AddCopy(facing));
 
             return block.CanAttachBlockAt(world.BlockAccessor, this, pos.AddCopy(facing), facing.Opposite);
@@ -107,23 +106,23 @@ namespace Vintagestory.GameContent
 
         public override AssetLocation GetRotatedBlockCode(int angle)
         {
-            if (LastCodePart() == "up" || LastCodePart() == "down") return Code;
+            if (Variant["side"] == "up" || Variant["side"] == "down") return Code;
 
-            BlockFacing newFacing = BlockFacing.HORIZONTALS_ANGLEORDER[((360 - angle) / 90 + BlockFacing.FromCode(LastCodePart()).HorizontalAngleIndex) % 4];
-            return CodeWithParts(newFacing.Code);
+            BlockFacing newFacing = BlockFacing.HORIZONTALS_ANGLEORDER[((360 - angle) / 90 + BlockFacing.FromCode(Variant["side"]).HorizontalAngleIndex) % 4];
+            return CodeWithVariant("side", newFacing.Code);
         }
 
         public override AssetLocation GetVerticallyFlippedBlockCode()
         {
-            return LastCodePart() == "up" ? CodeWithParts("down") : CodeWithParts("up");
+            return Variant["side"] == "up" ? CodeWithVariant("side", "down") : CodeWithVariant("side", "up");
         }
 
         public override AssetLocation GetHorizontallyFlippedBlockCode(EnumAxis axis)
         {
-            BlockFacing facing = BlockFacing.FromCode(LastCodePart());
+            BlockFacing facing = BlockFacing.FromCode(Variant["side"]);
             if (facing.Axis == axis)
             {
-                return CodeWithParts(facing.Opposite.Code);
+                return CodeWithVariant("side", facing.Opposite.Code);
             }
             return Code;
         }

--- a/Block/BlockSmeltingContainer.cs
+++ b/Block/BlockSmeltingContainer.cs
@@ -94,7 +94,7 @@ namespace Vintagestory.GameContent
 
             AlloyRecipe alloy = GetMatchingAlloy(world, stacks);
 
-            Block block = world.GetBlock(CodeWithPath(FirstCodePart() + "-smelted"));
+            Block block = world.GetBlock(CodeWithVariant("type", "smelted"));
             ItemStack outputStack = new ItemStack(block);
 
             if (alloy != null)

--- a/Block/BlockSoil.cs
+++ b/Block/BlockSoil.cs
@@ -172,7 +172,7 @@ namespace Vintagestory.GameContent
             {
                 int nextStage = GameMath.Clamp(targetStage, currentStage - 1, currentStage + 1);
 
-                return world.GetBlock(CodeWithParts(growthStages[nextStage]));
+                return world.GetBlock(CodeWithVariant("grasscoverage", growthStages[nextStage]));
             }
 
             return null;
@@ -202,7 +202,7 @@ namespace Vintagestory.GameContent
             int nextStage = Math.Max(currentStage - 1, 0);
             if (nextStage != currentStage)
             {
-                return world.GetBlock(CodeWithParts(growthStages[nextStage]));
+                return world.GetBlock(CodeWithVariant("grasscoverage", growthStages[nextStage]));
             }
             
             return null;

--- a/BlockEntity/BEHenBox.cs
+++ b/BlockEntity/BEHenBox.cs
@@ -66,7 +66,7 @@ namespace Vintagestory.GameContent
 
         public bool TryAddEgg(Entity entity, string chickCode, double incubationTime)
         {
-            if (Block.LastCodePart() == fullCode)
+            if (Block.Variant["eggCount"] == fullCode)
             {
                 if (timeToIncubate == 0)
                 {
@@ -96,7 +96,7 @@ namespace Vintagestory.GameContent
 
         private int CountEggs()
         {
-            int eggs = Block.LastCodePart()[0];
+            int eggs = Block.Variant["eggCount"][0];
             return eggs <= '9' && eggs >= '0' ? eggs - '0' : 0;
         }
 
@@ -143,7 +143,7 @@ namespace Vintagestory.GameContent
                 }
 
 
-                Block replacementBlock = Api.World.GetBlock(new AssetLocation(Block.FirstCodePart() + "-empty"));
+                Block replacementBlock = Api.World.GetBlock(Block.CodeWithVariant("eggCount", "empty"));
                 Api.World.BlockAccessor.ExchangeBlock(replacementBlock.Id, this.Pos);
                 this.Api.World.SpawnCubeParticles(Pos.ToVec3d().Add(0.5, 0.5, 0.5), new ItemStack(this.Block), 1, 20, 1, null);
                 this.Block = replacementBlock;
@@ -240,7 +240,7 @@ namespace Vintagestory.GameContent
                 else if (timeToIncubate > 0)
                     dsc.AppendLine(Lang.Get("Incubation time remaining: {0:0} hours", timeToIncubate * 24));
 
-                if (occupier == null && Block.LastCodePart() == fullCode)
+                if (occupier == null && Block.Variant["eggCount"] == fullCode)
                     dsc.AppendLine(Lang.Get("A broody hen is needed!"));
             }
             else if (eggCount > 0)

--- a/Systems/MechanicalPower/Block/BlockAngledGears.cs
+++ b/Systems/MechanicalPower/Block/BlockAngledGears.cs
@@ -62,7 +62,7 @@ namespace Vintagestory.GameContent.Mechanics
 
         public override ItemStack OnPickBlock(IWorldAccessor world, BlockPos pos)
         {
-            return new ItemStack(world.GetBlock(new AssetLocation("angledgears-s")));  
+            return new ItemStack(world.GetBlock(CodeWithVariant("orientation", "s")));  
         }
 
 
@@ -71,15 +71,15 @@ namespace Vintagestory.GameContent.Mechanics
             if (adjFacing == null)
             {
                 char orient = facing.Code[0];
-                return world.GetBlock(new AssetLocation(FirstCodePart() + (cageGear ? "-" + orient + orient : "-" + orient)));
+                return world.GetBlock(CodeWithVariant("orientation", cageGear ? "-" + orient + orient : "-" + orient));
             }
 
-            AssetLocation loc = new AssetLocation(FirstCodePart() + "-" + adjFacing.Code[0] + facing.Code[0]);
+            AssetLocation loc = CodeWithVariant("orientation", adjFacing.Code[0] + facing.Code[0] + "");
             Block toPlaceBlock = world.GetBlock(loc);
 
             if (toPlaceBlock == null)
             {
-                loc = new AssetLocation(FirstCodePart() + "-" + facing.Code[0] + adjFacing.Code[0]);
+                loc = CodeWithVariant("orientation", facing.Code[0] + adjFacing.Code[0] + "");
                 toPlaceBlock = world.GetBlock(loc);
             }
 
@@ -229,7 +229,7 @@ namespace Vintagestory.GameContent.Mechanics
             if (lostFacings.Count > 0)
             {
                 orients = orients.Replace("" + lostFacings[0].Code[0], "");
-                Block toPlaceBlock = world.GetBlock(new AssetLocation(FirstCodePart() + "-" + orients));
+                Block toPlaceBlock = world.GetBlock(CodeWithVariant("orientation", orients));
                 (toPlaceBlock as BlockMPBase).ExchangeBlockAt(world, pos);
                 BlockEntity be = world.BlockAccessor.GetBlockEntity(pos);
                 BEBehaviorMPBase bemp = be.GetBehavior<BEBehaviorMPBase>();
@@ -283,7 +283,7 @@ namespace Vintagestory.GameContent.Mechanics
             string orient = Variant["orientation"];
             if (orient.Length == 2 && orient[1] == orient[0])
             {
-                Block toPlaceBlock = world.GetBlock(new AssetLocation(FirstCodePart() + "-" + orient[0]));
+                Block toPlaceBlock = world.GetBlock(CodeWithVariant("orientation", orient[0] + ""));
                 ((BlockMPBase)toPlaceBlock).ExchangeBlockAt(world, pos);
                 BEBehaviorMPAngledGears beg = world.BlockAccessor.GetBlockEntity(pos)?.GetBehavior<BEBehaviorMPAngledGears>();
                 beg?.ClearLargeGear();

--- a/Systems/MechanicalPower/Block/BlockAxle.cs
+++ b/Systems/MechanicalPower/Block/BlockAxle.cs
@@ -9,7 +9,7 @@ namespace Vintagestory.GameContent.Mechanics
     {
         public bool IsOrientedTo(BlockFacing facing)
         {
-            string dirs = LastCodePart();
+            string dirs = Variant["rotation"];
 
             return dirs[0] == facing.Code[0] || (dirs.Length > 1 && dirs[1] == facing.Code[0]);
         }
@@ -37,11 +37,11 @@ namespace Vintagestory.GameContent.Mechanics
                     BlockFacing faceOpposite = face.Opposite;
                     if (block.HasMechPowerConnectorAt(world, pos, faceOpposite))
                     {
-                        AssetLocation loc = new AssetLocation(FirstCodePart() + "-" + faceOpposite.Code[0] + face.Code[0]);
+                        AssetLocation loc = CodeWithVariant("rotation", faceOpposite.Code[0] + face.Code[0] + "");
                         Block toPlaceBlock = world.GetBlock(loc);
                         if (toPlaceBlock == null)
                         {
-                            loc = new AssetLocation(FirstCodePart() + "-" + face.Code[0] + faceOpposite.Code[0]);
+                            loc = CodeWithVariant("rotation", face.Code[0] + faceOpposite.Code[0] + "");
                             toPlaceBlock = world.GetBlock(loc);
                         }
 

--- a/Systems/MechanicalPower/Block/BlockBrake.cs
+++ b/Systems/MechanicalPower/Block/BlockBrake.cs
@@ -29,7 +29,7 @@ namespace Vintagestory.GameContent.Mechanics
             }
 
             BlockFacing[] horVer = Block.SuggestedHVOrientation(byPlayer, blockSel);
-            AssetLocation blockCode = CodeWithParts(horVer[0].Code);
+            AssetLocation blockCode = CodeWithVariant("side", horVer[0].Code);
             Block orientedBlock = world.BlockAccessor.GetBlock(blockCode);
 
 

--- a/Systems/MechanicalPower/Block/BlockClutch.cs
+++ b/Systems/MechanicalPower/Block/BlockClutch.cs
@@ -37,7 +37,7 @@ namespace Vintagestory.GameContent.Mechanics
                 }
             }
 
-            Block orientedBlock = world.BlockAccessor.GetBlock(CodeWithParts(bestFacing.Code));
+            Block orientedBlock = world.BlockAccessor.GetBlock(CodeWithVariant("side", bestFacing.Code));
             return orientedBlock.DoPlaceBlock(world, byPlayer, blockSel, itemstack);
         }
 

--- a/Systems/MechanicalPower/Block/BlockCreativeRotor.cs
+++ b/Systems/MechanicalPower/Block/BlockCreativeRotor.cs
@@ -43,7 +43,7 @@ namespace Vintagestory.GameContent.Mechanics
                         //Prevent rotor back-to-back placement
                         if (block is IMPPowered) return false;
 
-                        Block toPlaceBlock = world.GetBlock(new AssetLocation(FirstCodePart() + "-" + face.Opposite.Code));
+                        Block toPlaceBlock = world.GetBlock(CodeWithVariant("side", face.Opposite.Code));
                         world.BlockAccessor.SetBlock(toPlaceBlock.BlockId, blockSel.Position);
 
                         block.DidConnectAt(world, pos, face.Opposite);

--- a/Systems/MechanicalPower/Block/BlockLargeGear3m.cs
+++ b/Systems/MechanicalPower/Block/BlockLargeGear3m.cs
@@ -45,7 +45,8 @@ namespace Vintagestory.GameContent.Mechanics
                     if (dx == 1) orient = 'e';
                     else if (dx == -1) orient = 'w';
                     else if (dz == 1) orient = 's';
-                    BlockMPBase toPlaceBlock = world.GetBlock(new AssetLocation("angledgears-" + orient + orient)) as BlockMPBase;
+                    Block smallGearBlock = world.BlockAccessor.GetBlock(smallGear);
+                    BlockMPBase toPlaceBlock = world.GetBlock(smallGearBlock.CodeWithVariant("orientation", orient + orient + "")) as BlockMPBase;
                     BlockFacing bf = BlockFacing.FromFirstLetter(orient);
                     toPlaceBlock.ExchangeBlockAt(world, smallGear);
                     toPlaceBlock.DidConnectAt(world, smallGear, bf.Opposite);

--- a/Systems/MechanicalPower/Block/BlockPulverizer.cs
+++ b/Systems/MechanicalPower/Block/BlockPulverizer.cs
@@ -54,7 +54,7 @@ namespace Vintagestory.GameContent.Mechanics
                 {
                     if (block.HasMechPowerConnectorAt(world, pos, face.Opposite))
                     {
-                        AssetLocation loc = new AssetLocation(FirstCodePart() + "-" + face.GetCCW().Code);
+                        AssetLocation loc = CodeWithVariant("side", face.GetCCW().Code);
                         Block toPlaceBlock = world.GetBlock(loc);
                         if (toPlaceBlock.DoPlaceBlock(world, byPlayer, blockSel, itemstack))
                         {
@@ -137,7 +137,7 @@ namespace Vintagestory.GameContent.Mechanics
 
         public override ItemStack[] GetDrops(IWorldAccessor world, BlockPos pos, IPlayer byPlayer, float dropQuantityMultiplier = 1f)
         {
-            ItemStack pulvFrame = new ItemStack(world.BlockAccessor.GetBlock(CodeWithParts("north")));
+            ItemStack pulvFrame = new ItemStack(world.BlockAccessor.GetBlock(CodeWithVariant("side", "north")));
             BEPulverizer bep = world.BlockAccessor.GetBlockEntity(pos) as BEPulverizer;
             if (bep != null)
             {

--- a/Systems/MechanicalPower/Block/BlockToggle.cs
+++ b/Systems/MechanicalPower/Block/BlockToggle.cs
@@ -9,7 +9,7 @@ namespace Vintagestory.GameContent.Mechanics
     {
         public bool IsOrientedTo(BlockFacing facing)
         {
-            string dirs = LastCodePart();
+            string dirs = Variant["orientation"];
 
             return dirs[0] == facing.Code[0] || (dirs.Length > 1 && dirs[1] == facing.Code[0]);
         }
@@ -36,11 +36,11 @@ namespace Vintagestory.GameContent.Mechanics
                 {
                     if (block.HasMechPowerConnectorAt(world, pos, face.Opposite))
                     {
-                        AssetLocation loc = new AssetLocation(FirstCodePart() + "-" + face.Opposite.Code[0] + face.Code[0]);
+                        AssetLocation loc = CodeWithVariant("orientation", face.Opposite.Code[0] + face.Code[0] + "");
                         Block toPlaceBlock = world.GetBlock(loc);
                         if (toPlaceBlock == null)
                         {
-                            loc = new AssetLocation(FirstCodePart() + "-" + face.Code[0] + face.Opposite.Code[0]);
+                            loc = CodeWithVariant("orientation", face.Code[0] + face.Opposite.Code[0] + "");
                             toPlaceBlock = world.GetBlock(loc);
                         }
 

--- a/Systems/MechanicalPower/Block/BlockTransmission.cs
+++ b/Systems/MechanicalPower/Block/BlockTransmission.cs
@@ -7,7 +7,7 @@ namespace Vintagestory.GameContent.Mechanics
     {
         public bool IsOrientedTo(BlockFacing facing)
         {
-            string dirs = LastCodePart();
+            string dirs = Variant["orientation"];
 
             return dirs[0] == facing.Code[0] || (dirs.Length > 1 && dirs[1] == facing.Code[0]);
         }
@@ -37,11 +37,11 @@ namespace Vintagestory.GameContent.Mechanics
                         AssetLocation loc;
                         if (face == BlockFacing.EAST || face == BlockFacing.WEST)
                         {
-                            loc = new AssetLocation(FirstCodePart() + "-we");
+                            loc = CodeWithVariant("orientation", "we");
                         }
                         else
                         {
-                            loc = new AssetLocation(FirstCodePart() + "-ns");
+                            loc = CodeWithVariant("orientation", "ns");
                         }
                         Block toPlaceBlock = world.GetBlock(loc);
 

--- a/Systems/MechanicalPower/Block/BlockWindmillRotor.cs
+++ b/Systems/MechanicalPower/Block/BlockWindmillRotor.cs
@@ -42,7 +42,7 @@ namespace Vintagestory.GameContent.Mechanics
                         //Prevent rotor back-to-back placement
                         if (block is IMPPowered) return false;
 
-                        Block toPlaceBlock = world.GetBlock(new AssetLocation(FirstCodePart() + "-" + face.Opposite.Code));
+                        Block toPlaceBlock = world.GetBlock(CodeWithVariant("side", face.Opposite.Code));
                         world.BlockAccessor.SetBlock(toPlaceBlock.BlockId, blockSel.Position);
 
                         block.DidConnectAt(world, pos, face.Opposite);


### PR DESCRIPTION
When I added wooden variants to all mechanical blocks, they were crashing because they didn't expect new variants.

These fixes allow variants for mechanical blocks and crucibles.
The rest of fixes may not be that important, but they worth adding too.