### PR TITLE
Update MechanicalPowerMod, BEClayOven

### DIFF
--- a/Systems/Cooking/Clayoven/BEClayOven.cs
+++ b/Systems/Cooking/Clayoven/BEClayOven.cs
@@ -539,20 +539,15 @@ namespace Vintagestory.GameContent
 
                 if (resultCode != null)
                 {
-                    ItemStack resultStack = null;
-                    if (slot.Itemstack.Class == EnumItemClass.Block)
-                    {
-                        Block block = Api.World.GetBlock(new AssetLocation(resultCode));
-                        if (block != null)
-                        {
-                            resultStack = new ItemStack(block);
-                        }
-                    }
-                    else
-                    {
-                        Item item = Api.World.GetItem(new AssetLocation(resultCode));
-                        if (item != null) resultStack = new ItemStack(item);
-                    }
+                    ItemStack resultStack = (ItemStack)null;
+                    
+                    Block block = this.Api.World.GetBlock(new AssetLocation(resultCode));
+                    if (block != null)
+                        resultStack = new ItemStack(block);
+                    
+                    Item item = this.Api.World.GetItem(new AssetLocation(resultCode));
+                    if (item != null)
+                        resultStack = new ItemStack(item);
 
 
                     if (resultStack != null)

--- a/Systems/Cooking/Clayoven/BEClayOven.cs
+++ b/Systems/Cooking/Clayoven/BEClayOven.cs
@@ -92,7 +92,18 @@ namespace Vintagestory.GameContent
                 if (slot == null) return EnumOvenContentMode.Firewood;
 
                 BakingProperties bakingProps = BakingProperties.ReadFrom(slot.Itemstack);
-                if (bakingProps == null) return EnumOvenContentMode.Firewood;
+                if (bakingProps == null)
+                {
+                    if (slot.Itemstack.Class == EnumItemClass.Item)
+                    {
+                        if (slot.Itemstack.Item.Code.Path.Contains("firewood"))
+                            return EnumOvenContentMode.Firewood;
+                        else
+                            return EnumOvenContentMode.Quadrants;
+                    }
+
+                    return EnumOvenContentMode.Firewood;
+                }
 
                 return bakingProps.LargeItem ? EnumOvenContentMode.SingleCenter : EnumOvenContentMode.Quadrants;
             }

--- a/Systems/MechanicalPower/MechanicalPowerMod.cs
+++ b/Systems/MechanicalPower/MechanicalPowerMod.cs
@@ -231,6 +231,8 @@ namespace Vintagestory.GameContent.Mechanics
                 if (newnode.OutFacingForNetworkDiscovery != null && (nowRemovedNode == null || newnode.Position != nowRemovedNode.Position))
                 {
                     MechanicalNetwork newnetwork = newnode.CreateJoinAndDiscoverNetwork(newnode.OutFacingForNetworkDiscovery);
+                    if (newnetwork==null)
+                        continue;
                     bool reversed = newnode.GetPropagationDirection() == oldTurnDir.Opposite;
                     newnetwork.Speed = reversed ? -network.Speed : network.Speed;
                     newnetwork.AngleRad = network.AngleRad;
@@ -382,3 +384,4 @@ namespace Vintagestory.GameContent.Mechanics
 
     }
 }
+


### PR DESCRIPTION
**Issue № 1.** This patch introduces a fix for the null error after CreateJoinAndDiscoverNetwork. This is due to the fact that some of my devices connect to the mechanical network after the initialization phase. Therefore, sometimes, especially at the boundaries of loaded chunks, CreateJoinAndDiscoverNetwork can return null . Adding this protection doesn't change anything. However, my devices from the mod work perfectly and don't interfere with chunk loading.
[Experiencing the old bug, probably the same as in Electricity](https://github.com/tehtelev/ElectricalProgressive/issues/5)

<img width="1920" height="1017" alt="2025-10-12_20-30-39" src="https://github.com/user-attachments/assets/35900cf9-3d66-428b-9cf0-ea1a693d097b" />
