### PR TITLE
Fix Bugs With Liquid Only Meals and with Meal Liquid Portion Comparison

### DIFF
--- a/Systems/Cooking/CookingRecipe.cs
+++ b/Systems/Cooking/CookingRecipe.cs
@@ -516,6 +516,13 @@ namespace Vintagestory.GameContent
                 ItemStack inputStack = inputStacksList[0];
                 inputStacksList.RemoveAt(0);
                 if (inputStack == null) continue;
+                int stackPortion = inputStack.StackSize;
+
+                if (inputStack.Collectible.Attributes?["waterTightContainerProps"].Exists == true)
+                {
+                    var props = BlockLiquidContainerBase.GetContainableProps(stack);
+                    stackPortion = (int)(stack.StackSize / props.ItemsPerLitre / GetIngrendientFor(stack).PortionSizeLitres);
+                }
 
                 bool found = false;
                 for (int i = 0; i < ingredientList.Count; i++)
@@ -526,7 +533,7 @@ namespace Vintagestory.GameContent
                     {
                         if (curQuantities[i] >= ingred.MaxQuantity) continue;
 
-                        totalOutputQuantity = Math.Min(totalOutputQuantity, inputStack.StackSize);
+                        totalOutputQuantity = Math.Min(totalOutputQuantity, stackPortion);
                         curQuantities[i]++;
                         found = true;
                         break;
@@ -551,15 +558,12 @@ namespace Vintagestory.GameContent
                 var stack = inputStacks[i];
                 if (stack == null) continue;
 
-                int qportions = stack.StackSize;
-
                 if (stack.Collectible.Attributes?["waterTightContainerProps"].Exists == true)
                 {
                     var props = BlockLiquidContainerBase.GetContainableProps(stack);
-                    qportions = (int)(stack.StackSize / props.ItemsPerLitre / GetIngrendientFor(stack).PortionSizeLitres);
+                    if (stack.StackSize != (int)(quantityServings * props.ItemsPerLitre * GetIngrendientFor(stack).PortionSizeLitres)) return false;
                 }
-
-                if (qportions != quantityServings) return false;
+                else if (stack.StackSize != quantityServings) return false;
             }
 
             return true;


### PR DESCRIPTION
Currently in the game it is impossible to add a cooking recipe that exclusively contains liquids.  Since the stack size of liquids is higher than the adjusted size for portions it will always return false.  This fixes the calculation of the minimum portion size.

Also, for recipes like Jam where you need 0.2L of Honey for each portion the cast to Int would make it such that 0.3L of honey would resolve as 30 / 100 / 0.2, or 1.5, which would then get cut down to simply 1, meaning it would “match” and therefore use more liquid than intended in the recipe.  The secondary change to how it calculates if they are equal should fix this.