### PR TITLE
IInFirepitRendererSupplier tightly coupled to BlockEntityFirepit

### DIFF
--- a/BlockEntity/Firepit/FirepitInterfaces.cs
+++ b/BlockEntity/Firepit/FirepitInterfaces.cs
@@ -60,7 +60,7 @@ namespace Vintagestory.GameContent
         /// <param name="world"></param>
         /// <param name="pos"></param>
         /// <returns></returns>
-        IInFirepitRenderer GetRendererWhenInFirepit(ItemStack stack, BlockEntityFirepit firepit, bool forOutputSlot);
+        IInFirepitRenderer GetRendererWhenInFirepit(ItemStack stack, BlockEntity firepit, bool forOutputSlot);
 
         /// <summary>
         /// The model type the firepit should be using while you render your custom item
@@ -69,7 +69,7 @@ namespace Vintagestory.GameContent
         /// <param name="world"></param>
         /// <param name="pos"></param>
         /// <returns></returns>
-        EnumFirepitModel GetDesiredFirepitModel(ItemStack stack, BlockEntityFirepit firepit, bool forOutputSlot);
+        EnumFirepitModel GetDesiredFirepitModel(ItemStack stack, BlockEntity firepit, bool forOutputSlot);
     }
 
 }

--- a/Systems/Cooking/BlockCookedContainer.cs
+++ b/Systems/Cooking/BlockCookedContainer.cs
@@ -493,12 +493,12 @@ namespace Vintagestory.GameContent
         }
 
 
-        public IInFirepitRenderer GetRendererWhenInFirepit(ItemStack stack, BlockEntityFirepit firepit, bool forOutputSlot)
+        public IInFirepitRenderer GetRendererWhenInFirepit(ItemStack stack, BlockEntity firepit, bool forOutputSlot)
         {
             return new PotInFirepitRenderer(api as ICoreClientAPI, stack, firepit.Pos, forOutputSlot);
         }
 
-        public EnumFirepitModel GetDesiredFirepitModel(ItemStack stack, BlockEntityFirepit firepit, bool forOutputSlot)
+        public EnumFirepitModel GetDesiredFirepitModel(ItemStack stack, BlockEntity firepit, bool forOutputSlot)
         {
             return EnumFirepitModel.Wide;
         }

--- a/Systems/Cooking/BlockCookingContainer.cs
+++ b/Systems/Cooking/BlockCookingContainer.cs
@@ -341,12 +341,12 @@ namespace Vintagestory.GameContent
             return stacks.ToArray();
         }
 
-        public IInFirepitRenderer GetRendererWhenInFirepit(ItemStack stack, BlockEntityFirepit firepit, bool forOutputSlot)
+        public IInFirepitRenderer GetRendererWhenInFirepit(ItemStack stack, BlockEntity firepit, bool forOutputSlot)
         {
             return new PotInFirepitRenderer(api as ICoreClientAPI, stack, firepit.Pos, forOutputSlot);
         }
 
-        public EnumFirepitModel GetDesiredFirepitModel(ItemStack stack, BlockEntityFirepit firepit, bool forOutputSlot)
+        public EnumFirepitModel GetDesiredFirepitModel(ItemStack stack, BlockEntity firepit, bool forOutputSlot)
         {
             return EnumFirepitModel.Wide;
         }


### PR DESCRIPTION
Regarding both
`IInFirepitRendererSupplier`
  `.GetRendererWhenInFirepit(_, BlockEntityFirepit firepit, _)`
  `.GetDesiredFirepitModel(_, BlockEntityFirepit firepit, _);`

Implementations only reference (BlockEntity)firepit.Pos
Requesting interface updated to reflect, so Renderers can be reused as a generic 'firepit stack' renderer in other developments.

Inherited classes could still `if(firepit is BlockEntityFirepit bef)` as requireded