### PR TITLE
 Fix Doors and Trapdoors Solid Side Detection and Miscellaneous Other Door/Trapdoor Bugs (Important for 1.20)

### DIFF
--- a/BlockBehavior/BehaviorDoor.cs
+++ b/BlockBehavior/BehaviorDoor.cs
@@ -90,9 +90,9 @@ namespace Vintagestory.GameContent
         protected bool hasCombinableLeftDoor(IWorldAccessor world, float RotateYRad, BlockPos pos, int doorWidth)
         {
             int width = doorWidth;
-            BlockPos leftPos = pos.AddCopy(width * (int)Math.Round(Math.Sin(RotateYRad - 90)), 0, width * (int)Math.Round(Math.Cos(RotateYRad - 90)));
+            BlockPos leftPos = pos.AddCopy((int)Math.Round(Math.Sin(RotateYRad - GameMath.PIHALF)), 0, (int)Math.Round(Math.Cos(RotateYRad - GameMath.PIHALF)));
             var leftDoor = getDoorAt(world, leftPos);
-            if (leftDoor != null && !leftDoor.InvertHandles)
+            if (leftDoor != null && !leftDoor.InvertHandles && leftDoor.facingWhenClosed == BlockFacing.HorizontalFromYaw(RotateYRad))
             {
                 return true;
             }
@@ -179,6 +179,7 @@ namespace Vintagestory.GameContent
                 AssetLocation loc = new AssetLocation("multiblock-monolithic-" + sdx + "-" + sdy + "-" + sdz);
                 Block block = world.GetBlock(loc);
                 world.BlockAccessor.SetBlock(block.Id, mpos);
+                if (world.Side == EnumAppSide.Server) world.BlockAccessor.TriggerNeighbourBlockUpdate(mpos);
                 return true;
             });
         }
@@ -198,6 +199,7 @@ namespace Vintagestory.GameContent
                 if (mblock is BlockMultiblock)
                 {
                     world.BlockAccessor.SetBlock(0, mpos);
+                    if (world.Side == EnumAppSide.Server) world.BlockAccessor.TriggerNeighbourBlockUpdate(mpos);
                 }
 
                 return true;
@@ -287,6 +289,14 @@ namespace Vintagestory.GameContent
 
         public override void GetDecal(IWorldAccessor world, BlockPos pos, ITexPositionSource decalTexSource, ref MeshData decalModelData, ref MeshData blockModelData, ref EnumHandling handled)
         {
+            var beh = world.BlockAccessor.GetBlockEntity(pos)?.GetBehavior<BEBehaviorDoorTest>();
+
+            if (beh.Opened)
+            {
+                float rot = beh.InvertHandles ? 90 : -90;
+                decalModelData = decalModelData.Rotate(new Vec3f(0.5f, 0.5f, 0.5f), 0, rot * GameMath.DEG2RAD, 0);
+                if (!beh.InvertHandles) decalModelData = decalModelData.Scale(new Vec3f(0.5f, 0.5f, 0.5f), 1, 1f, -1);
+            }
             base.GetDecal(world, pos, decalTexSource, ref decalModelData, ref blockModelData, ref handled);
         }
 
@@ -316,8 +326,7 @@ namespace Vintagestory.GameContent
             var beh = block.GetBEBehavior<BEBehaviorDoor>(pos);
             if (beh == null) return 0f;
 
-            if (beh.Opened) return 0f;
-            if (face != beh.facingWhenClosed) return 0f;
+            if (!beh.IsSideSolid(face)) return 0f;
 
             if (block.Variant["style"] == "sleek-windowed") return 1.0f;
 
@@ -330,8 +339,7 @@ namespace Vintagestory.GameContent
         {
             var beh = block.GetBEBehavior<BEBehaviorDoor>(pos.AddCopy(offset.X, offset.Y, offset.Z));
             if (beh == null) return 0f;
-            if (beh.Opened) return 0f;
-            if (face != beh.facingWhenClosed) return 0f;
+            if (!beh.IsSideSolid(face)) return 0f;
 
             if (block.Variant["style"] == "sleek-windowed") return offset.Y == -1 ? 0.0f : 1.0f;
 
@@ -346,10 +354,11 @@ namespace Vintagestory.GameContent
             var beh = block.GetBEBehavior<BEBehaviorDoor>(pos);
             if (beh == null) return 0;
 
-            if (type == EnumRetentionType.Sound) return beh.Opened ? 0 : 3;
+            if (type == EnumRetentionType.Sound) return beh.IsSideSolid(facing) ? 3 : 0;
 
             if (!airtight) return 0;
-            return beh.Opened ? 3 : 1;
+            if (api.World.Config.GetBool("openDoorsNotSolid", false)) return beh.IsSideSolid(facing) ? 1 : 0;
+            return (beh.IsSideSolid(facing) || beh.IsSideSolid(facing.Opposite)) ? 1 : 3; // Also check opposite so the door can be facing inwards or outwards.
         }
 
 
