### PR TITLE
Fix Skeps Not Always Dropping East Variant and So Not Properly Stacking In Crate if Placed and Picked Up

### DIFF
--- a/Block/BlockSkep.cs
+++ b/Block/BlockSkep.cs
@@ -34,7 +34,7 @@ namespace Vintagestory.GameContent
                 return true;
             }
 
-            if (byPlayer.InventoryManager.TryGiveItemstack(new ItemStack(this)))
+            if (byPlayer.InventoryManager.TryGiveItemstack(new ItemStack(world.BlockAccessor.GetBlock(this.CodeWithVariant("side", "east")))))
             {
                 world.BlockAccessor.SetBlock(0, blockSel.Position);
                 world.PlaySoundAt(new AssetLocation("sounds/block/planks"), blockSel.Position, -0.5, byPlayer, false);
@@ -88,13 +88,13 @@ namespace Vintagestory.GameContent
         {
             if (IsEmpty())
             {
-                return new ItemStack[] { new ItemStack(this) };
+                return new ItemStack[] { new ItemStack(world.BlockAccessor.GetBlock(this.CodeWithVariant("side", "east"))) };
             }
 
             BlockEntityBeehive beh = world.BlockAccessor.GetBlockEntity(pos) as BlockEntityBeehive;
             if (beh == null || !beh.Harvestable)
             {
-                return new ItemStack[] { new ItemStack(this) };
+                return new ItemStack[] { new ItemStack(world.BlockAccessor.GetBlock(this.CodeWithVariant("side", "east"))) };
             }
 
             if (Drops == null) return null;


### PR DESCRIPTION
I noticed when messing with skeps and using a crate that both in the inventory I could visually see the skep didn't match, as well as being unable to stack them in a crate because they were technically a different variant.  It seems the code does this because it is overriding the typical behavior of blocks to give the drops for their behaviors, and perhaps it would be better to make it do that normally when it cannot be harvested, but for now I hardcoded it instead so it will always drop East like expected.