### PR TITLE
Add EntityBehaviorGait, update EntityBehaviorRideable to utilize it

### DIFF
--- a/Entity/Behavior/BehaviorGait.cs
+++ b/Entity/Behavior/BehaviorGait.cs
@@ -1,0 +1,83 @@
+﻿using System.Linq;
+using Vintagestory.API.Client;
+using Vintagestory.API.Common;
+using Vintagestory.API.Common.Entities;
+using Vintagestory.API.Datastructures;
+
+namespace Vintagestory.GameContent
+{
+    public record GaitMeta
+    {
+        public string Code { get; set; } // Unique identifier for the gait, ideally matched with rideable controls
+        public float TurnRadius { get; set; } = 3.5f;
+        public float MoveSpeed { get; set; } = 0f;
+        public bool Backwards { get; set; } = false;
+        public float StaminaCost { get; set; } = 0f;
+        public string FallbackGaitCode { get; set; } // Gait to slow down to such as when fatiguing
+        public bool IsSprint { get; set; } // Used to toggle entity.Controls.Sprint from rideable, consider alternatives?
+        public AssetLocation Sound { get; set; }
+    }
+
+    public class EntityBehaviorGait : EntityBehavior
+    {
+        public override string PropertyName()
+        {
+            return "gait";
+        }
+
+        public readonly FastSmallDictionary<string, GaitMeta> Gaits = new(1);
+        public GaitMeta CurrentGait
+        {
+            get => Gaits[entity.WatchedAttributes.GetString("currentgait")];
+            set => entity.WatchedAttributes.SetString("currentgait", value.Code);
+        }
+
+        public GaitMeta IdleGait;
+        public GaitMeta FallbackGait => CurrentGait.FallbackGaitCode is null ? IdleGait : Gaits[CurrentGait.FallbackGaitCode];
+
+        public float GetTurnRadius() => CurrentGait?.TurnRadius ?? 3.5f; // Default turn radius if not set
+
+        public void SetIdle() => CurrentGait = IdleGait;
+        public bool IsIdle => CurrentGait == IdleGait;
+        public bool IsBackward => CurrentGait.Backwards;
+        public bool IsForward => !CurrentGait.Backwards && CurrentGait != IdleGait;        
+        public GaitMeta CascadingFallbackGait(int n)
+        {
+            var result = CurrentGait;
+
+            while (n > 0)
+            {
+                if (result.FallbackGaitCode is null) return IdleGait;
+                result = Gaits[result.FallbackGaitCode];
+                n--;
+            }
+
+            return result;
+        }
+
+        protected ICoreAPI api;
+        protected ICoreClientAPI capi;
+
+        public EntityBehaviorGait(Entity entity) : base(entity)
+        {
+        }
+
+        public override void Initialize(EntityProperties properties, JsonObject attributes)
+        {
+            base.Initialize(properties, attributes);
+
+            api = entity.Api;
+            capi = api as ICoreClientAPI;
+
+            GaitMeta[] gaitarray = attributes["gaits"].AsArray<GaitMeta>();
+            foreach (GaitMeta gait in gaitarray)
+            {
+                Gaits[gait.Code] = gait;
+            }
+
+            string idleGaitCode = attributes["idleGait"].AsString("idle");
+            IdleGait = Gaits[idleGaitCode];
+            CurrentGait = IdleGait; // Set initial gait to Idle
+        }
+    }
+}

