### PR TITLE
Call `CollectibleBehavior`s' corresponding methods in `ItemBow`'s `OnHeldInteractStop` and `OnHeldInteractCancel`

### DIFF
--- a/Item/ItemBow.cs
+++ b/Item/ItemBow.cs
@@ -121,6 +121,23 @@ namespace Vintagestory.GameContent
 
         public override bool OnHeldInteractCancel(float secondsUsed, ItemSlot slot, EntityAgent byEntity, BlockSelection blockSel, EntitySelection entitySel, EnumItemUseCancelReason cancelReason)
         {
+	        bool result = true;
+			bool preventDefault = false;
+			foreach (CollectibleBehavior collectibleBehavior in this.CollectibleBehaviors)
+			{
+				EnumHandling handled = EnumHandling.PassThrough;
+				bool behaviorResult = collectibleBehavior.OnHeldInteractCancel(secondsUsed, slot, byEntity, blockSel, entitySel, cancelReason, ref handled);
+				if (handled != EnumHandling.PassThrough)
+				{
+					result = (result && behaviorResult);
+					preventDefault = true;
+				}
+				if (handled == EnumHandling.PreventSubsequent)
+				{
+					return result;
+				}
+			}
+   
             byEntity.Attributes.SetInt("aiming", 0);
             byEntity.AnimManager.StopAnimation(aimAnimation);
 


### PR DESCRIPTION
Many of the tools mostly ignore the `CollectibleBehavior`s they have.
Here's why that's a problem:

1. This makes `CollectibleBehavior`s useless, since none of the callbacks will be called with any sort of consistency
2. Debugging is painful, since each item has special handling. You can spend hours debugging new code, only to discover that one specific item just chose to violate the contract of calling it's Behaviour
4. Hinders modding, by making it hard to implement sweeping changes that touch multiple items.
5. Hinders mod compatibility, since the modders will employ fragile work-arounds to implement their desired changes anyway
7. The documentation is quite literally lying to both modders and game developers.
    This is what `CollectibleBehavior.OnHeldAttackStep`'s documentation says:
    `/// Called continously when a custom attack action is playing. Return false to stop the action.`
    This is patently not true, since many items including shovels, axes, and pickaxes simply never invoke this method in their `CollectibleObject.OnHeldAttackStep`