### PR TITLE
Overhaul Charcoal Pit and Charcoal Pile

### DIFF
--- a/Block/BlockCharcoalPile.cs
+++ b/Block/BlockCharcoalPile.cs
@@ -1,9 +1,66 @@
 ﻿using Vintagestory.API.Common;
+using Vintagestory.API.Datastructures;
+using Vintagestory.API.MathTools;
 
 namespace Vintagestory.GameContent
 {
     public class BlockCharcoalPile : BlockLayeredSlowDig
     {
+        public override bool OnFallOnto(IWorldAccessor world, BlockPos pos, Block block, TreeAttribute blockEntityAttributes)
+        {
+            Block nBlock = (BlockCharcoalPile)world.BlockAccessor.GetMostSolidBlock(pos);
+            if (block is BlockCharcoalPile && nBlock is BlockCharcoalPile)
+            {
+
+                Block uBlock = block;
+                while (((BlockCharcoalPile)nBlock).CountLayers() < 8 && uBlock != null)
+                {
+                    nBlock = ((BlockCharcoalPile)nBlock).GetNextLayer(world);
+                    uBlock = ((BlockCharcoalPile)uBlock).GetPrevLayer(world);
+                }
+
+                world.BlockAccessor.SetBlock(nBlock.BlockId, pos);
+                world.BlockAccessor.TriggerNeighbourBlockUpdate(pos);
+                if (uBlock != null)
+                {
+                    world.BlockAccessor.SetBlock(uBlock.BlockId, pos.UpCopy());
+                    world.BlockAccessor.TriggerNeighbourBlockUpdate(pos.UpCopy());
+                }
+                return true;
+            }
+
+            return base.OnFallOnto(world, pos, block, blockEntityAttributes);
+        }
+
+        public override void OnBlockBroken(IWorldAccessor world, BlockPos pos, IPlayer byPlayer, float dropQuantityMultiplier = 1f)
+        {
+            Block block = world.BlockAccessor.GetBlock(pos);
+
+            BlockPos abovePos = pos.UpCopy();
+            Block aboveBlock = null;
+
+            while (abovePos.Y < world.BlockAccessor.MapSizeY)
+            {
+                aboveBlock = world.BlockAccessor.GetBlock(abovePos);
+                if (aboveBlock.FirstCodePart() != block.FirstCodePart()) break;
+
+                abovePos.Up();
+            }
+
+            if (abovePos == pos.UpCopy() || aboveBlock == null || byPlayer?.WorldData.CurrentGameMode == EnumGameMode.Creative)
+            {
+                base.OnBlockBroken(world, pos, byPlayer);
+                world.BlockAccessor.TriggerNeighbourBlockUpdate(pos);
+                return;
+            }
+            else if (aboveBlock.FirstCodePart() == block.FirstCodePart()) aboveBlock.OnBlockBroken(world, abovePos, byPlayer);
+            else
+            {
+                BlockPos topPos = abovePos.DownCopy();
+                Block topBlock = world.BlockAccessor.GetBlock(topPos);
+                topBlock.OnBlockBroken(world, topPos, byPlayer);
+            }
+        }
 
         public override float RandomSoundPitch(IWorldAccessor world)
         {


### PR DESCRIPTION
The old code would check ± 6 in each direction, which meant that it was actually checking a 13x13x13 cube with the fire pit at the center.  I have slightly modified it so it will check an 11x11x11 cube located _under_ the fire pit, with the fire pit in the center.  This should match the handbook saying that “your charcoal pit can be any dimension up to 11x11x11 blocks” and “Cover the filled pit completely, but leave the top of a single stack of firewood in the center exposed to air.”

It might be desirable to make it so it doesn’t have to be centered in the cube horizontally, but that would take a more complex fix, while this should make it match the explanation from the handbook.

Edit: With the Overhaul Charcoal Pile commit the JSON needs to be updated to add `fullBlockCode: "charcoalpile-8"` to the attributes as well as the UnstableFalling block behavior.  More in the later comments.