### PR TITLE
Add Necessary Code for Labeled Trunk

### DIFF
--- a/Block/BlockLabeledChest.cs
+++ b/Block/BlockLabeledChest.cs
@@ -46,4 +46,46 @@ namespace Vintagestory.GameContent
             return interactions.Append(base.GetPlacedBlockInteractionHelp(world, selection, forPlayer));
         }
     }
+
+    public class BlockLabeledTrunk : BlockGenericTypedContainerTrunk
+    {
+        WorldInteraction[] interactions;
+
+        public override void OnLoaded(ICoreAPI api)
+        {
+            base.OnLoaded(api);
+
+            if (api.Side != EnumAppSide.Client) return;
+
+            interactions = ObjectCacheUtil.GetOrCreate(api, "signBlockInteractions", () =>
+            {
+                List<ItemStack> stacksList = new List<ItemStack>();
+
+                foreach (CollectibleObject collectible in api.World.Collectibles)
+                {
+                    if (collectible.Attributes?["pigment"].Exists == true)
+                    {
+                        stacksList.Add(new ItemStack(collectible));
+                    }
+                }
+
+                return new WorldInteraction[] {
+                    new WorldInteraction()
+                    {
+                        ActionLangCode = "blockhelp-sign-write",
+                        HotKeyCode = "shift",
+                        MouseButton = EnumMouseButton.Right,
+                        Itemstacks = stacksList.ToArray()
+                    }
+                };
+            });
+        }
+
+
+
+        public override WorldInteraction[] GetPlacedBlockInteractionHelp(IWorldAccessor world, BlockSelection selection, IPlayer forPlayer)
+        {
+            return interactions.Append(base.GetPlacedBlockInteractionHelp(world, selection, forPlayer));
+        }
+    }
 }

--- a/BlockEntity/BELabeledChest.cs
+++ b/BlockEntity/BELabeledChest.cs
@@ -31,7 +31,7 @@ namespace Vintagestory.GameContent
         public override string DialogTitle {
             get
             {
-                if (text == null || text.Length == 0) return Lang.Get("Chest Contents");
+                if (text == null || text.Length == 0) return Lang.Get(dialogTitleLangCode);
                 else return text.Replace("\r", "").Replace("\n", " ").Substring(0, Math.Min(text.Length, 15));
             }
         }

--- a/BlockEntityRenderer/ChestLabelRenderer.cs
+++ b/BlockEntityRenderer/ChestLabelRenderer.cs
@@ -23,6 +23,12 @@ namespace Vintagestory.GameContent
 
             IRenderAPI rpi = api.Render;
             Vec3d camPos = api.World.Player.Entity.CameraPos;
+            Block block = api.World.BlockAccessor.GetBlock(pos);
+
+            Vec3f labelOffset = new Vec3f();
+            labelOffset.X = block.Code.Path.Contains("labeledtrunk") ? -0.5f : 0;
+            labelOffset.Y = 0;
+            labelOffset.Z = 0;
 
             if (camPos.SquareDistanceTo(pos.X, pos.Y, pos.Z) > 20 * 20) return;
 
@@ -39,7 +45,7 @@ namespace Vintagestory.GameContent
                 .Translate(0.5f, 0.5f, 0.5f)
                 .RotateY(rotY + GameMath.PI)
                 .Translate(-0.5f, -0.5, -0.5f)
-                .Translate(0.5f, 0.35f, 1 / 16f + 0.03f)
+                .Translate(0.5f + labelOffset.X, 0.35f + labelOffset.Y, 1 / 16f + 0.03f + labelOffset.Z)
                 .Scale(0.45f * QuadWidth, 0.45f * QuadHeight, 0.45f * QuadWidth)
                 .Values
             ;

--- a/Item/ItemPileable.cs
+++ b/Item/ItemPileable.cs
@@ -40,6 +40,7 @@ namespace Vintagestory.GameContent
 
             var atblock = byEntity.World.BlockAccessor.GetBlock(onBlockPos);
             BlockEntity be = byEntity.World.BlockAccessor.GetBlockEntity(onBlockPos);
+            if (atblock as BlockMultiblock != null) be = byEntity.World.BlockAccessor.GetBlockEntity(onBlockPos.AddCopy((atblock as BlockMultiblock).OffsetInv));
 
             if (be is BlockEntityLabeledChest || be is BlockEntitySignPost || be is BlockEntitySign || be is BlockEntityBloomery || be is BlockEntityFirepit || be is BlockEntityForge || be is BlockEntityCrate || atblock.HasBehavior<BlockBehaviorJonasGasifier>()) return;
 

--- a/Systems/Core.cs
+++ b/Systems/Core.cs
@@ -492,6 +492,7 @@ namespace Vintagestory.GameContent
             api.RegisterBlockClass("BlockDamageOnTouch", typeof(BlockDamageOnTouch));
             api.RegisterBlockClass("BlockPlantDamageOnTouch", typeof(BlockPlantDamageOnTouch));
             api.RegisterBlockClass("BlockLabeledChest", typeof(BlockLabeledChest));
+            api.RegisterBlockClass("BlockLabeledTrunk", typeof(BlockLabeledTrunk));
             api.RegisterBlockClass("BlockStalagSection", typeof(BlockStalagSection));
             api.RegisterBlockClass("BlockLooseOres", typeof(BlockLooseOres));
             api.RegisterBlockClass("BlockPan", typeof(BlockPan));


### PR DESCRIPTION
I made a mod that adds the Labeled Trunk model that has been seen in Dev Logs as an actual working [Labeled Trunk](https://mods.vintagestory.at/labeledtrunk) block and I figured I'd submit a PR that makes the necessary changes for that to work.

I also included bits that were used to make the Labeled Containers mod properly offset the text for the sign, in the form of the labelOffset variable, which would allow any GenericTypedContainer to be given the capability of having a sign added to it if those values could be set with the JSON.  For this PR it's just hard coded to what it would need to be for the Labeled Trunk model that's already in the game files.

If the trunk JSON file is copied and the block code is changed to "labeledtrunk", and all the classes, shapes, and textures updated properly it will simply work with this code added, nothing else needs to be changed, but you could allow labelOffset to be set by the JSON itself so it's more versatile, and you don't have to use a specific block code.