### PR TITLE
Optimization of the firepit and the pot

### DIFF
--- a/BlockEntity/Firepit/BEFirepit.cs
+++ b/BlockEntity/Firepit/BEFirepit.cs
@@ -18,7 +18,8 @@ namespace Vintagestory.GameContent
 
         // Temperature before the half second tick
         public float prevFurnaceTemperature = 20;
-
+        // flag to determine whether static or dynamic rendering is used
+        private bool prevForceStatic = false;
         // Current temperature of the furnace
         public float furnaceTemperature = 20;
         // Current temperature of the ore (Degree Celsius * deg
@@ -624,16 +625,40 @@ namespace Vintagestory.GameContent
 
         void UpdateRenderer()
         {
-            if (renderer == null) return;
+            if (renderer == null)
+                return;
 
-            ItemStack contentStack = inputStack == null ? outputStack : inputStack;
+
+            bool forceStatic = forceStaticMesh();
+
+            // If the mode has changed, we re-tessellate the block
+            if (forceStatic != prevForceStatic)
+            {
+                MarkDirty(true);
+                prevForceStatic = forceStatic;
+            }
+
+            // if we need static rendering of the pot mesh
+            if (forceStatic)
+            {
+                // Remove the dynamic renderer if there was one
+                if (renderer.contentStackRenderer != null)
+                {
+                    renderer.contentStackRenderer.Dispose();
+                    renderer.contentStackRenderer = null;
+                }
+                renderer.SetContents(null, null);
+                return;
+            }
+
+            ItemStack contentStack = inputStack ?? outputStack;
 
             bool useOldRenderer =
-                renderer.ContentStack != null &&
-                renderer.contentStackRenderer != null &&
-                contentStack?.Collectible is IInFirepitRendererSupplier &&
-                renderer.ContentStack.Equals(Api.World, contentStack, GlobalConstants.IgnoredStackAttributes)
-            ;
+                    renderer.ContentStack != null &&
+                    renderer.contentStackRenderer != null &&
+                    contentStack?.Collectible is IInFirepitRendererSupplier &&
+                    renderer.ContentStack.Equals(Api.World, contentStack, GlobalConstants.IgnoredStackAttributes)
+                ;
 
             if (useOldRenderer) return; // Otherwise the cooking sounds restarts all the time
 
@@ -844,24 +869,72 @@ namespace Vintagestory.GameContent
 
         public EnumFirepitModel CurrentModel { get; private set; }
 
+        public bool forceStaticMesh()
+        {
+            return (inputStack != null && furnaceTemperature < 50) && (inputStack?.Block?.Code.Path.Contains("claypot") ?? false);
+        }
+
+
+
+        private void AddPotStaticMesh(ITerrainMeshPool mesher, ITesselatorAPI tesselator, ItemStack potStack)
+        {
+            Block potBlock = potStack.Block;
+            if (potBlock == null) return;
+
+            // Unique keys for each pot type
+            string potKey = "pot-static-" + potBlock.Code;
+            string lidKey = "lid-static-" + potBlock.Code;
+
+            // Get or create a pot mesh
+            MeshData potMesh = ObjectCacheUtil.GetOrCreate<MeshData>(Api, potKey, () =>
+            {
+                MeshData mesh;
+                tesselator.TesselateShape(potBlock, Shape.TryGet(Api, "shapes/block/clay/pot-opened-empty.json"), out mesh);
+                mesh.Translate(0, 1 / 16f, 0);
+                return mesh;
+            });
+            mesher.AddMeshData(potMesh);
+
+            // Get or create a lid mesh
+            MeshData lidMesh = ObjectCacheUtil.GetOrCreate<MeshData>(Api, lidKey, () =>
+            {
+                MeshData mesh;
+                tesselator.TesselateShape(potBlock, Shape.TryGet(Api, "shapes/block/clay/pot-part-lid.json"), out mesh);
+                mesh.Translate(0, 6.5f / 16f, 0);
+                return mesh;
+            });
+            mesher.AddMeshData(lidMesh);
+        }
+
+
         public override bool OnTesselation(ITerrainMeshPool mesher, ITesselatorAPI tesselator)
         {
-            if (Block == null || Block.Code.Path.Contains("construct")) return false;
+            if (Block == null || Block.Code.Path.Contains("construct"))
+                return false;
 
-            
-            ItemStack contentStack = inputStack == null ? outputStack : inputStack;
-            MeshData contentmesh = getContentMesh(contentStack, tesselator);
-            if (contentmesh != null)
+
+
+            if (forceStaticMesh())
             {
-                mesher.AddMeshData(contentmesh);
+                // For the cold pot we use a static mesh with a lid
+                AddPotStaticMesh(mesher, tesselator, inputStack);
+                CurrentModel = EnumFirepitModel.Wide; // We indicate that there is a pot inside
+            }
+            else
+            {
+                ItemStack contentStack = inputStack ?? outputStack;
+                // Otherwise, the standard logic for getting the content mesh
+                MeshData contentmesh = getContentMesh(contentStack, tesselator);
+                if (contentmesh != null) mesher.AddMeshData(contentmesh);
+                // getContentMesh sets CurrentModel itself
             }
 
+            // The mesh of the block itself (fire/coals) is added as usual
             string burnState = Block.Variant["burnstate"];
             string contentState = CurrentModel.ToString().ToLowerInvariant();
             if (burnState == "cold" && fuelSlot.Empty) burnState = "extinct";
-            if (burnState == null) return true;
-
-            mesher.AddMeshData(getOrCreateMesh(burnState, contentState));
+            if (burnState != null)
+                mesher.AddMeshData(getOrCreateMesh(burnState, contentState));
 
             return true;
         }
@@ -969,3 +1042,4 @@ namespace Vintagestory.GameContent
         }
     }
 }
