### PR TITLE
Fill bloomery 1 ingot worth of nuggets at a time when sneaking

### DIFF
--- a/Block/BlockBloomery.cs
+++ b/Block/BlockBloomery.cs
@@ -150,7 +150,8 @@ namespace Vintagestory.GameContent
             {
                 
                 if (hotbarstack == null) return true;
-                if (beb.TryAdd(byPlayer, byPlayer.Entity.Controls.CtrlKey ? 5 : 1))
+                int largeAmount = hotbarstack.Collectible.Code.PathStartsWith("nugget") ? 20 : 5;
+                if (beb.TryAdd(byPlayer, byPlayer.Entity.Controls.CtrlKey ? largeAmount : 1))
                 {
                     if (world.Side == EnumAppSide.Client) (byPlayer as IClientPlayer).TriggerFpAnimation(EnumHandInteract.HeldItemInteract);
                 }


### PR DESCRIPTION
Old behaviour: add 1 item normally, 5 when sneaking.

New behaviour: add 1 item normally, 20 when sneaking and it's nuggets, 5 when sneaking and adding other items (e.g. quartz for glass). 