### PR TITLE
List bookshelves, scroll racks, antler mounts in handbook

### DIFF
--- a/Systems/Handbook/CollectibleBehaviorHandbookTextAndExtraInfo.cs
+++ b/Systems/Handbook/CollectibleBehaviorHandbookTextAndExtraInfo.cs
@@ -2202,6 +2202,10 @@ namespace Vintagestory.GameContent
             {
                 AddPaddingAndRichText(storableComps, capi, "handbook-storable-shelves");
             }
+            if (stack.ItemAttributes?.IsTrue("bookshelvable") == true)
+            {
+                AddPaddingAndRichText(storableComps, capi, "handbook-storable-bookshelf");
+            }
             if (stack.ItemAttributes?.IsTrue("displaycaseable") == true)
             {
                 AddPaddingAndRichText(storableComps, capi, "handbook-storable-displaycase");
@@ -2217,6 +2221,14 @@ namespace Vintagestory.GameContent
             if (stack.ItemAttributes?["waterTightContainerProps"].Exists == true)
             {
                 AddPaddingAndRichText(storableComps, capi, "handbook-storable-barrel");
+            }
+            if (stack.ItemAttributes?.IsTrue("antlermountable") == true)
+            {
+                AddPaddingAndRichText(storableComps, capi, "handbook-storable-antlermount");
+            }
+            if (stack.ItemAttributes?.IsTrue("scrollrackable") == true)
+            {
+                AddPaddingAndRichText(storableComps, capi, "handbook-storable-scrollrack");
             }
 
             if (storableComps.Count > 0)


### PR DESCRIPTION
Items compatible with the aforementioned storage blocks do not say so in the handbook.
This change adds handbook links for these storage methods, improving consistency.
For example, papers and tuning cylinders aren't scrolls, but can still be stored in a scroll rack.

Example localization for these keys:
```
	"handbook-storable-bookshelf":  "• <a href=\"handbooksearch://bookshelf\">Bookshelves</a>",
	"handbook-storable-antlermount": "• <a href=\"handbooksearch://antler mount\">Antler mounts</a>",
	"handbook-storable-scrollrack": "• <a href=\"handbooksearch://scroll rack\">Scroll racks</a>",
```
I suggest a search rather than a direct link because these blocks come in multiple variants.