### PR TITLE
Remove unnecessary branch in lightning attraction

### DIFF
--- a/BlockEntityBehavior/BEBehaviorAttractsLightning.cs
+++ b/BlockEntityBehavior/BEBehaviorAttractsLightning.cs
@@ -73,14 +73,9 @@ namespace Vintagestory.GameContent
 
             float yDiff = configProps.ArtificialElevation + ourRainHeight - impactRainHeight;
 
-            // We want the modifier to always be beneficial (if greater than 1)
-            if(yDiff < 0)
-            {
-                yDiff /= configProps.ElevationAttractivenessMultiplier;
-            } else
-            {
-                yDiff *= configProps.ElevationAttractivenessMultiplier;
-            }
+            // If yDiff is less than 0, this doesn't change the result
+            // since any multiplication or division would still be less than 0
+            yDiff *= configProps.ElevationAttractivenessMultiplier;
 
             yDiff = GameMath.Min(40, yDiff);
 


### PR DESCRIPTION
Current logic and comment are misleading. They state that a negative yDiff can be impacted by the attractiveness multiplier when yDiff is less than 0, but it never can since any multiplication or division on a negative number is still less than 0, and a negative yDiff will always be less than the result of Vec2d.DistanceTo, causing the attraction to fail.