--- a/Entity/Behavior/BehaviorGait.cs
+++ b/Entity/Behavior/BehaviorGait.cs
@@ -9,7 +9,7 @@ namespace Vintagestory.GameContent
     public record GaitMeta
     {
         public string Code { get; set; } // Unique identifier for the gait, ideally matched with rideable controls
-        public float TurnRadius { get; set; } = 3.5f;
+        public float YawMultiplier { get; set; } = 3.5f;
         public float MoveSpeed { get; set; } = 0f;
         public bool Backwards { get; set; } = false;
         public float StaminaCost { get; set; } = 0f;
@@ -35,12 +35,12 @@ namespace Vintagestory.GameContent
         public GaitMeta IdleGait;
         public GaitMeta FallbackGait => CurrentGait.FallbackGaitCode is null ? IdleGait : Gaits[CurrentGait.FallbackGaitCode];
 
-        public float GetTurnRadius() => CurrentGait?.TurnRadius ?? 3.5f; // Default turn radius if not set
+        public float GetYawMult() => CurrentGait?.YawMultiplier ?? 3.5f; // Default turn radius if not set
 
         public void SetIdle() => CurrentGait = IdleGait;
         public bool IsIdle => CurrentGait == IdleGait;
         public bool IsBackward => CurrentGait.Backwards;
-        public bool IsForward => !CurrentGait.Backwards && CurrentGait != IdleGait;        
+        public bool IsForward => !CurrentGait.Backwards && CurrentGait != IdleGait;
         public GaitMeta CascadingFallbackGait(int n)
         {
             var result = CurrentGait;

--- a/Entity/Behavior/BehaviorRideable.cs
+++ b/Entity/Behavior/BehaviorRideable.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -21,8 +21,9 @@ namespace Vintagestory.GameContent
         Press
     }
 
-    public class EntityBehaviorRideable : EntityBehaviorSeatable, IMountable, IRenderer, IMountableListener
+    public class EntityBehaviorRideable(Entity entity) : EntityBehaviorSeatable(entity), IMountable, IRenderer, IMountableListener
     {
+        public List<GaitMeta> RideableGaitOrder = new(); // List of gaits in order of increasing speed for the rideable entity
         public Vec3f MountAngle { get; set; } = new Vec3f();
         public EntityPos SeatPosition => entity.SidedPos;
         public double RenderOrder => 1;
@@ -33,11 +34,11 @@ namespace Vintagestory.GameContent
         public double ForwardSpeed = 0.0;
         // current turning speed (rad/tick)
         public double AngularVelocity = 0.0;
-        public bool ShouldSprint;
 
         public bool IsInMidJump;
         public event CanRideDelegate CanRide;
         public event CanRideDelegate CanTurn;
+        public AnimationMetaData curAnim;
 
         protected ICoreAPI api;
         // Time the player can walk off an edge before gravity applies.
@@ -45,17 +46,28 @@ namespace Vintagestory.GameContent
         // Time the player last jumped.
         protected long lastJumpMs;
         protected bool jumpNow;
-        protected EntityAgent eagent;
-        protected RideableConfig rideableconfig;
-        protected ILoadedSound trotSound;
-        protected ILoadedSound gallopSound;
+        protected EntityAgent eagent = entity as EntityAgent;
+        protected long lastGaitChangeMs = 0;
+        protected float timeSinceLastGaitCheck = 0;
+        protected float timeSinceLastGaitFatigue = 0;
+        protected ILoadedSound gaitSound;
+
+        protected FastSmallDictionary<string, ControlMeta> Controls;
+        protected string[] GaitOrderCodes; // List of gaits in order of increasing speed for the rideable entity
         protected ICoreClientAPI capi;
-        protected AssetLocation trotSoundLoc, gallopSoundLoc;
-        protected ControlMeta curControlMeta = null;
-        protected bool shouldMove = false;
-        public AnimationMetaData curAnim;
-        protected string curTurnAnim = null;
-        protected EnumControlScheme scheme;
+        protected EntityBehaviorGait ebg;
+        protected int minGeneration = 0; // Minimum generation for the animal to be rideable
+        protected GaitMeta saddleBreakGait;
+        protected string saddleBreakGaitCode;
+
+        ControlMeta curControlMeta = null;
+        bool shouldMove = false;
+
+        internal string prevSoundCode;
+        internal string curSoundCode = null;
+
+        string curTurnAnim = null;
+        EnumControlScheme scheme;
 
         #region Semitamed animals
 
@@ -98,11 +110,6 @@ namespace Vintagestory.GameContent
             }
         }
 