+

--- a/BlockEntityRenderer/PotInFirepitRenderer.cs
+++ b/BlockEntityRenderer/PotInFirepitRenderer.cs
@@ -32,7 +32,7 @@ namespace Vintagestory.GameContent
             this.pos = pos;
             this.isInOutputSlot = isInOutputSlot;
 
-            potPos = new Vec3d(pos.X + 0.5d, pos.Y + 0.5d, pos.Z + 0.5d);  // Центр костра
+            potPos = new Vec3d(pos.X + 0.5d, pos.Y + 0.5d, pos.Z + 0.5d);  // Firepit center
             aabb = new Cuboidd(pos.X, pos.Y, pos.Z, pos.X + 1, pos.Y + 1, pos.Z + 1);
 
             BlockCookedContainer potBlock = capi.World.GetBlock(stack.Collectible.CodeWithVariant("type", "cooked")) as BlockCookedContainer;

--- a/BlockEntityRenderer/PotInFirepitRenderer.cs
+++ b/BlockEntityRenderer/PotInFirepitRenderer.cs
@@ -9,7 +9,7 @@ namespace Vintagestory.GameContent
     public class PotInFirepitRenderer : IInFirepitRenderer
     {
         public double RenderOrder => 0.5;
-        public int RenderRange => 20;
+        public int RenderRange => 200;
 
         ICoreClientAPI capi;
         MultiTextureMeshRef potWithFoodRef;
@@ -17,6 +17,9 @@ namespace Vintagestory.GameContent
         MultiTextureMeshRef lidRef;
         BlockPos pos;
         float temp;
+
+        Vec3d potPos;
+        Cuboidd aabb;
 
         ILoadedSound cookingSound;
 
@@ -28,6 +31,9 @@ namespace Vintagestory.GameContent
             this.capi = capi;
             this.pos = pos;
             this.isInOutputSlot = isInOutputSlot;
+
+            potPos = new Vec3d(pos.X + 0.5d, pos.Y + 0.5d, pos.Z + 0.5d);  // Центр костра
+            aabb = new Cuboidd(pos.X, pos.Y, pos.Z, pos.X + 1, pos.Y + 1, pos.Z + 1);
 
             BlockCookedContainer potBlock = capi.World.GetBlock(stack.Collectible.CodeWithVariant("type", "cooked")) as BlockCookedContainer;
 
@@ -59,9 +65,25 @@ namespace Vintagestory.GameContent
 
         public void OnRenderFrame(float deltaTime, EnumRenderStage stage)
         {
+            if (capi?.Render == null)
+                return;
+
+
             IRenderAPI rpi = capi.Render;
             Vec3d camPos = capi.World.Player.Entity.CameraPos;
 
+            // Checking the distance
+            double distanceSq = potPos.SquareDistanceTo(camPos);
+            if (distanceSq > RenderRange * RenderRange)
+                return;  // Skip if outside RenderRange
+
+            // Frustum-culling according to AABB
+            FrustumCulling culler = rpi.DefaultFrustumCuller;
+
+            if (!IsAABBInFrustum(culler, aabb))
+                return; // Skip if outside frustum
+
+            // Rest of rendering
             rpi.GlDisableCullFace();
             rpi.GlToggleBlend(true);
 
@@ -82,11 +104,10 @@ namespace Vintagestory.GameContent
 
 
             prog.ModelMatrix = ModelMat
-                .Identity()
-                .Translate(pos.X - camPos.X + 0.001f, pos.Y - camPos.Y, pos.Z - camPos.Z - 0.001f)
-                .Translate(0f, 1 / 16f, 0f)
-                .Values
-            ;
+                    .Identity()
+                    .Translate(pos.X - camPos.X + 0.001f, pos.Y - camPos.Y, pos.Z - camPos.Z - 0.001f)
+                    .Translate(0f, 1 / 16f, 0f)
+                    .Values;
 
             prog.ViewMatrix = rpi.CameraMatrixOriginf;
             prog.ProjectionMatrix = rpi.CurrentProjectionMatrix;
@@ -101,15 +122,14 @@ namespace Vintagestory.GameContent
                 float cookIntensity = GameMath.Clamp((temp - 50) / 50, 0, 1);
 
                 prog.ModelMatrix = ModelMat
-                    .Identity()
-                    .Translate(pos.X - camPos.X, pos.Y - camPos.Y, pos.Z - camPos.Z)
-                    .Translate(0, 6.5f / 16f, 0)
-                    .Translate(-origx, 0, -origz)
-                    .RotateX(cookIntensity * GameMath.Sin(capi.World.ElapsedMilliseconds / 50f) / 60)
-                    .RotateZ(cookIntensity * GameMath.Sin(capi.World.ElapsedMilliseconds / 50f) / 60)
-                    .Translate(origx, 0, origz)
-                    .Values
-                ;
+                        .Identity()
+                        .Translate(pos.X - camPos.X, pos.Y - camPos.Y, pos.Z - camPos.Z)
+                        .Translate(0, 6.5f / 16f, 0)
+                        .Translate(-origx, 0, -origz)
+                        .RotateX(cookIntensity * GameMath.Sin(capi.World.ElapsedMilliseconds / 50f) / 60)
+                        .RotateZ(cookIntensity * GameMath.Sin(capi.World.ElapsedMilliseconds / 50f) / 60)
+                        .Translate(origx, 0, origz)
+                        .Values;
                 prog.ViewMatrix = rpi.CameraMatrixOriginf;
                 prog.ProjectionMatrix = rpi.CurrentProjectionMatrix;
 
@@ -119,6 +139,30 @@ namespace Vintagestory.GameContent
 
             prog.Stop();
         }
+
+        // Auxiliary method for the AABB vs Frustum test
+        private bool IsAABBInFrustum(FrustumCulling culler, Cuboidd aabb)
+        {
+            double centerX = (aabb.MinX + aabb.MaxX) * 0.5;
+            double centerY = (aabb.MinY + aabb.MaxY) * 0.5;
+            double centerZ = (aabb.MinZ + aabb.MaxZ) * 0.5;
+            double dx = aabb.MaxX - aabb.MinX;
+            double dy = aabb.MaxY - aabb.MinY;
+            double dz = aabb.MaxZ - aabb.MinZ;
+
+            Sphere sphere = new Sphere(
+                (float)centerX,   
+                (float)centerY,
+                (float)centerZ,
+                (float)dx,
+                (float)dy,
+                (float)dz
+            );
+
+            return culler.InFrustum(sphere);
+        }
+
+
 
         public void OnUpdate(float temperature)
         {


### PR DESCRIPTION
Improved cooking pot rendering in a campfire. The main issue is that a cooking pot is always rendered when it's in a campfire, even if nothing is being cooked in it. Another issue is that such campfires can also be found in ruins. Moreover, there may be dozens of such ruins in the rendering area, which the player may never find. However, the cooking pot will always render.
**Suggested improvements:**
1) The cooking pot renderer now has a clipping based on the player's view cone and the RenderRange distance. I chose a distance of 200 because at that distance, the campfire turns into just a few pixels on the screen.
2) Additionally, following Tyrone's suggestion, a system was implemented that renders a static mesh of the cooking pot when it's cold. When the temperature exceeds 50 degrees, the dynamic renderer will be activated for the cooking pot.

This makes it possible to reduce the impact of campfires on player tickrates to zero, including in settlements.

**My tests with 1000 blocks rendered**

Vanilla
<img width="747" height="750" alt="1024 ванила" src="https://github.com/user-attachments/assets/73ce75f4-432a-419c-8eb5-30a376ee1c84" />

With revision
<img width="599" height="756" alt="1024 мой" src="https://github.com/user-attachments/assets/6b2aa3fc-d512-43a3-9b42-736afa94fd90" />


**Video of testing**
[Vanilla (test on 1.21.6)](https://youtu.be/6snnBBEkPyY)
[Visibility cutoff only](https://youtu.be/xEOmgS2TKlI)
[Visibility cutoff + static meshes](https://youtu.be/_7Bo6GG8qzo)