### PR TITLE
Allow IAnvilWorkable on CollectibleBehaviors (using GetCollectibleInterface)

### DIFF
--- a/Block/BlockAnvil.cs
+++ b/Block/BlockAnvil.cs
@@ -114,7 +114,7 @@ namespace Vintagestory.GameContent
                         Itemstacks = workableStacklist.ToArray(),
                         GetMatchingStacks = (wi, bs, es) => {
                             BlockEntityAnvil bea = api.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityAnvil;
-                            return bea?.WorkItemStack == null ? null : new ItemStack[] { (bea.WorkItemStack.Collectible as IAnvilWorkable).GetBaseMaterial(bea.WorkItemStack) };
+                            return bea?.WorkItemStack == null ? null : new ItemStack[] { bea.WorkItemStack.Collectible.GetCollectibleInterface<IAnvilWorkable>().GetBaseMaterial(bea.WorkItemStack) };
                         }
                     }
                 };

--- a/BlockEntity/BEAnvil.cs
+++ b/BlockEntity/BEAnvil.cs
@@ -149,7 +149,7 @@ namespace Vintagestory.GameContent
 
         public bool CanWorkCurrent
         {
-            get { return workItemStack != null && (workItemStack.Collectible as IAnvilWorkable).CanWork(WorkItemStack); }
+            get { return workItemStack != null && workItemStack.Collectible.GetCollectibleInterface<IAnvilWorkable>().CanWork(WorkItemStack); }
         }
 
         public ItemStack WorkItemStack
@@ -255,9 +255,7 @@ namespace Vintagestory.GameContent
             if (slot.Itemstack == null) return false;
             ItemStack stack = slot.Itemstack;
 
-            IAnvilWorkable workableobj = stack.Collectible as IAnvilWorkable;
-
-
+            IAnvilWorkable workableobj = stack.Collectible.GetCollectibleInterface<IAnvilWorkable>();
 
             if (workableobj == null) return false;
             int requiredTier = workableobj.GetRequiredAnvilTier(stack);
@@ -444,7 +442,7 @@ namespace Vintagestory.GameContent
             SmithingRecipe recipe = SelectedRecipe;
 
 
-            EnumHelveWorkableMode? mode = (workItemStack?.Collectible as IAnvilWorkable)?.GetHelveWorkableMode(workItemStack, this);
+            EnumHelveWorkableMode? mode = workItemStack?.Collectible.GetCollectibleInterface<IAnvilWorkable>()?.GetHelveWorkableMode(workItemStack, this);
 
             StringBuilder sb = new StringBuilder();
             sb.AppendLine("Workitem: " + workItemStack);
@@ -465,7 +463,7 @@ namespace Vintagestory.GameContent
                 return;
             }
 
-            var mode = (workItemStack.Collectible as IAnvilWorkable).GetHelveWorkableMode(workItemStack, this);
+            var mode = workItemStack.Collectible.GetCollectibleInterface<IAnvilWorkable>()?.GetHelveWorkableMode(workItemStack, this);
             if (mode == EnumHelveWorkableMode.NotWorkable) return;
 
             rotation = 0;
@@ -621,7 +619,7 @@ namespace Vintagestory.GameContent
             ItemStack ditchedStack;
             if (SelectedRecipe == null)
             {
-                ditchedStack = returnOnCancelStack ?? (workItemStack.Collectible as IAnvilWorkable).GetBaseMaterial(workItemStack);
+                ditchedStack = returnOnCancelStack ?? workItemStack.Collectible.GetCollectibleInterface<IAnvilWorkable>().GetBaseMaterial(workItemStack);
                 float temp = workItemStack.Collectible.GetTemperature(Api.World, workItemStack);
                 ditchedStack.Collectible.SetTemperature(Api.World, ditchedStack, temp);
             }
@@ -1164,7 +1162,7 @@ namespace Vintagestory.GameContent
 
         internal void OpenDialog(ItemStack ingredient)
         {
-            List<SmithingRecipe> recipes = (ingredient.Collectible as IAnvilWorkable).GetMatchingRecipes(ingredient);
+            List<SmithingRecipe> recipes = ingredient.Collectible.GetCollectibleInterface<IAnvilWorkable>().GetMatchingRecipes(ingredient);
 
             List<ItemStack> stacks = recipes
                 .Select(r => r.Output.ResolvedItemstack)


### PR DESCRIPTION
This change replaces direct casting of collectibles to `IAnvilWorkable` with calls to `GetCollectibleInterface<IAnvilWorkable>()`. This increases flexibility by allowing implementations of IAnvilWorkable via collectible behaviors instead of being limited to direct class implementations. It should also be compatible with any existing code.