### PR TITLE
Move PitKiln base.Initialize() before the BEBurning callback registration

### DIFF
--- a/BlockEntity/BEPitKiln.cs
+++ b/BlockEntity/BEPitKiln.cs
@@ -69,6 +69,8 @@ namespace Vintagestory.GameContent
                 BurningUntilTotalHours = Math.Min(api.World.Calendar.TotalHours + BurnTimeHours, BurningUntilTotalHours);
             }
 
+            base.Initialize(api);
+
             bh.OnFireTick = (dt) => {
                 if (api.World.Calendar.TotalHours >= BurningUntilTotalHours)
                 {
@@ -90,8 +92,6 @@ namespace Vintagestory.GameContent
 
                 return block?.CombustibleProps != null && block.CombustibleProps.BurnDuration > 0 && (!IsAreaLoaded() || upblock.Replaceable >= 6000);
             };
-
-            base.Initialize(api);
 
             DetermineBuildStages();
 


### PR DESCRIPTION
This fixes https://github.com/anegostudios/VintageStory-Issues/issues/5181.

Because `BlockEntityGroundStorage` registers its own `OnFireDeath` callback as of 1.20.0-pre.1 (cf0900e82304b5c42128ef7259ee5dd1e49a3b44), it overrides the behavior in PitKiln that resets the "lit" property, causing the issue mentioned above.

I'm not sure if changing this can cause other issues, but a quick test didn't show any odd behavior after applying the patch.