### PR TITLE
Allow Containers and Contents to set Custom Drink Speed

### DIFF
--- a/Systems/Liquid/WaterTightContainableProps.cs
+++ b/Systems/Liquid/WaterTightContainableProps.cs
@@ -9,6 +9,7 @@ namespace Vintagestory.GameContent
     public class LiquidTopOpenContainerProps
     {
         public float CapacityLitres = 10;
+        public float DrinkSpeed = 1;
         public float TransferSizeLitres = 0.01f;
         public AssetLocation EmptyShapeLoc;
         public AssetLocation OpaqueContentShapeLoc;
@@ -34,6 +35,7 @@ namespace Vintagestory.GameContent
         public int MaxStackSize;
         public int GlowLevel;
         public FoodNutritionProperties NutritionPropsPerLitre;
+        public float DrinkSpeed = 1;
         public FoodNutritionProperties NutritionPropsPerLitreWhenInMeal = null;
 
         public enum EnumSpilledAction { PlaceBlock, DropContents };


### PR DESCRIPTION
This PR allows to make containers and their contents more moddable by allowing custom drink speed and modifiers.
Containers can now define a `drinkSpeed` attribute (defaults: `1`) which sets the liquid quantity consumed when drinking. This can be defined just like `capacityLitres` either as a general attribute or as a part of `liquidContainerProps`. (This solution was chosen for consistency with the current code, alternatively one could adopt the second option only to have less ambiguity). `WaterTightContainableProps` have been also updated to allow a drink speed modifier, which would allow certain liquids (perhaps honey?) to have lower drink speed. At the moment this value used by multiplying the current drink speed, so that the liquid itself doesn't override the container's speed, and both are taken into account.

Arguably, drink speed should be capped to 1, but that could be achieved by always choosing to use values lower than one for both attributes. This is true for vanilla at the moment (obviously), and modders could potentially benefit from the freedom of a higher value in niche situations, so I haven't capped it here.

To avoid liquids being impossible to drink at all if the minimum amount of litres is higher than the drink speed, the actual drink speed value is capped from below by `1.0f/ItemsPerLitre`.