@@ -357,10 +366,11 @@ namespace Vintagestory.GameContent
         {
             var beh = block.GetBEBehavior< BEBehaviorDoor>(pos.AddCopy(offset.X, offset.Y, offset.Z));
             if (beh == null) return 0;
-            if (type == EnumRetentionType.Sound) return beh.Opened ? 0 : 3;
+            if (type == EnumRetentionType.Sound) return beh.IsSideSolid(facing) ? 3 : 0;
 
             if (!airtight) return 0;
-            return beh.Opened ? 3 : 1; 
+            if (api.World.Config.GetBool("openDoorsNotSolid", false)) return beh.IsSideSolid(facing) ? 1 : 0;
+            return (beh.IsSideSolid(facing) || beh.IsSideSolid(facing.Opposite)) ? 1 : 3; // Also check opposite so the door can be facing inwards or outwards.
         }
 
         public bool MBCanAttachBlockAt(IBlockAccessor blockAccessor, Block block, BlockPos pos, BlockFacing blockFace, Cuboidi attachmentArea, Vec3i offsetInv)

--- a/BlockBehavior/BlockBehaviorTrapDoor.cs
+++ b/BlockBehavior/BlockBehaviorTrapDoor.cs
@@ -111,6 +111,13 @@ namespace Vintagestory.GameContent
 
         public override void GetDecal(IWorldAccessor world, BlockPos pos, ITexPositionSource decalTexSource, ref MeshData decalModelData, ref MeshData blockModelData, ref EnumHandling handled)
         {
+            var beh = world.BlockAccessor.GetBlockEntity(pos)?.GetBehavior<BEBehaviorTrapDoorTest>();
+
+            if (beh.Opened)
+            {
+                decalModelData = decalModelData.Rotate(new Vec3f(0.5f, 0.5f, 0.5f), 90 * GameMath.DEG2RAD, 0, 0);
+                decalModelData = decalModelData.Scale(new Vec3f(0.5f, 0.5f, 0.5f), 1, -1f, 1);
+            }
             base.GetDecal(world, pos, decalTexSource, ref decalModelData, ref blockModelData, ref handled);
         }
 
@@ -140,10 +147,7 @@ namespace Vintagestory.GameContent
             var beh = block.GetBEBehavior<BEBehaviorTrapDoor>(pos);
             if (beh == null) return 0f;
 
-            if (beh.Opened) return 0f;
-            //if (face != beh.facingWhenClosed) return 0f;
-
-            if (block.Variant["style"] == "sleek-windowed") return 1.0f;
+            if (!beh.IsSideSolid(face)) return 0f;
 
             if (!airtight) return 0f;
 
@@ -156,10 +160,11 @@ namespace Vintagestory.GameContent
             var beh = block.GetBEBehavior<BEBehaviorTrapDoor>(pos);
             if (beh == null) return 0;
 
-            if (type == EnumRetentionType.Sound) return beh.Opened ? 0 : 3;
+            if (type == EnumRetentionType.Sound) return beh.IsSideSolid(facing) ? 3 : 0;
 
             if (!airtight) return 0;
-            return beh.Opened ? 3 : 1;
+            if (api.World.Config.GetBool("openDoorsNotSolid", false)) return beh.IsSideSolid(facing) ? 1 : 0;
+            return (beh.IsSideSolid(facing) || beh.IsSideSolid(facing.Opposite)) ? 1 : 3; // Also check opposite so the door can be facing inwards or outwards.
         }
     }
 }

--- a/Legacy/BlockDoor.cs
+++ b/Legacy/BlockDoor.cs
@@ -24,6 +24,14 @@ namespace Vintagestory.GameContent
             return BlockFacing.FromCode(Variant["horizontalorientation"]);
         }
 