-        public EntityBehaviorRideable(Entity entity) : base(entity)
-        {
-            eagent = entity as EntityAgent;
-        }
-
         protected override IMountableSeat CreateSeat(string seatId, SeatConfig config)
         {
             return new EntityRideableSeat(this, seatId, config);
@@ -111,12 +118,9 @@ namespace Vintagestory.GameContent
         public override void Initialize(EntityProperties properties, JsonObject attributes)
         {
             base.Initialize(properties, attributes);
-            api = entity.Api;
 
-            var gs = attributes?["gallopSound"].AsString();
-            var ts = attributes?["trotSound"].AsString();
-            if (gs != null) gallopSoundLoc = AssetLocation.Create(gs, entity.Code.Domain);
-            if (ts != null) trotSoundLoc = AssetLocation.Create(ts, entity.Code.Domain);
+            api = entity.Api;
+            capi = api as ICoreClientAPI;
 
             // /entity spawn semitameddeer-elk-male-adult 1
             if (attributes["saddleBreaksRequired"].Exists)
@@ -128,19 +132,38 @@ namespace Vintagestory.GameContent
 
                 saddleBreakDayInterval = attributes["saddleBreakDayInterval"].AsFloat();
                 tamedEntityCode = attributes["tamedEntityCode"].AsString();
+                saddleBreakGaitCode = attributes["saddleBreakGait"].AsString();
             }
 
-            rideableconfig = attributes.AsObject<RideableConfig>();
-            foreach (var val in rideableconfig.Controls.Values) { val.RiderAnim?.Init(); }
+            Controls = attributes["controls"].AsObject<FastSmallDictionary<string, ControlMeta>>();
+            minGeneration = attributes["minGeneration"].AsInt(0);
+            GaitOrderCodes = attributes["rideableGaitOrder"].AsArray<string>();
 
+            foreach (var val in Controls.Values) val.RiderAnim?.Init();
+            curAnim = Controls["idle"].RiderAnim;
 
-            capi = api as ICoreClientAPI;
-            curAnim = rideableconfig.Controls["idle"].RiderAnim;
+            capi?.Event.RegisterRenderer(this, EnumRenderStage.Before, "rideablesim");
 
-            if (capi != null)
+        }
+        public override void AfterInitialized(bool onFirstSpawn)
+        {
+            base.AfterInitialized(onFirstSpawn);
+
+            ebg = eagent.GetBehavior<EntityBehaviorGait>();
+
+            // Gaits are required for rideable entities
+            if (ebg is null)
             {
-                capi.Event.RegisterRenderer(this, EnumRenderStage.Before, "rideablesim");
+                throw new Exception("EntityBehaviorGait not found on rideable entity. Ensure it is properly registered in the entity's properties.");
             }
+
+            foreach (var str in GaitOrderCodes)
+            {
+                GaitMeta gait = ebg?.Gaits[str];
+                if (gait != null) RideableGaitOrder.Add(gait);
+            }
+
+            saddleBreakGait = ebg.Gaits.FirstOrDefault(g => g.Value.Code == saddleBreakGaitCode).Value;
         }
 
         public override void OnEntityDespawn(EntityDespawnData despawn)
@@ -193,6 +216,7 @@ namespace Vintagestory.GameContent
         private void Inventory_SlotModified(int obj)
         {
             updateControlScheme();
+            ebg?.SetIdle();
         }
 
         private void updateControlScheme()
@@ -227,19 +251,16 @@ namespace Vintagestory.GameContent
         {
             if (!wasPaused && capi.IsGamePaused)
             {
-                trotSound?.Pause();
-                gallopSound?.Pause();
+                gaitSound?.Pause();
             }
             if (wasPaused && !capi.IsGamePaused)
             {
-                if (trotSound?.IsPaused == true) trotSound?.Start();
-                if (gallopSound?.IsPaused == true) gallopSound?.Start();
+                if (gaitSound?.IsPaused == true) gaitSound?.Start();
             }
 
             wasPaused = capi.IsGamePaused;
 
             if (capi.IsGamePaused) return;
-
 
             updateAngleAndMotion(dt);
         }
@@ -253,15 +274,13 @@ namespace Vintagestory.GameContent
             float step = GlobalConstants.PhysicsFrameTime;
             var motion = SeatsToMotion(step);
 
-            if (jumpNow)
-            {
-                updateRidingState();
-            }
+            if (jumpNow) updateRidingState();
 
             ForwardSpeed = Math.Sign(motion.X);
 
-            AngularVelocity = motion.Y * 1.5;
-            if (!eagent.Controls.Sprint) AngularVelocity *= 3;
+            float yawMultiplier = ebg?.GetTurnRadius() ?? 3.5f;
+
+            AngularVelocity = motion.Y * yawMultiplier;
 
             entity.SidedPos.Yaw += (float)motion.Y * dt * 30f;
             entity.SidedPos.Yaw = entity.SidedPos.Yaw % GameMath.TWOPI;
@@ -273,8 +292,50 @@ namespace Vintagestory.GameContent
         }
 
         bool prevForwardKey, prevBackwardKey, prevSprintKey;
+        public void SpeedUp() => SetNextGait(true);
+        public void SlowDown() => SetNextGait(false);
 
