### PR TITLE
Fix bucket variants having broken model and textures

### DIFF
--- a/Block/BlockBucket.cs
+++ b/Block/BlockBucket.cs
@@ -18,7 +18,7 @@ namespace Vintagestory.GameContent
     // - BlockBucket has methods for placing/taking liquids from a bucket stack or a placed bucket block
     public class BlockBucket : BlockLiquidContainerTopOpened
     {
-        protected override string meshRefsCacheKey => "bucketMeshRefs";
+        protected override string meshRefsCacheKey => "bucketMeshRefs" + Code;
 
 
         public override void OnLoaded(ICoreAPI api)


### PR DESCRIPTION
When adding new bucket, it doesn't use new model and textures, but uses vanilla bucket model and textures instead.

This fix caches every variant separately, instead using single cache key for many variants, thus allowing custom buckets to display correctly