+        public bool IsSideSolid(BlockFacing facing)
+        {
+            BlockFacing facingWhenClosed = GetDirection().Opposite;
+            BlockFacing facingWhenOpened = GetKnobOrientation() == "left" ? facingWhenClosed.GetCCW() : facingWhenClosed.GetCW();
+
+            return (!open && facingWhenClosed == facing) || (open && facingWhenOpened == facing);
+        }
+
         public string GetKnobOrientation(Block block)
         {
             return Variant["knobOrientation"];
@@ -39,7 +47,7 @@ namespace Vintagestory.GameContent
             BlockPos abovePos = blockSel.Position.AddCopy(0, 1, 0);
             IBlockAccessor ba = world.BlockAccessor;
 
-            if (ba.GetBlock(abovePos).Id == 0 && CanPlaceBlock(world, byPlayer, blockSel, ref failureCode))
+            if (CanPlaceBlock(world, byPlayer, blockSel.AddPosCopy(0, 1, 0), ref failureCode) && CanPlaceBlock(world, byPlayer, blockSel, ref failureCode))
             {
                 BlockFacing[] horVer = SuggestedHVOrientation(byPlayer, blockSel);
 
@@ -58,7 +66,9 @@ namespace Vintagestory.GameContent
                 Block upBlock = ba.GetBlock(upBlockCode);
 
                 ba.SetBlock(downBlock.BlockId, blockSel.Position);
+                if (world.Side == EnumAppSide.Server) world.BlockAccessor.TriggerNeighbourBlockUpdate(blockSel.Position);
                 ba.SetBlock(upBlock.BlockId, abovePos);
+                if (world.Side == EnumAppSide.Server) world.BlockAccessor.TriggerNeighbourBlockUpdate(abovePos);
                 return true;
             }
 
@@ -102,12 +112,14 @@ namespace Vintagestory.GameContent
             if (otherPart is BlockDoor && ((BlockDoor)otherPart).IsUpperHalf() != IsUpperHalf())
             {
                 world.BlockAccessor.SetBlock(0, otherPos);
+                if (world.Side == EnumAppSide.Server) world.BlockAccessor.TriggerNeighbourBlockUpdate(otherPos);
             }
 
             Block block = world.BlockAccessor.GetBlock(pos);
             if (block is BlockDoor)
             {
                 world.BlockAccessor.SetBlock(0, pos);
+                if (world.Side == EnumAppSide.Server) world.BlockAccessor.TriggerNeighbourBlockUpdate(pos);
             }
         }
 
@@ -164,6 +176,7 @@ namespace Vintagestory.GameContent
             {
                 world.BlockAccessor.ExchangeBlock(world.BlockAccessor.GetBlock(otherNewCode).BlockId, otherPos);
                 world.BlockAccessor.MarkBlockDirty(otherPos);
+                if (world.Side == EnumAppSide.Server) world.BlockAccessor.TriggerNeighbourBlockUpdate(otherPos);
             }
         }
 
@@ -185,18 +198,20 @@ namespace Vintagestory.GameContent
 
         public override int GetRetention(BlockPos pos, BlockFacing facing, EnumRetentionType type)
         {
+            if (type == EnumRetentionType.Sound) return IsSideSolid(facing) ? 3 : 0;
+
             if (!airtight) return 0;
-            return open ? 3 : 1;
+            if (api.World.Config.GetBool("openDoorsNotSolid", false)) return IsSideSolid(facing) ? 1 : 0;
+            return (IsSideSolid(facing) || IsSideSolid(facing.Opposite)) ? 1 : 3; // Also check opposite so the door can be facing inwards or outwards.
         }
 
         public override float GetLiquidBarrierHeightOnSide(BlockFacing face, BlockPos pos)
         {
-            if (open) return 0f;
-            if (face != GetDirection().Opposite) return 0f;
+            if (!IsSideSolid(face)) return 0f;
 
             if (!airtight) return 0f;
 
-            return IsUpperHalf() ? 0.0f : 1.0f;
+            return Attributes?["liquidBarrierHeight"].AsFloat(IsUpperHalf() ? 0.0f : 1.0f) ?? (IsUpperHalf() ? 0.0f : 1.0f);
         }
 
     }


### PR DESCRIPTION
I realized at some point that if you place a door down in what would be the open position and then “close” it the game will think of it as open and it will count as open for cases like cellars and for liquid flowing through it.  This PR changes the logic slightly so that instead of appearing to be a completely solid block any time the Opened variable is false and a non-solid block otherwise, the game will respond to it as if the side of the door that is up against the wall of the space is the solid side, the same way it treats slabs.

With trapdoors being added this is particularly necessary because the "Opened" variable will far more often not match whether the block is visually open than ever before.

[Video demonstrating various bugs this fixes.](https://media.discordapp.net/attachments/402173001178677268/1318917893790105621/Vintage_Story_2024-12-18_05-19-08.mp4?ex=67641182&is=6762c002&hm=f5ef9d5f40d6bb8d080ef91cde8df10330b640a83ec00dc82893f7d4744b09ee&)