-        bool forward, backward, sprint;
+        public GaitMeta GetNextGait(bool forward, GaitMeta currentGait = null)
+        {
+            currentGait ??= ebg.CurrentGait;
+
+            if (eagent.Swimming) return forward ? ebg.Gaits["swim"] : ebg.Gaits["swimback"];
+
+            if (RideableGaitOrder is not null && RideableGaitOrder.Count > 0 && this.IsBeingControlled())
+            {
+                int currentIndex = RideableGaitOrder.IndexOf(currentGait);
+                int nextIndex = forward ? currentIndex + 1 : currentIndex - 1;
+
+                // Boundary behavior
+                if (nextIndex < 0) nextIndex = 0;
+                if (nextIndex >= RideableGaitOrder.Count) nextIndex = currentIndex - 1;
+
+                return RideableGaitOrder[nextIndex];
+            }
+            else
+            {
+                return ebg.IdleGait;
+            }
+        }
+
+        public void SetNextGait(bool forward, GaitMeta nextGait = null)
+        {
+            if (api.Side != EnumAppSide.Server) return;
+
+            nextGait ??= GetNextGait(forward);
+
+            ebg.CurrentGait = nextGait;
+        }
+
+        public GaitMeta GetFirstForwardGait()
+        {
+            if (RideableGaitOrder == null || RideableGaitOrder.Count == 0)
+                return ebg.IdleGait;
+
+            // Find the first forward gait
+            return RideableGaitOrder.FirstOrDefault(g => !g.Backwards && g.MoveSpeed > 0) ?? ebg.IdleGait;
+        }
+
         public virtual Vec2d SeatsToMotion(float dt)
         {
             int seatsRowing = 0;
@@ -285,7 +346,6 @@ namespace Vintagestory.GameContent
             jumpNow = false;
             coyoteTimer -= dt;
 
-            bool shouldSprint = false;
             Controller = null;
 
             foreach (var seat in Seats)
@@ -294,9 +354,7 @@ namespace Vintagestory.GameContent
 
                 if (seat.Passenger == null) continue;
 
-                var eplr = seat.Passenger as EntityPlayer;
-
-                if (eplr != null)
+                if (seat.Passenger is EntityPlayer eplr)
                 {
                     eplr.Controls.LeftMouseDown = seat.Controls.LeftMouseDown;
                     if (eplr.HeadYawLimits == null)
@@ -370,59 +428,68 @@ namespace Vintagestory.GameContent
                     jumpNow = true;
                 }
 
-                if (scheme == EnumControlScheme.Hold && !controls.TriesToMove)
-                {
-                    continue;
-                }
+                if (scheme == EnumControlScheme.Hold && !controls.TriesToMove) continue;
 
                 float str = ++seatsRowing == 1 ? 1 : 0.5f;
 
+                // Detect if button currently being pressed
+                bool nowForwards = controls.Forward;
+                bool nowBackwards = controls.Backward;
+                bool nowSprint = controls.Sprint;
+                controls.Sprint = false;
 
-                if (scheme == EnumControlScheme.Hold)
+                // Detect if current press is a fresh press
+                bool forwardPressed = nowForwards && !prevForwardKey;
+                bool backwardPressed = nowBackwards && !prevBackwardKey;
+                bool sprintPressed = nowSprint && !prevSprintKey;
+
+                long nowMs = entity.World.ElapsedMilliseconds;
+
+                // This ensures we start moving without sprint key
+                if (forwardPressed && ebg.IsIdle) SpeedUp();
+
+                // Handle backward to idle change without sprint key
+                if (forwardPressed && ebg.IsBackward) ebg.SetIdle();
+
+                // Cycle up with sprint
+                if (ebg.IsForward && sprintPressed && nowMs - lastGaitChangeMs > 300)
                 {
-                    forward = controls.Forward;
-                    backward = controls.Backward;
-                    shouldSprint |= controls.Sprint && !entity.Swimming;
-                } else
-                {
-                    bool nowForwards = controls.Forward;
-                    bool nowBackwards = controls.Backward;
-                    bool nowSprint = controls.Sprint;
+                    SpeedUp();
 
-                    if (!forward && !backward && nowForwards && !prevForwardKey) { forward = true;  }
-                    else if (forward && nowBackwards && !prevBackwardKey) { forward = false; sprint = false; }
-                    else if (!backward && nowBackwards && !prevBackwardKey) { backward = true; sprint = false; }
-                    else if (backward && nowForwards && !prevForwardKey) {  backward = false; }
-
-                    if (nowSprint && !prevSprintKey && !sprint) sprint = true;
-                    else if (nowSprint && !prevSprintKey && sprint) sprint = false;
-
-                    prevForwardKey = nowForwards;
-                    prevBackwardKey = nowBackwards;
-                    prevSprintKey = nowSprint;
-                    shouldSprint = sprint && !entity.Swimming;
+                    lastGaitChangeMs = nowMs;
                 }
 
+                // Cycle down with back
+                if (backwardPressed && nowMs - lastGaitChangeMs > 300)
+                {
+                    SlowDown();
+
+                    lastGaitChangeMs = nowMs;
+                }
+
+                prevSprintKey = nowSprint;
+                prevForwardKey = scheme == EnumControlScheme.Press && nowForwards;
+                prevBackwardKey = scheme == EnumControlScheme.Press && nowBackwards;
+
+                #region Motion update
                 if (canturn && (controls.Left || controls.Right))
                 {
                     float dir = controls.Left ? 1 : -1;
                     angularMotion += str * dir * dt;
                 }
-                if (forward || backward)
+                if (ebg.IsForward || ebg.IsBackward)
                 {
-                    float dir = forward ? 1 : -1;
+                    float dir = ebg.IsForward ? 1 : -1;
                     linearMotion += str * dir * dt * 2f;
                 }
+                #endregion
             }
