### PR TITLE
Fix issues with containers that have variantGroups

### DIFF
--- a/Block/BlockGenericTypedContainer.cs
+++ b/Block/BlockGenericTypedContainer.cs
@@ -217,7 +217,7 @@ namespace Vintagestory.GameContent
         public override void OnBeforeRender(ICoreClientAPI capi, ItemStack itemstack, EnumItemRenderTarget target, ref ItemRenderInfo renderinfo)
         {
             Dictionary<string, MultiTextureMeshRef> meshrefs = new Dictionary<string, MultiTextureMeshRef>();
-            string key = "genericTypedContainerMeshRefs" + FirstCodePart() + SubtypeInventory;
+            string key = "genericTypedContainerMeshRefs" + Code + SubtypeInventory;
 
             
             meshrefs = ObjectCacheUtil.GetOrCreate(capi, key, () =>
@@ -249,7 +249,7 @@ namespace Vintagestory.GameContent
             ICoreClientAPI capi = api as ICoreClientAPI;
             if (capi == null) return;
 
-            string key = "genericTypedContainerMeshRefs" + FirstCodePart() + SubtypeInventory;
+            string key = "genericTypedContainerMeshRefs" + Code + SubtypeInventory;
             Dictionary<string, MultiTextureMeshRef> meshrefs = ObjectCacheUtil.TryGet<Dictionary<string, MultiTextureMeshRef>>(api, key);
             
             if (meshrefs != null) {


### PR DESCRIPTION
For 1.21+ only!

Sometimes when storage vessel falls, you can briefly notice that it has different textures.
It happens because only FirstCodePart is cached instead Code