### PR TITLE
Handbook extra section mod compatibility patch

### DIFF
--- a/Systems/Handbook/CollectibleBehaviorHandbookTextAndExtraInfo.cs
+++ b/Systems/Handbook/CollectibleBehaviorHandbookTextAndExtraInfo.cs
@@ -2211,9 +2211,9 @@ namespace Vintagestory.GameContent
             }
 
             string domainAndType = collObj.Code.Domain + ":" + stack.Class.Name();
-            string code = collObj.Code.ToShortString();
-            string langExtraSectionTitle = Lang.GetMatchingIfExists(domainAndType + "-handbooktitle-" + code);
-            string langExtraSectionText = Lang.GetMatchingIfExists(domainAndType + "-handbooktext-" + code);
+            string path = collObj.Code.Path;
+            string langExtraSectionTitle = Lang.GetMatchingIfExists(domainAndType + "-handbooktitle-" + path);
+            string langExtraSectionText = Lang.GetMatchingIfExists(domainAndType + "-handbooktext-" + path);
 
             if (langExtraSectionTitle != null || langExtraSectionText != null)
             {


### PR DESCRIPTION
Small fix but will probably go a long way. Today I struggled to make handbook content for my modded items cause it wasn't as straightforward as implied by the language files.

### Expected Behaviour (lang file)
```JSON
{
  "{domain}:block-handbooktext-{code-with-variants}": "Beautiful handbook text here..."
}
```

### Actual Behaviour (what actually ended up working)
```JSON
{
  "{domain}:block-handbooktext-{domain}:{code-with-variants}": "Beautiful handbook text here..."
}
```
to give an example:
```JSON
{
  "examplemod:block-handbooktext-examplemod:exampleblock-blue": "This is the blue variation."
}
```

### Reason
The lang lookup for generating the extra sections uses the ToShortString function, which only returns "just" the path if it's the default domain. For modded domains it still uses the combination of domain and path with yet another colon. To improve on modded handbook content, I suggest using only the path for looking up the handbook text and title.
**Edit:** not actually using _only_ the path... The domain gets added either way (at the very start of the lang lookup), so it would just skip the second addition of the domain.