### PR TITLE
Fix for rendering mechanical device texture variants

### DIFF
--- a/Systems/MechanicalPower/Renderer/MechNetworkRenderer.cs
+++ b/Systems/MechanicalPower/Renderer/MechNetworkRenderer.cs
@@ -57,7 +57,7 @@ namespace Vintagestory.GameContent.Mechanics
                 rendererCode = device.Block.Attributes?["mechanicalPower"]?["renderer"].AsString("generic");
             }
 
-            int hashCode = device.Shape.GetHashCode() + rendererCode.GetHashCode();
+            int hashCode = device.Shape.GetHashCode() + rendererCode.GetHashCode() + device.Block.Textures.GetHashCode();
 
             if (!MechBlockRendererByShape.TryGetValue(hashCode, out index))
             {


### PR DESCRIPTION
PR for issue [6353 from issue tracker](https://github.com/anegostudios/VintageStory-Issues/issues/6353).

When rendering a mechanical power device variants with different textures do not render correctly. This is because the texture for the first variant to be placed is used for all variants since only the hash code of the shape is considered.