### PR TITLE
Fix Waterfall Not Updating Flow When Blocked on Bottom Side

### DIFF
--- a/BlockBehavior/BehaviorFiniteSpreadingLiquid.cs
+++ b/BlockBehavior/BehaviorFiniteSpreadingLiquid.cs
@@ -540,17 +540,17 @@ namespace Vintagestory.GameContent
         {
             Block ourSolid = world.BlockAccessor.GetBlock(pos, BlockLayersAccess.SolidBlocks);
 
-            BlockPos npos = pos.Copy();
-            npos.Y++;
+            BlockPos npos = pos.UpCopy();
             Block ublock = world.BlockAccessor.GetBlock(npos, BlockLayersAccess.Fluid);
-            npos.Y--;
-            if (IsSameLiquid(ourblock, ublock) && ourSolid.GetLiquidBarrierHeightOnSide(BlockFacing.UP, pos) == 0.0)
+            Block uSolid = world.BlockAccessor.GetBlock(npos, BlockLayersAccess.SolidBlocks);
+            if (IsSameLiquid(ourblock, ublock) && ourSolid.GetLiquidBarrierHeightOnSide(BlockFacing.UP, pos) == 0.0 && uSolid.GetLiquidBarrierHeightOnSide(BlockFacing.DOWN, npos) == 0.0)
             {
                 return MAXLEVEL;
             }
             else
             {
                 int level = 0;
+                npos.Y--;
                 for (int i = 0; i < BlockFacing.HORIZONTALS.Length; i++)
                 {
                     BlockFacing.HORIZONTALS[i].IterateThruFacingOffsets(npos);


### PR DESCRIPTION
I noticed that when you place a slab in the bottom half of a water source block it wouldn't stop the downward flow of water.  Say I had a single block large hole with water flowing down out of it, I would expect the slab to make all the water go away, but instead nothing would change.  Turns out that's because it wasn't checking the down facing on the block above it when determining if it should disappear, only the up facing on itself.