### PR TITLE
Add inForgeTransform to .tfedit ui

### DIFF
--- a/BlockEntity/BEForge.cs
+++ b/BlockEntity/BEForge.cs
@@ -6,6 +6,7 @@ using Vintagestory.API.Common;
 using Vintagestory.API.Config;
 using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
+using Vintagestory.Client.NoObf;
 
 #nullable disable
 
@@ -39,8 +40,19 @@ namespace Vintagestory.GameContent
                 ICoreClientAPI capi = (ICoreClientAPI)api;
                 capi.Event.RegisterRenderer(renderer = new ForgeContentsRenderer(Pos, capi), EnumRenderStage.Opaque, "forge");
                 renderer.SetContents(contents, fuelLevel, burning, true);
-
                 RegisterGameTickListener(OnClientTick, 50);
+
+                // Regen mesh on transform change
+                api.Event.RegisterEventBusListener(
+                    (string _, ref EnumHandling _, IAttribute _) =>
+                        renderer.RegenMesh(), filterByEventName: "genjsontransform");
+                // Add inForgeTransform to .tfedit extra transforms
+                if (!GuiDialogTransformEditor.extraTransforms?.Any(x => x.AttributeName == "inForgeTransform") == true)
+                    GuiDialogTransformEditor.extraTransforms.Add(new TransformConfig
+                    {
+                        Title = Lang.Get("transform-inforge"),
+                        AttributeName = "inForgeTransform"
+                    });
             }
 
             RegisterGameTickListener(OnCommonTick, 200);

--- a/BlockEntityRenderer/ForgeContentsRenderer.cs
+++ b/BlockEntityRenderer/ForgeContentsRenderer.cs
@@ -33,7 +33,7 @@ namespace Vintagestory.GameContent
 
         Matrixf ModelMat = new Matrixf();
 
-        
+
 
         public double RenderOrder
         {
@@ -62,7 +62,7 @@ namespace Vintagestory.GameContent
         {
             this.pos = pos;
             this.capi = capi;
-            
+
             Block block = capi.World.GetBlock(new AssetLocation("forge"));
 
             coaltexpos = capi.BlockTextureAtlas.GetPosition(block, "coal");
@@ -99,7 +99,7 @@ namespace Vintagestory.GameContent
         }
 
 
-        void RegenMesh()
+        public void RegenMesh()
         {
             workItemMeshRef?.Dispose();
             workItemMeshRef = null;
@@ -185,7 +185,7 @@ namespace Vintagestory.GameContent
             prog.AddRenderFlags = 0;
             prog.ExtraGodray = 0;
             prog.OverlayOpacity = 0;
-            
+
 
             if (stack != null && workItemMeshRef != null)
             {
@@ -198,13 +198,13 @@ namespace Vintagestory.GameContent
                 prog.NormalShaded = 1;
                 prog.RgbaLightIn = lightrgbs;
                 prog.RgbaGlowIn = new Vec4f(glowColor[0], glowColor[1], glowColor[2], extraGlow / 255f);
-                
+
                 prog.ExtraGlow = extraGlow;
                 prog.Tex2D = textureId;
                 prog.ModelMatrix = ModelMat.Identity().Translate(pos.X - camPos.X, pos.Y - camPos.Y + 10 / 16f + fuelLevel * 0.65f, pos.Z - camPos.Z).Values;
                 prog.ViewMatrix = rpi.CameraMatrixOriginf;
                 prog.ProjectionMatrix = rpi.CurrentProjectionMatrix;
-                
+
                 rpi.RenderMesh(workItemMeshRef);
             }
 
@@ -234,7 +234,7 @@ namespace Vintagestory.GameContent
                 prog.TempGlowMode = 1;
 
                 int glow = 255 - (int)(flicker * 50);
-                
+
                 prog.ExtraGlow = burning ? glow : 0;
 
                 // The coal or embers
@@ -245,7 +245,7 @@ namespace Vintagestory.GameContent
                 prog.ProjectionMatrix = rpi.CurrentProjectionMatrix;
 
                 rpi.RenderMesh(burning ? emberQuadRef : coalQuadRef);
-                
+
             }
 
 


### PR DESCRIPTION
This PR adds the `inForgeTransform` transform to the `.tfedit` ui by registering the extra transform in the `Initialize` method
Additionally, it makes `ForgeContentsRederer.RegenMesh()` public, so that it can subscribe a call to `RegenMesh` when the `genjsontransform` event is fired (which would regen the forge mesh when the transform changes).

The code expects the lang key `"transform-inforge"` to be:
```json
"transform-inforge": "In forge"
```