### PR TITLE
Prevent taking one portion of liquid being overwritten by drinking

### DIFF
--- a/Systems/Liquid/BlockLiquidContainerBase.cs
+++ b/Systems/Liquid/BlockLiquidContainerBase.cs
@@ -119,7 +119,8 @@ namespace Vintagestory.GameContent
             if (Attributes?["capacityLitres"].Exists == true)
             {
                 capacityLitresFromAttributes = Attributes["capacityLitres"].AsInt(10);
-            } else
+            }
+            else
             {
                 var props = Attributes?["liquidContainerProps"]?.AsObject<LiquidTopOpenContainerProps>(null, Code.Domain);
                 if (props != null)
@@ -131,7 +132,8 @@ namespace Vintagestory.GameContent
             if (Attributes?["drinkPortionSize"].Exists == true)
             {
                 drinkPortionSizeFromAttributes = Attributes["drinkPortionSize"].AsInt(1);
-            } else
+            }
+            else
             {
                 var props = Attributes?["liquidContainerProps"]?.AsObject<LiquidTopOpenContainerProps>(null, Code.Domain);
                 if (props != null)
@@ -156,7 +158,7 @@ namespace Vintagestory.GameContent
                 foreach (CollectibleObject obj in api.World.Collectibles)
                 {
                     if (obj is BlockLiquidContainerBase blc && blc.IsTopOpened && blc.AllowHeldLiquidTransfer)
-                    liquidContainerStacks.Add(new ItemStack(obj));
+                        liquidContainerStacks.Add(new ItemStack(obj));
                 }
 
                 var lcstacks = liquidContainerStacks.ToArray();
@@ -331,7 +333,7 @@ namespace Vintagestory.GameContent
             if (becontainer == null) return null;
 
             int slotid = GetContainerSlotId(pos);
-            if (slotid >=becontainer.Inventory.Count) return null;
+            if (slotid >= becontainer.Inventory.Count) return null;
 
             ItemStack? stack = becontainer.Inventory[slotid]?.Itemstack;
             if (stack == null) return null;
@@ -796,7 +798,7 @@ namespace Vintagestory.GameContent
                 float healthLossMul = GlobalConstants.FoodSpoilageHealthLossMul(spoilState, liquidStack, byEntity);
 
                 int itemPortionsDrank = SplitStackAndPerformAction(byEntity, slot, (stack) => TryTakeLiquid(stack, litresToDrink)?.StackSize ?? 0);
-                if(itemPortionsDrank == 0) return;
+                if (itemPortionsDrank == 0) return;
                 float mul = itemPortionsDrank / containableProps.ItemsPerLitre;
 
                 byEntity.ReceiveSaturation(nutriProps.Satiety * satLossMul * mul, nutriProps.FoodCategory);
@@ -993,7 +995,7 @@ namespace Vintagestory.GameContent
             }
 
 
-            int moved = SplitStackAndPerformAction(byEntity, containerSlot, (stack) => { SetContent(stack, null); return contentStack.StackSize; } );
+            int moved = SplitStackAndPerformAction(byEntity, containerSlot, (stack) => { SetContent(stack, null); return contentStack.StackSize; });
 
             DoLiquidMovedEffects(byPlayer, contentStack, moved, EnumLiquidDirection.Pour);
             return true;


### PR DESCRIPTION
Fix anegostudios/VintageStory-Issues#5840 and anegostudios/VintageStory-Issues#1697

Calling up to Collectible.OnHeldInteractStart too early was hijacking the control flow and branching into tryEatBegin, so we have to delay that until confirming that we don't need to do any liquid interactions. Shift+RMB when looking at the side of the block still results in ground storage.

It seems like liquid containers should maybe have block interaction priority, but I didn't want to mess with that and potentially create much bigger problems.

Vanilla:

https://github.com/user-attachments/assets/e73ec58d-852b-425f-a0fe-acaa7e9280bd

Fixed:

https://github.com/user-attachments/assets/31217836-301a-42c3-80ab-ec4807e125be

