### PR TITLE
Add nest type for determining which birds can use which nests (VSSurvivalMod part)

### DIFF
--- a/Block/BlockHenbox.cs
+++ b/Block/BlockHenbox.cs
@@ -7,6 +7,17 @@ namespace Vintagestory.GameContent
 {
     public class BlockHenbox : Block
     {
+        public string NestType;
+
+        public override void OnLoaded(ICoreAPI api)
+        {
+            base.OnLoaded(api);
+
+            NestType = Attributes?["nestType"]?.AsString();
+            if (NestType == null) api.Logger.Warning("BlockHenbox " + Code + " nestType attribute not set, defaulting to \"ground\"");
+            NestType ??= "ground";
+        }
+
         public override bool OnBlockInteractStart(IWorldAccessor world, IPlayer byPlayer, BlockSelection blockSel) {
             var blockEntity = world.BlockAccessor.GetBlockEntity(blockSel.Position) as BlockEntityHenBox;
             if (blockEntity != null) {

--- a/Block/BlockHenbox.cs
+++ b/Block/BlockHenbox.cs
@@ -7,9 +7,19 @@ namespace Vintagestory.GameContent
 {
     public class BlockHenbox : Block
     {
+        public override bool OnBlockInteractStart(IWorldAccessor world, IPlayer byPlayer, BlockSelection blockSel) {
+            var blockEntity = world.BlockAccessor.GetBlockEntity(blockSel.Position) as BlockEntityHenBox;
+            if (blockEntity != null) {
+                return blockEntity.OnInteract(world, byPlayer, blockSel);
+            }
+
+            return base.OnBlockInteractStart(world, byPlayer, blockSel);
+        }
+
         public override WorldInteraction[] GetPlacedBlockInteractionHelp(IWorldAccessor world, BlockSelection selection, IPlayer forPlayer)
         {
-            if (Variant["eggCount"] == "empty") return System.Array.Empty<WorldInteraction>();
+            var blockEntity = world.BlockAccessor.GetBlockEntity(selection.Position) as BlockEntityHenBox;
+            if (blockEntity == null || blockEntity.CountEggs() == 0) return System.Array.Empty<WorldInteraction>();
 
             return new WorldInteraction[]
             {

--- a/BlockEntity/BEHenBox.cs
+++ b/BlockEntity/BEHenBox.cs
@@ -16,7 +16,7 @@ namespace Vintagestory.GameContent
      * 1.  / Any well-fed hen - i.e. ready to lay - will activate task AITaskSeekBlockAndLay
      * 2.  / Once sitting on the henbox for 5 real seconds, the hen will first attempt to lay an egg in the henbox
      * 3.  / If the hen can lay an egg (fewer than 3 eggs currently) it does so; makes an egg laying sound and activates another AITask.  TODO: we could add a flapping animation
-     * 4. / The egg will be fertile (it will have a chickCode) if there was a male nearby; otherwise it will be infertile; eggs added by a player are always infertile (for now).  [TODO: track individual egg items' fertility and parentage so that players can micro-manage]
+     * 4. / The egg will be fertile (it will have a chickCode) if there was a male nearby; otherwise it will be infertile
      * 5.  / If the hen cannot lay an egg (henbox is full of 3 eggs already), the hen becomes "broody" and will sit on the eggs for a long time (around three quarters of a day)
      * 6.  / That broody hen or another broody hen will continue returning to the henbox and sitting on the eggs until they eventually hatch
      * 7.  / HenBox BlockEntity tracks how long a hen (any hen) has sat on the eggs warming them - as set in the chicken-hen JSON it needs 5 in-game days
@@ -25,30 +25,35 @@ namespace Vintagestory.GameContent
      * HenBox tracks the parent entity and the generation of each egg separately => in future could have 1 duck egg in a henbox for example, so that 1 duckling hatches and 2 hen chicks
      */
 
-    public class BlockEntityHenBox : BlockEntity, IAnimalNest
+    public class BlockEntityHenBox : BlockEntityDisplay, IAnimalNest
     {
-        internal InventoryGeneric inventory;
-        protected string fullCode = "1egg";
-
-        public Size2i AtlasSize => (Api as ICoreClientAPI).BlockTextureAtlas.Size;
+        protected InventoryGeneric inventory;
+        public override InventoryBase Inventory => inventory;
+        public string inventoryClassName = "nestbox";
+        public override string InventoryClassName => inventoryClassName;
 
         public Vec3d Position => Pos.ToVec3d().Add(0.5, 0.5, 0.5);
         public string Type => "nest";
 
         public Entity occupier;
 
-        protected int[] parentGenerations = new int[10];
-        protected AssetLocation[] chickNames = new AssetLocation[10];
         protected double timeToIncubate;
         protected double occupiedTimeLast;
+        protected bool IsOccupiedClientside = false;
+
+        protected int Capacity
+        {
+            get => Block.Attributes?["quantitySlots"]?.AsInt(1) ?? 1;
+        }
 
 
         public BlockEntityHenBox()
         {
+            container = new ConstantPerishRateContainer(() => Inventory, "inventory");
         }
 
 
-        public bool IsSuitableFor(Entity entity)
+        public virtual bool IsSuitableFor(Entity entity)
         {
             return entity is EntityAgent && entity.Code.Path == "chicken-hen";
         }
@@ -58,48 +63,84 @@ namespace Vintagestory.GameContent
             return occupier != null && occupier != entity;
         }
 
-        public void SetOccupier(Entity entity)
+        public virtual void SetOccupier(Entity entity)
         {
+            if (occupier == entity)
+            {
+                return;
+            }
             occupier = entity;
+            MarkDirty();
         }
 
-        public float DistanceWeighting => 2 / (CountEggs() + 2);
+        public virtual float DistanceWeighting => 2 / (CountEggs() + 2);
 
 
         public virtual bool TryAddEgg(Entity entity, string chickCode, double incubationTime)
         {
-            if (Block.LastCodePart() == fullCode)
-            {
-                if (timeToIncubate == 0)
-                {
-                    timeToIncubate = incubationTime;
-                    occupiedTimeLast = entity.World.Calendar.TotalDays;
+            for (int i = 0; i < inventory.Count; ++i) {
+                if (inventory[i].Empty) {
+                    inventory[i].Itemstack = MakeEggItem(entity, chickCode, incubationTime);
+                    inventory.DidModifyItemSlot(inventory[i]);
+                    timeToIncubate = 0;
+                    return true;
                 }
-                this.MarkDirty();
-                return false;
             }
-
-            timeToIncubate = 0;
-            int eggs = CountEggs();
-            parentGenerations[eggs] = entity.WatchedAttributes.GetInt("generation", 0);
-            chickNames[eggs] = chickCode == null ? null : entity.Code.CopyWithPath(chickCode);
-            eggs++;
-            Block replacementBlock = Api.World.GetBlock(Block.CodeWithVariant("eggCount", eggs + ((eggs > 1) ? "eggs" : "egg")));
-            if (replacementBlock == null)
+            if (timeToIncubate == 0)
             {
-                return false;
+                timeToIncubate = incubationTime;
+                occupiedTimeLast = entity.World.Calendar.TotalDays;
+                MarkDirty();
             }
-            Api.World.BlockAccessor.ExchangeBlock(replacementBlock.Id, this.Pos);
-            this.Block = replacementBlock;
-            this.MarkDirty();
-
-            return true;
+            return false;
         }
 
-        protected int CountEggs()
+        protected virtual ItemStack MakeEggItem(Entity entity, string chickCode, double incubationTime, ICoreAPI api=null)
         {
-            int eggs = Block.LastCodePart()[0];
-            return eggs <= '9' && eggs >= '0' ? eggs - '0' : 0;
+            api ??= this.Api;
+            ItemStack eggStack;
+            JsonItemStack[] eggTypes = entity?.Properties.Attributes?["eggTypes"].AsArray<JsonItemStack>();
+            if (eggTypes == null)
+            {
+                string fallbackCode = "game:egg-chicken-raw";
+                if (entity != null) api.Logger.Warning("No egg type specified for entity " + entity.Code + ", falling back to " + fallbackCode);
+                eggStack = new ItemStack(api.World.GetItem(fallbackCode));
+            }
+            else
+            {
+                JsonItemStack jsonEgg = eggTypes[api.World.Rand.Next(eggTypes.Length)];
+                if (!jsonEgg.Resolve(api.World, null, false))
+                {
+                    api.Logger.Warning("Failed to resolve egg " + jsonEgg.Type + " with code " + jsonEgg.Code + " for entity " + entity.Code);
+                    return null;
+                }
+                eggStack = new ItemStack(jsonEgg.ResolvedItemstack.Collectible);
+            }
+
+            if (chickCode != null) {
+                TreeAttribute chickTree = new TreeAttribute();
+                if (entity != null) chickCode = AssetLocation.Create(chickCode, entity?.Code.Domain ?? "game");
+                chickTree.SetString("code", chickCode);
+                chickTree.SetInt("generation", entity?.WatchedAttributes.GetInt("generation", 0) + 1 ?? 0);
+                EntityAgent eagent = entity as EntityAgent;
+                if (eagent != null) chickTree.SetLong("herdID", eagent.HerdId);
+                eggStack.Attributes["chick"] = chickTree;
+            }
+
+            return eggStack;
+        }
+
+        public int CountEggs()
+        {
+            int count = 0;
+            for (int i = 0; i < inventory.Count; ++i)
+            {
+                if (!inventory[i].Empty)
+                {
+                    ++count;
+                }
+            }
+            return count;
         }
 
         protected virtual void On1500msTick(float dt)
@@ -120,16 +161,17 @@ namespace Vintagestory.GameContent
             if (timeToIncubate <= 0)
             {
                 timeToIncubate = 0;
-                int eggs = CountEggs();
                 Random rand = Api.World.Rand;
 
-                for (int c = 0; c < eggs; c++)
+                for (int i = 0; i < inventory.Count; ++i)
                 {
-                    AssetLocation chickName = chickNames[c];
-                    if (chickName == null) continue;
-                    int generation = parentGenerations[c];
+                    TreeAttribute chickData = (TreeAttribute) inventory[i].Itemstack?.Attributes["chick"];
+                    if (chickData == null) continue;
 
-                    EntityProperties childType = Api.World.GetEntityType(chickName);
+                    string chickCode = chickData.GetString("code");
+                    if (chickCode == null || chickCode == "") continue;
+
+                    EntityProperties childType = Api.World.GetEntityType(chickCode);
                     if (childType == null) continue;
                     Entity childEntity = Api.World.ClassRegistry.CreateEntity(childType);
                     if (childEntity == null) continue;
@@ -140,37 +182,86 @@ namespace Vintagestory.GameContent
 
                     childEntity.Pos.SetFrom(childEntity.ServerPos);
                     childEntity.Attributes.SetString("origin", "reproduction");
-                    childEntity.WatchedAttributes.SetInt("generation", generation + 1);
+                    childEntity.WatchedAttributes.SetInt("generation", chickData.GetInt("generation", 0));
+                    EntityAgent eagent = childEntity as EntityAgent;
+                    if (eagent != null) eagent.HerdId = chickData.GetLong("herdID", 0);
                     Api.World.SpawnEntity(childEntity);
+
+                    inventory[i].Itemstack = null;
+                    inventory.DidModifyItemSlot(inventory[i]);
                 }
-
-
-                Block replacementBlock = Api.World.GetBlock(new AssetLocation(Block.FirstCodePart() + "-empty"));
-                Api.World.BlockAccessor.ExchangeBlock(replacementBlock.Id, this.Pos);
-                this.Api.World.SpawnCubeParticles(Pos.ToVec3d().Add(0.5, 0.5, 0.5), new ItemStack(this.Block), 1, 20, 1, null);
-                this.Block = replacementBlock;
             }
         }
 
 
         public override void Initialize(ICoreAPI api)
         {
+            inventoryClassName = Block.Attributes?["inventoryClassName"]?.AsString() ?? inventoryClassName;
+            int capacity = Capacity;
+            if (inventory == null) {
+                CreateInventory(capacity, api);
+            }
+            else if (capacity != inventory.Count) {
+                api.Logger.Warning("Nest " + Block.Code + " loaded with " + inventory.Count + " capacity when it should be " + capacity + ".");
+                InventoryGeneric oldInv = inventory;
+                CreateInventory(capacity, api);
+                int from = 0;
+                for (int to = 0; to < capacity; ++to) {
+                    for (; from < oldInv.Count && oldInv[from].Empty; ++from);
+                    if (from < oldInv.Count) {
+                        inventory[to].Itemstack = oldInv[from].Itemstack;
+                        inventory.DidModifyItemSlot(inventory[to]);
+                        ++from;
+                    }
+                }
+            }
             base.Initialize(api);
 
-            fullCode = this.Block.Attributes?["fullVariant"]?.AsString(null);
-            if (fullCode == null) fullCode = "1egg";
+            if (api.Side == EnumAppSide.Server) {
+                // Update from old save format to new one
+                int eggsWithBlock = -1;
+                if (Block.Code.Path.EndsWith("empty"))
+                {
+                    eggsWithBlock = 0;
+                }
+                else if (Block.Code.Path.EndsWith("1egg"))
+                {
+                    eggsWithBlock = 1;
+                }
+                else if (Block.Code.Path.EndsWith("eggs"))
+                {
+                    int eggs = Block.LastCodePart()[0];
+                    eggsWithBlock = eggs <= '9' && eggs >= '0' ? eggs - '0' : 0;
+                }
+                if (eggsWithBlock >= 0)
+                {
+                    Block emptyNest = api.World.GetBlock(new AssetLocation(Block.FirstCodePart()));
+                    api.World.BlockAccessor.ExchangeBlock(emptyNest.Id, this.Pos);
+                    MarkDirty();
+                }
+                for (int i = 0; i < eggsWithBlock; ++i)
+                {
+                    inventory[i].Itemstack ??= MakeEggItem(null, null, 0, api);
+                    inventory.DidModifyItemSlot(inventory[i]);
+                }
 
-            if (api.Side == EnumAppSide.Server)
-            {
+
+                IsOccupiedClientside = false;
                 api.ModLoader.GetModSystem<POIRegistry>().AddPOI(this);
                 RegisterGameTickListener(On1500msTick, 1500);
             }
         }
 
-
-        public override void OnBlockPlaced(ItemStack byItemStack = null)
+        protected void CreateInventory(int capacity, ICoreAPI api)
         {
-            base.OnBlockPlaced(byItemStack);
+            inventory = new InventoryGeneric(capacity, InventoryClassName, Pos?.ToString(), api);
+            inventory.Pos = this.Pos;
+            inventory.SlotModified += OnSlotModified;
+        }
+
+        protected virtual void OnSlotModified(int slot)
+        {
+            MarkDirty();
         }
 
 
@@ -200,34 +291,133 @@ namespace Vintagestory.GameContent
             base.ToTreeAttributes(tree);
             tree.SetDouble("inc", timeToIncubate);
             tree.SetDouble("occ", occupiedTimeLast);
-            for (int i = 0; i < 10; i++)
-            {
-                tree.SetInt("gen" + i, parentGenerations[i]);
-                AssetLocation chickName = chickNames[i];
-                if (chickName != null) tree.SetString("chick" + i, chickName.ToShortString());
-            }
+            tree.SetBool("isOccupied", occupier != null && occupier.Alive);
         }
 
 
         public override void FromTreeAttributes(ITreeAttribute tree, IWorldAccessor worldForResolving)
         {
+            TreeAttribute invTree = (TreeAttribute) tree["inventory"];
+            if (inventory == null)
+            {
+                int capacity = invTree?.GetInt("qslots") ?? Capacity;
+                CreateInventory(capacity, worldForResolving.Api);
+            }
             base.FromTreeAttributes(tree, worldForResolving);
+
             timeToIncubate = tree.GetDouble("inc");
             occupiedTimeLast = tree.GetDouble("occ");
             for (int i = 0; i < 10; i++)
             {
-                parentGenerations[i] = tree.GetInt("gen" + i);
-                string chickName = tree.GetString("chick" + i);
-                chickNames[i] = chickName == null ? null : new AssetLocation(chickName);
+                string chickCode = tree.GetString("chick" + i);
+                if (chickCode != null)
+                {
+                    int generation = tree.GetInt("gen" + i);
+                    inventory[i].Itemstack = MakeEggItem(null, chickCode, 0, worldForResolving.Api);
+                    inventory.DidModifyItemSlot(inventory[i]);
+                }
             }
+            IsOccupiedClientside = tree.GetBool("isOccupied");
+            RedrawAfterReceivingTreeAttributes(worldForResolving);
         }
 
+        public virtual bool CanPlayerPlaceItem(ItemStack itemstack)
+        {
+            // Included for moddability, testibility, and because another comment indicates that letting players move eggs around is a desired future feature.
+            // Note that if players are given the ability to place eggs inside, the perish rate should be made non-zero with accompanying adjustments.
+            return false;
+        }
+
+        public bool OnInteract(IWorldAccessor world, IPlayer byPlayer, BlockSelection blockSel) 
+        {
+            if (!world.Claims.TryAccess(byPlayer, blockSel.Position, EnumBlockAccessFlags.Use))
+            {
+                return false;
+            }
+
+            ItemSlot slot = byPlayer.InventoryManager.ActiveHotbarSlot;
+            if (CanPlayerPlaceItem(slot.Itemstack))
+            {
+                // Place egg in nest
+                for (int i = 0; i < inventory.Count; ++i)
+                {
+                    if (inventory[i].Empty)
+                    {
+                        AssetLocation sound = slot.Itemstack?.Block?.Sounds?.Place;
+                        AssetLocation itemPlaced = slot.Itemstack?.Collectible?.Code;
+                        ItemStackMoveOperation op = new ItemStackMoveOperation(Api.World, EnumMouseButton.Left, 0, EnumMergePriority.AutoMerge, 1);
+                        if (slot.TryPutInto(inventory[i], ref op) > 0)
+                        {
+                            Api.Logger.Audit(byPlayer.PlayerName + " put 1x" + itemPlaced + " into " + Block.Code + " at " + Pos);
+                            Api.World.PlaySoundAt(sound != null ? sound : new AssetLocation("sounds/player/build"), byPlayer.Entity, byPlayer, true, 16);
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            }
+
+            // Try to take all eggs from nest
+            bool anyEggs = false;
+            for (int i = 0; i < inventory.Count; ++i)
+            {
+                if (!inventory[i].Empty)
+                {
+                    string audit = inventory[i].Itemstack.Collectible?.Code;
+                    int quantity = inventory[i].Itemstack.StackSize;
+
+                    bool gave = byPlayer.InventoryManager.TryGiveItemstack(inventory[i].Itemstack);
+                    int taken = quantity - (inventory[i].Itemstack?.StackSize ?? 0);
+                    if (gave)
+                    {
+                        if (inventory[i].Itemstack != null && quantity == inventory[i].Itemstack.StackSize)
+                        {
+                            ItemStack stack = inventory[i].TakeOutWhole();
+                            taken = quantity;
+                        }
+
+                        anyEggs = true;
+                        world.Api.Logger.Audit(byPlayer.PlayerName + " took " + taken + "x " + audit + " from " + Block.Code + " at " + Pos);
+                        inventory.DidModifyItemSlot(inventory[i]);
+                    }
+                    if (inventory[i].Itemstack != null && inventory[i].Itemstack.StackSize == 0)
+                    {
+                        // This can happen even if TryGiveItemstack returned false, if the player is in creative mode
+                        if (!gave)
+                        {
+                            world.Api.Logger.Audit(byPlayer.PlayerName + " voided " + taken + "x " + audit + " from " + Block.Code + " at " + Pos);
+                        }
+                        // Otherwise eggs with stack size 0 will still be displayed and still occupy a slot
+                        inventory[i].Itemstack = null;
+                        inventory.DidModifyItemSlot(inventory[i]);
+                    }
+                    // If it doesn't fit, leave it in the nest
+                }
+            }
+            if (anyEggs)
+            {
+                world.PlaySoundAt(new AssetLocation("sounds/player/collect"), blockSel.Position.X, blockSel.Position.Y, blockSel.Position.Z, byPlayer);
+            }
+            return anyEggs;
+        }
 
         public override void GetBlockInfo(IPlayer forPlayer, StringBuilder dsc)
         {
-            int eggCount = CountEggs();
+            int eggCount = 0;
             int fertileCount = 0;
-            for (int i = 0; i < eggCount; i++) if (chickNames[i] != null) fertileCount++;
+            for (int i = 0; i < inventory.Count; ++i)
+            {
+                if (!inventory[i].Empty)
+                {
+                    ++eggCount;
+                    TreeAttribute chickData = (TreeAttribute) inventory[i].Itemstack.Attributes["chick"];
+                    if (chickData?.GetString("code") != null)
+                    {
+                        ++fertileCount;
+                    }
+                }
+            }
+
             if (fertileCount > 0)
             {
                 if (fertileCount > 1)
@@ -242,13 +432,47 @@ namespace Vintagestory.GameContent
                 else if (timeToIncubate > 0)
                     dsc.AppendLine(Lang.Get("Incubation time remaining: {0:0} hours", timeToIncubate * 24));
 
-                if (occupier == null && Block.LastCodePart() == fullCode)
+                if (!IsOccupiedClientside && eggCount >= inventory.Count)
                     dsc.AppendLine(Lang.Get("A broody hen is needed!"));
             }
             else if (eggCount > 0)
             {
                 dsc.AppendLine(Lang.Get("No eggs are fertilized"));
             }
+        }
+
+        protected override float[][] genTransformationMatrices()
+        {
+            ModelTransform[] transforms = Block.Attributes?["displayTransforms"]?.AsArray<ModelTransform>();
+            if (transforms == null)
+            {
+                capi.Logger.Warning("No display transforms found for " + Block.Code + ", placed items may be invisible or in the wrong location.");
+                transforms = new ModelTransform[DisplayedItems];
+                for (int i = 0; i < transforms.Length; ++i)
+                {
+                    transforms[i] = new ModelTransform();
+                }
+            }
+            if (transforms.Length != DisplayedItems)
+            {
+                capi.Logger.Warning("Display transforms for " + Block.Code + " block entity do not match number of displayed items, later placed items may be invisible or in the wrong location. Items: " + DisplayedItems + ", transforms: " + transforms.Length);
+            }
+
+            float[][] tfMatrices = new float[transforms.Length][];
+            for (int i = 0; i < transforms.Length; ++i)
+            {
+                FastVec3f off = transforms[i].Translation;
+                FastVec3f rot = transforms[i].Rotation;
+                tfMatrices[i] = new Matrixf()
+                    .Translate(off.X, off.Y, off.Z)
+                    .Translate(0.5f, 0, 0.5f)
+                    .RotateX(rot.X * GameMath.DEG2RAD)
+                    .RotateY(rot.Y * GameMath.DEG2RAD)
+                    .RotateZ(rot.Z * GameMath.DEG2RAD)
+                    .Translate(-0.5f, 0, -0.5f)
+                    .Values;
+            }
+            return tfMatrices;
         }
     }
 }

--- a/Inventory/ConstantPerishRateContainer.cs
+++ b/Inventory/ConstantPerishRateContainer.cs
@@ -1,0 +1,19 @@
+
+using Vintagestory.GameContent;
+
+namespace Vintagestory.GameContent
+{
+    public class ConstantPerishRateContainer : InWorldContainer
+    {
+        public float PerishRate = 0;
+
+        public ConstantPerishRateContainer(InventorySupplierDelegate inventorySupplier, string treeAttrKey) : base(inventorySupplier, treeAttrKey)
+        {
+        }
+
+        public override float GetPerishRate()
+        {
+            return PerishRate;
+        }
+    }
+}

--- a/Item/ItemEgg.cs
+++ b/Item/ItemEgg.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Vintagestory.API.Common;
+using Vintagestory.API.Config;
+using Vintagestory.API.Datastructures;
+
+#nullable enable
+
+namespace Vintagestory.GameContent
+{
+    public class ItemEgg : Item
+    {
+        public override int GetMergableQuantity(ItemStack sinkStack, ItemStack sourceStack, EnumMergePriority priority)
+        {
+            string[] ignored = new string[GlobalConstants.IgnoredStackAttributes.Length + 1];
+            ignored[0] = "chick";
+            Array.Copy(GlobalConstants.IgnoredStackAttributes, 0, ignored, 1, GlobalConstants.IgnoredStackAttributes.Length);
+            if (Equals(sinkStack, sourceStack, ignored) && sinkStack.StackSize < MaxStackSize)
+            {
+                return Math.Min(MaxStackSize - sinkStack.StackSize, sourceStack.StackSize);
+            }
+
+            return 0;
+        }
+
+        public override void TryMergeStacks(ItemStackMergeOperation op)
+        {
+            IAttribute? sourceChick = op.SourceSlot.Itemstack?.Attributes?["chick"];
+            IAttribute? sinkChick = op.SinkSlot.Itemstack?.Attributes?["chick"];
+            bool chickDataMatches = (sourceChick == null && sinkChick == null) || (sourceChick != null && sourceChick.Equals(sinkChick));
+            base.TryMergeStacks(op);
+            if (op.MovedQuantity > 0 && !chickDataMatches)
+            {
+                op.SinkSlot.Itemstack?.Attributes?.RemoveAttribute("chick");
+            }
+        }
+
+    }
+}

--- a/Systems/Core.cs
+++ b/Systems/Core.cs
@@ -945,6 +945,7 @@ namespace Vintagestory.GameContent
 
             api.RegisterItemClass("ItemSkillTimeswitch", typeof(ItemSkillTimeswitch));
             api.RegisterItemClass("ItemAnchor", typeof(ItemAnchor));
+            api.RegisterItemClass("ItemEgg", typeof(ItemEgg));
         }
 
 

--- a/assets/otherchanges.txt
+++ b/assets/otherchanges.txt
@@ -1,0 +1,6 @@
+Lang files - henbox-empty to henbox, remove (empty) from lang string
+remove henbox (1 egg), henbox (2 eggs), henbox (3 eggs)
+
+delete files: survival/shapes/block/wood/henbox/henbox-(1egg/2eggs/3eggs).json
+
+Optionally - instead of override to ItemEgg.GetMergableQuantity, could add "chickData" to vsapi/Config/GlobalConstants.IgnoredStackAttributes (simplifies code, performance impact likely slightly negative but very small)

--- a/assets/survival/blocktypes/legacy/henbox.json
+++ b/assets/survival/blocktypes/legacy/henbox.json
@@ -1,0 +1,47 @@
+{
+	code: "henbox",
+	class: "BlockHenbox",
+	entityClass: "HenBox",
+	variantgroups: [
+		{code: "eggCount", states: ["empty", "1egg", "2eggs", "3eggs"]}
+	],
+	attributes: {
+        inventoryClassName: "henbox",
+        quantitySlots: 3,
+        displayTransforms: [
+            { translation: { x: -0.05, y: 0.09, z: -0.07344 }, rotation: { x: 3, y: 47, z: 0 } },
+            { translation: { x: 0.01857, y: 0.09, z: 0.073675 }, rotation: { x: 4, y: 104, z: -5 } },
+            { translation: { x: 0.0899, y: 0.09, z: -0.03245 }, rotation: { x: -5, y: -14, z: -2 } },
+        ],
+	},
+	shape: {
+		base: "block/wood/henbox/henbox-empty"
+	},
+	resistance: 1,
+	sideopaque: {
+		all: false
+	},
+	sidesolid: {
+		all: false
+	},
+	blockmaterial: "Wood",
+	materialDensity: 450,
+	randomizeRotations: true,
+	sideao: { all: false },
+	lightAbsorption: 0,
+	collisionbox: {x1: 0.25, y1: 0, z1: 0.25, x2: 0.75, y2: 0.08, z2: 0.75},
+	selectionbox: {
+		x1: 0.2, y1: 0, z1: 0.2,
+		x2: .8, y2: .21, z2: .8
+	},
+	tphandTransform: {
+		origin: { x: 0.5, y: 0.5, z: 0 },
+		translation: { x: -1.2, y: -.5, z: .5 },
+		rotation: { x: 0, y: 0, z: 0 },
+		scale: .5
+	},
+	guiTransform: {
+		origin: { x: 0.5, y: 0.15, z: 0.5 },
+		scale: 1.8
+	}
+}

--- a/assets/survival/blocktypes/legacy/henbox.json
+++ b/assets/survival/blocktypes/legacy/henbox.json
@@ -6,6 +6,7 @@
 		{code: "eggCount", states: ["empty", "1egg", "2eggs", "3eggs"]}
 	],
 	attributes: {
+        nestType: "ground",
         inventoryClassName: "henbox",
         quantitySlots: 3,
         displayTransforms: [

--- a/assets/survival/blocktypes/wood/henbox.json
+++ b/assets/survival/blocktypes/wood/henbox.json
@@ -3,6 +3,7 @@
 	class: "BlockHenbox",
 	entityClass: "HenBox",
 	attributes: {
+        nestType: "ground",
         inventoryClassName: "henbox",
         quantitySlots: 3,
         displayTransforms: [

--- a/assets/survival/blocktypes/wood/henbox.json
+++ b/assets/survival/blocktypes/wood/henbox.json
@@ -1,0 +1,51 @@
+{
+	code: "henbox",
+	class: "BlockHenbox",
+	entityClass: "HenBox",
+	attributes: {
+        inventoryClassName: "henbox",
+        quantitySlots: 3,
+        displayTransforms: [
+            { translation: { x: -0.05, y: 0.09, z: -0.07344 }, rotation: { x: 3, y: 47, z: 0 } },
+            { translation: { x: 0.01857, y: 0.09, z: 0.073675 }, rotation: { x: 4, y: 104, z: -5 } },
+            { translation: { x: 0.0899, y: 0.09, z: -0.03245 }, rotation: { x: -5, y: -14, z: -2 } },
+        ],
+		handbook: {
+			extraSections: [
+				{ title: "handbooktitle-henbox", text: "handbooktext-henbox" }
+			]
+		}
+	},
+	creativeinventory: { general: ["*"] },
+	shape: {
+		base: "block/wood/henbox/henbox-empty"
+	},
+	resistance: 1,
+	sideopaque: {
+		all: false
+	},
+	sidesolid: {
+		all: false
+	},
+	blockmaterial: "Wood",
+	materialDensity: 450,
+	randomizeRotations: true,
+	sideao: { all: false },
+	lightAbsorption: 0,
+	collisionbox: {x1: 0.25, y1: 0, z1: 0.25, x2: 0.75, y2: 0.08, z2: 0.75},
+	selectionbox: {
+		x1: 0.2, y1: 0, z1: 0.2,
+		x2: .8, y2: .21, z2: .8
+	},
+	tphandTransform: {
+		origin: { x: 0.5, y: 0.5, z: 0 },
+		translation: { x: -1.2, y: -.5, z: .5 },
+		rotation: { x: 0, y: 0, z: 0 },
+		scale: .5
+	},
+	guiTransform: {
+		origin: { x: 0.5, y: 0.15, z: 0.5 },
+		scale: 1.8
+	}
+	
+}

--- a/assets/survival/entities/land/chicken-adult.json
+++ b/assets/survival/entities/land/chicken-adult.json
@@ -1,0 +1,396 @@
+{
+	code: "chicken",
+	class: "EntityAgent",
+	variantgroups: [
+		{ code: "age", states: ["hen", "henpoult", "rooster", "roosterpoult"]},
+	],
+	hitboxSize: { x: 0.5, y: 0.6 },
+	deadHitboxSize: { x: 0.5, y: 0.25 },
+	eyeHeight: 0.5,
+	weightByType: {
+		"chicken-hen*": 0.8,
+		"*": 1
+	},
+	fallDamageMultiplier: 0.75,
+	drops: [],
+	attributes: {
+		creatureDiet: {
+			foodCategories: ["Grain"],
+			foodTags: ["fruitmash"]
+		},
+		trappable: {
+			"small": { trapChance: 0.5, trapDestroyChance: 0.01 }
+		},
+		handbook: {
+			"groupcode": "creaturegroup-chicken"
+		},
+        eggTypes: [ { type: "item", code: "game:egg-chicken-raw" } ],
+	},
+	client: {
+		renderer: "Shape",
+		shapeByType: {
+			"chicken-hen*": { "base": "entity/land/chicken-hen" },
+			"*": { "base": "entity/land/chicken-rooster" }
+		},
+		textureByType: {
+			"chicken-hen*": { base: "entity/chicken/hen1", alternates: [ { base: "entity/chicken/hen2" }, { base: "entity/chicken/hen3" }, { base: "entity/chicken/hen4" }, { base: "entity/chicken/hen5" }, { base: "entity/chicken/hen6" }, { base: "entity/chicken/hen7" }, { base: "entity/chicken/hen8" } ] },
+			"*": { base: "entity/chicken/rooster1", alternates: [ { base: "entity/chicken/rooster2" }, { base: "entity/chicken/rooster3" }, { base: "entity/chicken/rooster4" }, { base: "entity/chicken/rooster5" } ] }
+		},
+		sizeByType: { "*poult": 0.72, "*": 1 },
+		sizeGrowthFactorByType: { "*poult": 0.24, "*": 0 },
+		behaviors: [
+			{ code: "repulseagents" }, 
+			{ code: "controlledphysics", stepHeight: 1.1251 }, 
+			{ code: "floatupwhenstuck", onlyWhenDead: true },
+			{ code: "interpolateposition" }, 
+			{ code: "multiplybase", "enabledByType": { "*-hen": true, "*": false } }, 
+			{ code: "harvestable" },
+			{ code: "despawn", minPlayerDistance: 8, belowLightLevel: 8, minSeconds: 300 },
+			{ code: "ropetieable", minGeneration: 2 }
+		],
+		animations: [
+			{
+				code: "hurt",
+				animation: "hurt", 
+				animationSpeed: 2.2,
+				weight: 10,
+				blendMode: "AddAverage" 
+			},
+			{
+				code: "roostercall",
+				animation: "roostercall",
+				animationSpeed: 1.3,
+				weight: 10,
+				blendMode: "AddAverage"
+			},
+			{
+				code: "eat",
+				animation: "eat", 
+				animationSpeed: 1,
+				weight: 4,
+				easeOutSpeed: 8,
+				easeInSpeed: 5,
+				blendMode: "AddAverage" 
+			},
+			{ 
+				code: "idle", 
+				animation: "idle",
+				blendMode: "AddAverage",
+				easeOutSpeed: 4,
+				triggeredBy: { defaultAnim: true },
+			},
+			{
+				code: "die",
+				animation: "death", 
+				animationSpeed: 1.25,
+				weight: 10,
+				blendMode: "Average",
+				triggeredBy: { onControls: ["dead"] }
+			},
+			{
+				code: "sleep", 
+				animation: "sleep",
+				easeInSpeed: 4,
+				easeOutSpeed: 4,
+				blendMode: "Average", 
+			},
+			{
+				code: "sit", 
+				animation: "sit",
+				easeInSpeed: 4,
+				easeOutSpeed: 4,
+				blendMode: "Average", 
+			}
+		]
+	},
+	server: {
+		attributes: {
+			pathfinder: {
+				minTurnAnglePerSec: 720,
+				maxTurnAnglePerSec: 1440
+			}
+		},
+		behaviors: [
+			{ code: "repulseagents" }, 
+			{ code: "controlledphysics", stepHeight: 1.1251 },
+			{ code: "despawn", minPlayerDistance: 8, belowLightLevel: 8, minSeconds: 300 },
+			{ code: "health", currenthealth: 3, maxhealth: 3 },
+			{ code: "deaddecay", hoursToDecay: 96, decayedBlock: "carcass-tiny" },
+			{ code: "harvestable", drops: [
+					{
+						type: "item", 
+						code: "poultry-raw", 
+						quantityByType: {
+							"*poult":{ avg: 1.25, var: 0.25 }, 
+							"*":{ avg: 1.75, var: 0.25 } 
+						}
+					},
+					{
+						type: "item", 
+						code: "feather", 
+						quantity: { avg: 12, var: 4 } 
+					}
+				],
+			},
+			{ code: "floatupwhenstuck", onlyWhenDead: true },
+			{ code: "multiplybase",
+				enabledByType: { "*-hen": true, "*": false },
+				multiplyCooldownDaysMin: 0,
+				multiplyCooldownDaysMax: 3,
+				portionsEatenForMultiply: 4
+			},
+			{ code: "grow",
+				enabledByType: { "*poult": true, "*": false },
+				hoursToGrowByType: {
+					"*-henpoult": 72,
+					"*-roosterpoult": 80
+				},
+				adultEntityCodesByType: {
+					"*-henpoult":["chicken-hen"],
+					"*-roosterpoult":["chicken-rooster"] 
+				}
+			},
+			{ code: "breathe" },
+			{
+				code: "emotionstates",
+				states: [
+					{ code: "alarmherdondamage", chance: 1, slot: 1, priority: 1, accumType: "max", enabledByType: { "*-rooster": false, "*": true } },
+					{ code: "aggressiveondamage", duration: 20, chance: 0.4, slot: 0, priority: 2, accumType: "noaccum", enabledByType: { "*-rooster": true, "*": false } },
+					{ code: "fleeondamage", duration: 10, chance: 1, slot: 0, priority: 1, accumType: "max" }
+				],
+			},
+			{ 
+				code: "taskai",
+				aiCreatureType: "LandCreature",
+				aitasks: [
+					{
+						"_comment": "pecker fight!!!",
+						code: "meleeattack",
+						enabledByType: { "*-rooster": true, "*": false },
+						entityCodes: ["chicken-rooster"],
+						priority: 2,
+						damage: 0.05,
+						mincooldown: 2500,
+						maxcooldown: 45000,
+						minDist: 0.9,
+						attackDurationMs: 2000,
+						damagePlayerAtMs: 600,
+						animation: "Attack",
+						animationSpeed: 1.5,
+						sound: "creature/chicken/rooster-alarm2"
+					},
+					{
+						code: "meleeattack",
+						enabledByType: { "*-rooster": true, "*": false },
+						entityCodes: ["player", "wolf-male", "wolf-female"],
+						priority: 2,
+						damage: 0.25,
+						mincooldown: 2500,
+						maxcooldown: 3500,
+						attackDurationMs: 2000,
+						damagePlayerAtMs: 600,
+						animation: "Attack",
+						animationSpeed: 1.5,
+						damageType: "PiercingAttack",
+						whenInEmotionState: "aggressiveondamage",
+						sound: "creature/chicken/rooster-alarm2"
+					},
+					{
+						code: "fleeentity",
+						seekingRange: 10,
+						entityCodes: ["player", "wolf-male", "wolf-female", "fox-*", "bear-*"],
+						priority: 1.8,
+						movespeed: 0.037,
+						animation: "Run",
+						animationSpeed: 2,
+						sound: "creature/chicken/hurt",
+						whenInEmotionState: "fleeondamage"
+					},
+					{
+						code: "seekentity",
+						priority: 1.7,
+						mincooldown: 1000,
+						maxcooldown: 1500,
+						seekingRange: 25,
+						movespeed: 0.033,
+						animation: "Run2",
+						animationSpeed: 2,
+						whenInEmotionState: "aggressiveondamage",
+						sound: "creature/chicken/rooster-alarm"
+					},
+					{
+						code: "fleeentity",
+						instafleeOnDamageChance: 1,
+						seekingRange: 11,
+						entityCodes: ["player", "wolf-male", "wolf-female", "fox-*", "bear-*"],
+						priority: 1.5,
+						movespeed: 0.037,
+						animationSpeed: 2.4,
+						animation: "Run",
+						sound: "creature/chicken/hen-flee"
+					},
+					{
+						code: "followleadholder",
+						minGeneration: 2,
+						priority: 1.45,
+						animation: "trot",
+						animationSpeed: 1.35,
+						movespeed: 0.019
+					},
+					{
+						code: "getoutofwater",
+						priority: 1.4,
+						movespeed: 0.02,
+						animation: "Run",
+						sound: "creature/chicken/hen-flee"
+					},
+					{
+						code: "seekblockandlay",
+						priorityByType: {"*-hen":1.36, "*":0},
+						layTime: 5,
+						chickCode: "chicken-baby",
+						sitDays: 0.9,
+						incubationDays: 5,
+						movespeed: 0.006,
+						animation: "Walk",
+						mincooldownHours: 1,
+						maxcooldownHours: 2,
+						sitAnimation: "Sit",
+						requiresNearbyEntityCode: "chicken-rooster",
+						requiresNearbyEntityRange: 12,
+						growthCapEntityCodes: ["chicken-baby", "chicken-hen", "chicken-rooster"],
+						failBlockCode: "egg-chicken-1",
+						sound: "creature/chicken/hen-lay"
+					},
+					{
+						code: "seekfoodandeat",
+						priority: 1.35,
+						eatSound: "creature/animal-eat-small",
+						eatTime: 1.5,
+						movespeed: 0.0065,
+						animation: "Walk",
+						mincooldownHours: 1,
+						maxcooldownHours: 4,
+					},
+					{
+						code: "stayclosetoentity",
+						enabledByType: { "*-hen": true, "*-henpoult": true, "*": false },
+						priority: 1.3,
+						entityCode: "chicken-rooster",
+						movespeed: 0.015,
+						maxDistance: 5,
+						searchRange: 12,
+						animation: "Run"
+					},
+					{
+						code: "idle",
+						animation: "Sleep",
+						priority: 1.25,
+						minduration: 5000000,
+						maxduration: 5000000,
+						mincooldown: 5000,
+						maxcooldown: 15000,
+						priorityForCancel: 1.38,
+						whenNotInEmotionState: "aggressiveondamage",
+						duringDayTimeFrames: [ { fromHour: 20, toHour: 24 }, { fromHour: 0, toHour: 6 } ],
+						stopOnNearbyEntityCodes: ["player", "wolf-male", "wolf-female", "fox-*"],
+						stopRange: 8,
+						stopOnHurt: true
+					},					
+					{
+						code: "idle",
+						animation: "RoosterCall",
+						priority: 1.23,
+						enabledByType: { "*-rooster": true, "*": false },
+						minduration: 3120,
+						maxduration: 3120,
+						mincooldown: 50000,
+						maxcooldown: 400000,
+						animationSpeed: 1.5,
+						sound: "creature/chicken/rooster-call",
+						soundRange: 48,
+						priorityForCancel: 1.35,
+					},
+					{
+						code: "idle",
+						animation: "Eat",
+						priority: 1.2,
+						minduration: 1000,
+						maxduration: 8000,
+						mincooldown: 1000,
+						maxcooldown: 10000,
+						priorityForCancel: 1.29
+					},
+					{
+						code: "idle",
+						animation: "Idle",
+						priority: 1.1,
+						minduration: 1000,
+						maxduration: 3000,
+						mincooldown: 2000,
+						maxcooldown: 30000
+					},
+					{
+						code: "wander", 
+						animation: "Walk",
+						priority: 1.0, 
+						movespeed: 0.007,
+						wanderChance: 0.02,
+						preferredLightLevel: 19
+					},			
+					{
+						code: "idle",
+						animation: "Sit",
+						priority: 0.9,
+						minduration: 6000,
+						maxduration: 40000,
+						mincooldown: 2000,
+						maxcooldown: 120000,
+						priorityForCancel: 1.29
+					},
+					{ 
+						code: "lookaround", 
+						priority: 0.5
+					}
+				]
+			},
+			{ code: "ropetieable", minGeneration: 2 },
+			{ code: "pettable", minGeneration: 1 }
+		],
+		spawnconditionsByType: {
+			"*-rooster": {
+				worldgen: {
+					TriesPerChunk: { avg: 0.1, var: 0 },
+					tryOnlySurface: true,
+					minLightLevel: 12,
+					groupSize: { dist: "verynarrowgaussian", avg: 4, var: 5 },
+					insideBlockCodes: ["air", "tallgrass-*"],
+					minTemp: -2,
+					minRain: 0.32,
+					minShrubs: 0.5,
+					companions: ["chicken-hen", "chicken-baby"]
+				},
+				runtime: {
+					group: "neutral",
+					tryOnlySurface: true,
+					chance: 0.001,
+					maxQuantity: 4,
+					minLightLevel: 12,
+					groupSize: { dist: "verynarrowgaussian", avg: 4, var: 5 },
+					insideBlockCodes: ["air", "tallgrass-*"],
+					minTemp: -2,
+					minRain: 0.32,
+					minShrubs: 0.5,
+					companions: ["chicken-hen", "chicken-baby"]
+				}
+			},
+			"*": null,
+		}
+	},
+	sounds: {
+		hurt: "creature/chicken/hurt",
+		death: "creature/chicken/hurt",
+		idle: "creature/chicken/hen-idle*"
+	},
+	idleSoundChance: 0.05
+}

--- a/assets/survival/entities/land/chicken-adult.json
+++ b/assets/survival/entities/land/chicken-adult.json
@@ -249,6 +249,7 @@
 						priorityByType: {"*-hen":1.36, "*":0},
 						layTime: 5,
 						chickCode: "chicken-baby",
+						nestTypes: [ "ground" ],
 						sitDays: 0.9,
 						incubationDays: 5,
 						movespeed: 0.006,

--- a/assets/survival/itemtypes/food/egg.json
+++ b/assets/survival/itemtypes/food/egg.json
@@ -1,0 +1,60 @@
+{
+	code: "egg",
+    class: "ItemEgg",
+	maxstacksize: 32,
+	variantgroups: [
+		{ code: "source", states: ["chicken" ] },
+		{ code: "state", states: ["raw"] },
+	],
+	behaviors: [
+		{ name: "GroundStorable", properties: { layout: 'Quadrants', collisionBox: { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.125, z2: 1 } } }
+	],
+	shape: { base: "item/food/egg" },
+	texture: { base: "item/food/egg/chicken" },
+	creativeinventory: { "general": ["*"], "items": ["*"] },
+	attributes: {
+		"nutritionPropsWhenInMeal": { saturation: 200, foodcategory: "Protein" },
+		foodTags: ["egg"],
+		inTrapTransform: {
+			"small": {
+				translation: { x: 0, y: 0.125, z: -0.08 },
+				rotation: { x: 0, y: -57, z: 0 }
+			},
+			"large": {
+				translation: { x: -0.5, y: 0.425, z: -0.55 },
+				rotation: { x: 0, y: -57, z: 82 }
+			}
+		}
+	},
+	nutritionPropsByType: {
+		"*-boiled": { saturation: 160, foodcategory: "Protein" },
+	},
+	materialDensity: 200,
+	guiTransform: {
+		translation: { x: 0, y: 0, z: 0 },
+		rotation: { x: -30, y: -20, z: 0 },
+		origin: { x: 0.49, y: 0.02, z: 0.5 },
+		scale: 5.95
+	},
+	tpHandTransform: {
+		translation: { x: -0.8, y: -0.25, z: -0.6 },
+		scale: 0.71
+	},
+	fpHandTransform: {
+		translation: { x: 0, y: -0.1, z: 0 },
+		rotation: { x: 180, y: 90, z: 22 }
+	},
+	groundTransform: {
+		translation: { x: 0, y: 0, z: 0 },
+		rotation: { x: 0, y: 0, z: 0 },
+		origin: { x: 0.5, y: 0, z: 0.5 },
+		scale: 5
+	},
+	transitionableProps: [{
+		type: "Perish",
+		freshHours: { avg: 120 },
+		transitionHours: { avg: 24 },
+		transitionedStack: { type: "item", code: "rot" },
+		transitionRatio: 0.5
+	}]
+}

--- a/assets/survival/recipes/grid/henbox.json
+++ b/assets/survival/recipes/grid/henbox.json
@@ -1,0 +1,10 @@
+{
+	ingredientPattern: "PHP	PPP",
+	ingredients: {
+		"H": { type: "item", code: "drygrass" },
+		"P": { type: "item", code: "plank-*" }
+	},
+	width: 3,
+	height: 2,
+	output: { type: "block", code: "henbox" }
+}


### PR DESCRIPTION
Together with a PR to VSEssentials (https://github.com/anegostudios/vsessentialsmod/pull/24), this does:

Modding API Feature: Species other than chickens are able to use the hen box if they use a matching nest type
Modding API Feature: AI task seekblockandlay now supports multiple chick types (such as male and female)
Modding API Tweak: IAnimalNest.TryAddEgg now takes an egg itemstack with chick info set in attributes

I'm including the previous merged PR underneath in the hopes that git will apply it correctly without extra merge conflicts. If that works correctly, the actual changes should look like this: https://github.com/anegostudios/vsessentialsmod/compare/master...sekelsta:vsessentialsmod:henboxPR?w=1 (plus potentially some line ending changes)