### PR TITLE
Fix Clayforming Voxel Count to be Consistent

### DIFF
--- a/BlockEntity/BEClayForm.cs
+++ b/BlockEntity/BEClayForm.cs
@@ -116,7 +116,7 @@ namespace Vintagestory.GameContent
                 baseMaterial.StackSize = 1;
             }
 
-            AvailableVoxels += 25;
+            AvailableVoxels = 0;
 
             slot.TakeOut(1);
             slot.MarkDirty();
@@ -507,9 +507,9 @@ namespace Vintagestory.GameContent
         {
             Voxels = new bool[16, 16, 16];
 
-            for (int x = 4; x < 12; x++)
+            for (int x = 5; x < 11; x++)
             {
-                for (int z = 4; z < 12; z++)
+                for (int z = 5; z < 11; z++)
                 {
                     Voxels[x, 0, z] = true;
                 }

--- a/Item/ItemClay.cs
+++ b/Item/ItemClay.cs
@@ -147,7 +147,7 @@ namespace Vintagestory.GameContent
             {
                 slot.TakeOut(1);
                 slot.MarkDirty();
-                bea.AvailableVoxels += 25;
+                bea.AvailableVoxels += 36;
             }
 
             // The server side call is made using a custom network packet


### PR DESCRIPTION
As I talked about with Tyron, this is my code that made clayforming use consistent numbers of voxels per clay item used, for integration in vanilla when desired.  It's a rather simple change but at least shows where exactly the code needs to change for when the team figures out what numbers to go with for balance.