-
-            this.ShouldSprint = shouldSprint;
-
 
             return new Vec2d(linearMotion, angularMotion);
         }
 
         float angularMotionWild = 1/10f;
-
+        bool wasSwimming = false;
         protected void updateRidingState()
         {
             if (!AnyMounted()) return;
@@ -431,7 +498,7 @@ namespace Vintagestory.GameContent
             {
                 ForwardSpeed = 1;
                 if (api.World.Rand.NextDouble() < 0.05) jumpNow = true;
-                ShouldSprint = true;
+                ebg.CurrentGait = saddleBreakGait;
 
                 if (api.World.ElapsedMilliseconds - mountedTotalMs > 4000)
                 {
@@ -453,11 +520,8 @@ namespace Vintagestory.GameContent
                     }
 
                     jumpNow = false;
-                    ShouldSprint = false;
                     ForwardSpeed = 0;
-                    eagent.StopAnimation(rideableconfig.Controls["sprint"].Animation);
                     Stop();
-
 
                     if (api.World.Calendar.TotalDays - LastSaddleBreakTotalDays > saddleBreakDayInterval)
                     {
@@ -479,14 +543,26 @@ namespace Vintagestory.GameContent
 
             if (wasMidJump && !IsInMidJump)
             {
-                var meta = rideableconfig.Controls["jump"];
+                var meta = Controls["jump"];
                 foreach (var seat in Seats) seat.Passenger?.AnimManager?.StopAnimation(meta.RiderAnim.Animation);
                 eagent.AnimManager.StopAnimation(meta.Animation);
             }
 
+            // Handle transition from swimming to walking
+            if (eagent.Swimming)
+            {
+                ebg.CurrentGait = ForwardSpeed > 0 ? ebg.Gaits["swim"] : ebg.Gaits["swimback"];
+            }
+            else if (!eagent.Swimming && wasSwimming)
+            {
+                ebg.CurrentGait = ebg.Gaits["walk"];
+            }
+
+            wasSwimming = eagent.Swimming;
+
             eagent.Controls.Backward = ForwardSpeed < 0;
             eagent.Controls.Forward = ForwardSpeed >= 0;
-            eagent.Controls.Sprint = ShouldSprint && ForwardSpeed > 0;
+            eagent.Controls.Sprint = ebg.CurrentGait.IsSprint && ForwardSpeed > 0;
 
             string nowTurnAnim=null;
             if (ForwardSpeed >= 0)
@@ -500,10 +576,13 @@ namespace Vintagestory.GameContent
                     nowTurnAnim = "turn-right";
                 }
             }
+            // This update fixes idle turn animation not stopping when entity has separate idle turn animations
             if (nowTurnAnim != curTurnAnim)
             {
                 if (curTurnAnim != null) eagent.StopAnimation(curTurnAnim);
-                eagent.StartAnimation((ForwardSpeed == 0 ? "idle-" : "") + (curTurnAnim = nowTurnAnim));
+                var anim = (ForwardSpeed == 0 ? "idle-" : "") + nowTurnAnim;
+                curTurnAnim = anim;
+                eagent.StartAnimation(anim);
             }
 
             ControlMeta nowControlMeta;
@@ -512,19 +591,16 @@ namespace Vintagestory.GameContent
             if (!shouldMove && !jumpNow)
             {
                 if (curControlMeta != null) Stop();
-                curAnim = rideableconfig.Controls[eagent.Swimming ? "swim" : "idle"].RiderAnim;
+                curAnim = Controls[eagent.Swimming ? "swim" : "idle"].RiderAnim;
 
-                if (eagent.Swimming) nowControlMeta = rideableconfig.Controls["swim"];
+                if (eagent.Swimming) nowControlMeta = Controls["swim"];
                 else nowControlMeta = null;
             }
             else
             {
+                nowControlMeta = Controls.FirstOrDefault(c => c.Key == ebg.CurrentGait.Code).Value;
 
-                string controlCode = eagent.Controls.Backward ? "walkback" : "walk";
-                if (eagent.Controls.Sprint) controlCode = "sprint";
-                if (eagent.Swimming) controlCode = "swim";
-
-                nowControlMeta = rideableconfig.Controls[controlCode];
+                nowControlMeta ??= Controls["idle"];
 
                 eagent.Controls.Jump = jumpNow;
 
@@ -532,12 +608,12 @@ namespace Vintagestory.GameContent
                 {
                     IsInMidJump = true;
                     jumpNow = false;
-                    var esr = eagent.Properties.Client.Renderer as EntityShapeRenderer;
-                    if (esr != null) esr.LastJumpMs = capi.InWorldEllapsedMilliseconds;
+                    if (eagent.Properties.Client.Renderer is EntityShapeRenderer esr)
+                        esr.LastJumpMs = capi.InWorldEllapsedMilliseconds;
 
-                    nowControlMeta = rideableconfig.Controls["jump"];
+                    nowControlMeta = Controls["jump"];
 
-                    nowControlMeta.EaseOutSpeed = (ForwardSpeed != 0) ? 30 : 40;
+                    if (ForwardSpeed != 0) nowControlMeta.EaseOutSpeed = 30;
 
                     foreach (var seat in Seats) seat.Passenger?.AnimManager?.StartAnimation(nowControlMeta.RiderAnim);
 
@@ -596,6 +672,8 @@ namespace Vintagestory.GameContent
 
         public void Stop()
         {
+            gaitSound?.Stop();
+            ebg.SetIdle();
             eagent.Controls.StopAllMovement();
             eagent.Controls.WalkVector.Set(0, 0, 0);
             eagent.Controls.FlyVector.Set(0,0,0);
@@ -627,7 +705,12 @@ namespace Vintagestory.GameContent
 
             if (shouldMove)
             {
-                move(dt, eagent.Controls, curControlMeta.MoveSpeed);
+                // Adjust move speed based based on gait and control meta
+                var curMoveSpeed = curControlMeta.MoveSpeed > 0
+                    ? curControlMeta.MoveSpeed
+                    : ebg.CurrentGait.MoveSpeed * curControlMeta.MoveSpeedMultiplier;
+
+                move(dt, eagent.Controls, curMoveSpeed);
             } else
             {
                 if (entity.Swimming) eagent.Controls.FlyVector.Y = 0.2;
@@ -644,56 +727,33 @@ namespace Vintagestory.GameContent
             if (eagent.OnGround) notOnGroundAccum = 0;
             else notOnGroundAccum += dt;
 
-            bool nowtrot = shouldMove && !eagent.Controls.Sprint && notOnGroundAccum < 0.2;
-            bool nowgallop = shouldMove && eagent.Controls.Sprint && notOnGroundAccum < 0.2;
+            gaitSound?.SetPosition((float)entity.Pos.X, (float)entity.Pos.Y, (float)entity.Pos.Z);
 
-            bool wastrot = trotSound != null && trotSound.IsPlaying;
-            bool wasgallop = gallopSound != null && gallopSound.IsPlaying;
-
-            trotSound?.SetPosition((float)entity.Pos.X, (float)entity.Pos.Y, (float)entity.Pos.Z);
-            gallopSound?.SetPosition((float)entity.Pos.X, (float)entity.Pos.Y, (float)entity.Pos.Z);
-
-            if (nowtrot != wastrot)
+            if (Controls.TryGetValue(ebg.CurrentGait.Code, out ControlMeta controlMeta))
             {
-                if (nowtrot)
+                var gaitMeta = ebg.CurrentGait;
+
+                curSoundCode = eagent.Swimming || notOnGroundAccum > 0.2 ? null : gaitMeta.Sound;
+
+                bool nowChange = curSoundCode != prevSoundCode;
+
+                if (nowChange)
                 {
-                    if (trotSound == null)
+                    gaitSound?.Stop();
+                    gaitSound?.Dispose();
+                    prevSoundCode = curSoundCode;
+
+                    if (curSoundCode is null) return;
+
+                    gaitSound = capi.World.LoadSound(new SoundParams()
                     {
-                        trotSound = capi.World.LoadSound(new SoundParams()
-                        {
-                            Location = trotSoundLoc,
-                            DisposeOnFinish = false,
-                            Position = entity.Pos.XYZ.ToVec3f(),
-                            ShouldLoop = true,
-                        });
-                    }
+                        Location = gaitMeta.Sound.Clone().WithPathPrefix("sounds/"),
+                        DisposeOnFinish = false,
+                        Position = entity.Pos.XYZ.ToVec3f(),
+                        ShouldLoop = true
+                    });
 
-                    trotSound.Start();
-
-                } else
-                {
-                    trotSound.Stop();
-                }
-            }
-
-            if (nowgallop != wasgallop)
-            {
-                if (nowgallop)
-                {
-                    if (gallopSound == null)
-                    {
-                        gallopSound = capi.World.LoadSound(new SoundParams()
-                        {
-                            Location = gallopSoundLoc,
-                            DisposeOnFinish = false,
-                            Position = entity.Pos.XYZ.ToVec3f(),
-                            ShouldLoop = true,
-                        });
-                    }
-                    gallopSound.Start();
-                } else
-                {
-                    gallopSound.Stop();
+                    gaitSound?.Start();
                 }
             }
         }
@@ -758,7 +818,7 @@ namespace Vintagestory.GameContent
             Stop();
 
             LastDismountTotalHours = entity.World.Calendar.TotalHours;
-            foreach (var meta in rideableconfig.Controls.Values)
+            foreach (var meta in Controls.Values)
             {
                 if (meta.RiderAnim?.Animation != null)
                 {
@@ -799,8 +859,6 @@ namespace Vintagestory.GameContent
         }
     }
 
-
-
     public class ElkAnimationManager : AnimationManager
     {
         public string animAppendix = "-antlers";
@@ -823,19 +881,10 @@ namespace Vintagestory.GameContent
         }
     }
 
-
     public class ControlMeta : AnimationMetaData
     {
-        public float MoveSpeed;
+        public float MoveSpeedMultiplier; // Multiplied by GaitMeta MoveSpeed to get rideable speed
+        public float MoveSpeed; // Overrides GaitMeta MoveSpeed
         public AnimationMetaData RiderAnim;
     }
-
-    public class RideableConfig
-    {
-        public int MinGeneration;
-        public Dictionary<string, ControlMeta> Controls;
-    }
-
-
-
 }

--- a/Entity/Behavior/BehaviorRideable.cs
+++ b/Entity/Behavior/BehaviorRideable.cs
@@ -59,6 +59,7 @@ namespace Vintagestory.GameContent
         protected int minGeneration = 0; // Minimum generation for the animal to be rideable
         protected GaitMeta saddleBreakGait;
         protected string saddleBreakGaitCode;
+        protected bool vanillaGaits = false;
 
         ControlMeta curControlMeta = null;
         bool shouldMove = false;
@@ -163,6 +164,7 @@ namespace Vintagestory.GameContent
                 if (gait != null) RideableGaitOrder.Add(gait);
             }
 
