### PR TITLE
Synchronize deleted items for randomizers

### DIFF
--- a/Systems/Loot/BlockEntityBlockRandomizer.cs
+++ b/Systems/Loot/BlockEntityBlockRandomizer.cs
@@ -126,7 +126,15 @@ namespace Vintagestory.GameContent
                 for (int i = 0; i < 10; i++)
                 {
                     var stree = tree["stack" + i] as TreeAttribute;
-                    if (stree == null) continue;
+                    if (stree == null)
+                    {
+                        Chances[i] = 0;
+                        if (!inventory[i].Empty)
+                        {
+                            inventory[i].Itemstack = null;
+                        }
+                        continue;
+                    }
 
                     Chances[i] = stree.GetFloat("chance");
 

--- a/Systems/Loot/LootRandomizer.cs
+++ b/Systems/Loot/LootRandomizer.cs
@@ -184,11 +184,19 @@ namespace Vintagestory.GameContent
             dialogs.Remove(slot);
             if (slot.Itemstack == null) return;
 
-            if (dialog.Attributes.GetInt("save") == 0) return;
+            ITreeAttribute dialogAttributes = dialog.Attributes;
+            if (dialogAttributes.GetInt("save") == 0) return;
 
-            foreach (var val in dialog.Attributes)
+            ITreeAttribute stree;
+            for (int i = 0; i < 10; i++)
             {
-                slot.Itemstack.Attributes[val.Key] = val.Value;
+                stree = dialogAttributes["stack" + i] as ITreeAttribute;
+                if (stree == null)
+                {
+                    slot.Itemstack.Attributes.RemoveAttribute("stack" + i);
+                    continue;
+                }
+                slot.Itemstack.Attributes["stack" + i] = stree;
             }
 
             using (MemoryStream ms = new MemoryStream())


### PR DESCRIPTION
Fixes an issue wherein deleting items from the randomizer pool is not properly synchronized back to the server for the following:

- BlockEntityBlockRandomizer
- ItemLootRandomizer