+            vanillaGaits = RideableGaitOrder.Count(g => g.MoveSpeed > 0 && g.Backwards == false) == 2;
             saddleBreakGait = ebg.Gaits.FirstOrDefault(g => g.Value.Code == saddleBreakGaitCode).Value;
         }
 
@@ -439,7 +441,7 @@ namespace Vintagestory.GameContent
 
                 // Toggling this off so that the next press of the sprint key will be a fresh press
                 // Need this to allow cycling up with sprint rather than just treating it as a boolean toggle
-                controls.Sprint = false;
+                controls.Sprint = vanillaGaits && controls.Sprint;
 
                 // Detect if current press is a fresh press
                 bool forwardPressed = nowForwards && !prevForwardKey;
@@ -463,8 +465,9 @@ namespace Vintagestory.GameContent
                 }
 
                 // Cycle down with back
-                if (backwardPressed && nowMs - lastGaitChangeMs > 300)
+                if (backwardPressed && nowMs - lastGaitChangeMs > 300 || (!nowSprint && ebg.CurrentGait.IsSprint))
                 {
+                    controls.Sprint = false;
                     SlowDown();
 
                     lastGaitChangeMs = nowMs;

--- a/Entity/Behavior/BehaviorRideable.cs
+++ b/Entity/Behavior/BehaviorRideable.cs
@@ -280,7 +280,7 @@ namespace Vintagestory.GameContent
 
             ForwardSpeed = Math.Sign(motion.X);
 
-            float yawMultiplier = ebg?.GetTurnRadius() ?? 3.5f;
+            float yawMultiplier = ebg.GetYawMult();
 
             AngularVelocity = motion.Y * yawMultiplier;
 
@@ -481,7 +481,7 @@ namespace Vintagestory.GameContent
                 if (canturn && (controls.Left || controls.Right))
                 {
                     float dir = controls.Left ? 1 : -1;
-                    angularMotion += str * dir * dt;
+                    angularMotion += ebg.GetYawMult() * dir * dt;
                 }
                 if (ebg.IsForward || ebg.IsBackward)
                 {

--- a/Entity/Behavior/BehaviorRideable.cs
+++ b/Entity/Behavior/BehaviorRideable.cs
@@ -561,7 +561,7 @@ namespace Vintagestory.GameContent
             }
             else if (!eagent.Swimming && wasSwimming)
             {
-                ebg.CurrentGait = ebg.Gaits["walk"];
+                ebg.CurrentGait = ForwardSpeed > 0 ? ebg.Gaits["walk"] : ebg.Gaits["walkback"];
             }
 
             wasSwimming = eagent.Swimming;

--- a/Entity/Behavior/BehaviorRideable.cs
+++ b/Entity/Behavior/BehaviorRideable.cs
@@ -436,6 +436,9 @@ namespace Vintagestory.GameContent
                 bool nowForwards = controls.Forward;
                 bool nowBackwards = controls.Backward;
                 bool nowSprint = controls.Sprint;
+
+                // Toggling this off so that the next press of the sprint key will be a fresh press
+                // Need this to allow cycling up with sprint rather than just treating it as a boolean toggle
                 controls.Sprint = false;
 
                 // Detect if current press is a fresh press

--- a/Systems/Core.cs
+++ b/Systems/Core.cs
@@ -1001,6 +1001,7 @@ namespace Vintagestory.GameContent
             api.RegisterEntityBehaviorClass("bossErel", typeof(EntityBehaviorErelBoss));
             api.RegisterEntityBehaviorClass("antlergrowth", typeof(EntityBehaviorAntlerGrowth));
             api.RegisterEntityBehaviorClass("idleanimations", typeof(EntityBehaviorIdleAnimations));
+            api.RegisterEntityBehaviorClass("gait", typeof(EntityBehaviorGait));
             api.RegisterEntityBehaviorClass("rideable", typeof(EntityBehaviorRideable));
             api.RegisterEntityBehaviorClass("attachable", typeof(EntityBehaviorAttachable));
             api.RegisterEntityBehaviorClass("rideableaccessories", typeof(EntityBehaviorRideableAccessories));


### PR DESCRIPTION
- Adds an extensible gait behavior for entities, allowing multiple movement paces (e.g. walk, trot, canter, gallop)
- GaitMeta object properties include
    - Turn radius
    - Move speed
    - Backwards flag
    - Fallback gait (gait item for transitioning to a fallback with certain actions)
    - Sprint flag
    - Sound asset location
- Updates rideable behavior to utilize these gaits allowing transitioning through available gaits as defined in rideable behavior config
- Supports any number/name of gaits (i.e. doesn't need to be named walk, trot etc. and doesn't need to be four gaits can be 1 to n gaits)
- Rideable utilizes GaitMeta movement speed with a multiplier such that an entity with a rider can scale the movement speed appropriately

See elk-tamed_withgait.json and elk-semitamed_withgait.json files for example behavior configs for EntityBehaviorGait and EntityBehaviorRideable

[elk-semitamed_withgait.json](https://github.com/user-attachments/files/20804222/elk-semitamed_withgait.json)
[elk-tamed_withgait.json](https://github.com/user-attachments/files/20804223/elk-tamed_withgait.json)

