### PR TITLE
Extract data manipulation code into separate methods for ore map UI creation

### DIFF
--- a/Systems/Prospecting/ItemProspectingPick.cs
+++ b/Systems/Prospecting/ItemProspectingPick.cs
@@ -335,9 +335,11 @@ namespace Vintagestory.GameContent
 
                 if (totalFactor > 0)
                 {
-                    var reading = new OreReading();
-                    reading.TotalFactor = totalFactor;
-                    reading.PartsPerThousand = ppt;
+                    var reading = new OreReading {
+                        DepositCode = val.Key,
+                        TotalFactor = totalFactor,
+                        PartsPerThousand = ppt
+                    };
                     readings.OreReadings[val.Key] = reading;
                 }
             }

--- a/Systems/Prospecting/ItemProspectingPick.cs
+++ b/Systems/Prospecting/ItemProspectingPick.cs
@@ -315,9 +315,8 @@ namespace Vintagestory.GameContent
             PropickReading readings = new PropickReading();
             readings.Position = new Vec3d(pos.X, pos.Y, pos.Z);
 
-            foreach (var val in reg.OreMaps)
+            foreach ((string key, var map) in reg.OreMaps)
             {
-                IntDataMap2D map = val.Value;
                 int noiseSize = map.InnerSize;
 
                 float posXInRegionOre = (float)lx / regsize * noiseSize;
@@ -326,21 +325,21 @@ namespace Vintagestory.GameContent
                 int oreDist = map.GetUnpaddedColorLerped(posXInRegionOre, posZInRegionOre);
 
 
-                if (!ppws.depositsByCode.ContainsKey(val.Key))
+                if (!ppws.depositsByCode.ContainsKey(key))
                 {
                     continue;
                 }
 
-                ppws.depositsByCode[val.Key].GetPropickReading(pos, oreDist, blockColumn, out double ppt, out double totalFactor);
+                ppws.depositsByCode[key].GetPropickReading(pos, oreDist, blockColumn, out double ppt, out double totalFactor);
 
                 if (totalFactor > 0)
                 {
                     var reading = new OreReading {
-                        DepositCode = val.Key,
+                        DepositCode = key,
                         TotalFactor = totalFactor,
                         PartsPerThousand = ppt
                     };
-                    readings.OreReadings[val.Key] = reading;
+                    readings.OreReadings[key] = reading;
                 }
             }
 

--- a/Systems/Prospecting/OreMapLayer/OreMapComponent.cs
+++ b/Systems/Prospecting/OreMapLayer/OreMapComponent.cs
@@ -13,6 +13,7 @@ namespace Vintagestory.GameContent
     {
         Vec2f viewPos = new Vec2f();
         Vec4f color = new Vec4f();
+        PropickReading reading;
         int waypointIndex;
         Matrixf mvMat = new Matrixf();
         OreMapLayer oreLayer;
@@ -20,7 +21,7 @@ namespace Vintagestory.GameContent
 
         public static float IconScale = 0.85f;
         public string filterByOreCode;
-        public PropickReading reading;
+        public PropickReading Reading => reading;
 
         public OreMapComponent(int waypointIndex, PropickReading reading, OreMapLayer wpLayer, ICoreClientAPI capi, string filterByOreCode) : base(capi)
         {
@@ -40,7 +41,7 @@ namespace Vintagestory.GameContent
                     col = GuiStyle.DamageColorGradient[(int)Math.Min(99, oreReading.TotalFactor * 150)];
                 } else {
                     // Or throw ?
-                    capi.Logger.Warning("Unhandled oremap filter code: {0}", filterByOreCode);
+                    capi.Logger.Warning("Ore Map filter element has unhandled non-dictionary value: {0}", filterByOreCode);
                 }
             }
 

--- a/Systems/Prospecting/OreMapLayer/OreMapComponent.cs
+++ b/Systems/Prospecting/OreMapLayer/OreMapComponent.cs
@@ -13,7 +13,6 @@ namespace Vintagestory.GameContent
     {
         Vec2f viewPos = new Vec2f();
         Vec4f color = new Vec4f();
-        PropickReading reading;
         int waypointIndex;
         Matrixf mvMat = new Matrixf();
         OreMapLayer oreLayer;
@@ -21,17 +20,30 @@ namespace Vintagestory.GameContent
 
         public static float IconScale = 0.85f;
         public string filterByOreCode;
+        public PropickReading reading;
 
         public OreMapComponent(int waypointIndex, PropickReading reading, OreMapLayer wpLayer, ICoreClientAPI capi, string filterByOreCode) : base(capi)
         {
             this.waypointIndex = waypointIndex;
             this.reading = reading;
             this.oreLayer = wpLayer;
+            this.filterByOreCode =  filterByOreCode;
 
+            GetComponentColor();
+        }
+
+        private void GetComponentColor() {
             int col = GuiStyle.DamageColorGradient[(int)Math.Min(99, reading.HighestReading * 150)];
-            if (filterByOreCode != null) col = GuiStyle.DamageColorGradient[(int)Math.Min(99, reading.OreReadings[filterByOreCode].TotalFactor * 150)];
 
-            this.color = new Vec4f();
+            if (filterByOreCode != null) {
+                if (reading.OreReadings.TryGetValue(filterByOreCode, out var oreReading)) {
+                    col = GuiStyle.DamageColorGradient[(int)Math.Min(99, oreReading.TotalFactor * 150)];
+                } else {
+                    // Or throw ?
+                    capi.Logger.Warning("Unhandled oremap filter code: {0}", filterByOreCode);
+                }
+            }
+
             ColorUtil.ToRGBAVec4f(col, ref color);
             color.W = 1;
         }

--- a/Systems/Prospecting/OreMapLayer/OreMapLayer.cs
+++ b/Systems/Prospecting/OreMapLayer/OreMapLayer.cs
@@ -35,7 +35,7 @@ namespace Vintagestory.GameContent
         CreateIconTextureDelegate oremapIconDele;
         public LoadedTexture oremapTexture;
 
-        string filterByOreCode;
+        public string filterByOreCode;
 
         public OreMapLayer(ICoreAPI api, IWorldMapManager mapSink) : base(api, mapSink)
         {
@@ -73,17 +73,7 @@ namespace Vintagestory.GameContent
         {
             string key = "worldmap-layer-" + LayerGroupCode;
 
-            HashSet<string> orecodes = new HashSet<string>();
-            foreach (var val in ownPropickReadings)
-            {
-                foreach (var reading in val.OreReadings)
-                {
-                    orecodes.Add(reading.Key);
-                }
-            }
-
-            string[] values = new string[] { null }.Append(orecodes.ToArray());
-            string[] names = new string[] { Lang.Get("worldmap-ores-everything") }.Append(orecodes.Select(code => Lang.Get("ore-"+code)).ToArray());
+            GetOreFilterDropdownData(out string[] values, out string[] names);
 
             ElementBounds dlgBounds =
                 ElementStdBounds.AutosizedMainDialog
@@ -111,6 +101,25 @@ namespace Vintagestory.GameContent
             guiDialogWorldMap.Composers[key].Enabled = false;
         }
 
+        private void GetOreFilterDropdownData(out string[] values, out string[] names)
+        {
+            HashSet<string> readingCodes = [];
+            foreach (var reading in ownPropickReadings.SelectMany(val => val.OreReadings)) {
+                readingCodes.Add(reading.Key);
+            }
+
+            // The set in vanilla inherently expects only stripped ore-* values, which would make any nonstandard values annoying to handle
+            // Leaving it as is, but perhaps better to move towards storing the full ore-* code as the key/deposit code value,
+            // reducing the need to append the ore- here and in other such places
+            var sorted = readingCodes
+                .Select(code => (value: code, name: Lang.Get("ore-" + code)))
+                .OrderBy(p => p.name, StringComparer.CurrentCulture)
+                .ToArray();
+
+            // Perhaps instead we could zip these into list of pairs and deconstruct at the caller ? Easier sorting but more cpu processing
+            values = new string[] { null }.Concat(sorted.Select(p => p.value)).ToArray();
+            names = new string[] { Lang.Get("worldmap-ores-everything") }.Concat(sorted.Select(p => p.name)).ToArray();
+        }
 
         private void onSelectionChanged(string code, bool selected)
         {
@@ -244,14 +253,17 @@ namespace Vintagestory.GameContent
             {
                 var reading = ownPropickReadings[i];
 
-                if (filterByOreCode == null || (reading.GetTotalFactor(filterByOreCode) > PropickReading.MentionThreshold))
-                {
-                    OreMapComponent comp = new OreMapComponent(i, reading, this, api as ICoreClientAPI, filterByOreCode);
-                    wayPointComponents.Add(comp);
-                }
+                if (!ShouldDisplayReading(reading)) continue;
+                OreMapComponent comp = new OreMapComponent(i, reading, this, api as ICoreClientAPI, filterByOreCode);
+                wayPointComponents.Add(comp);
             }
 
             wayPointComponents.AddRange(tmpWayPointComponents);
+        }
+
+        private bool ShouldDisplayReading(PropickReading reading) {
+            if(filterByOreCode == null) return true;
+            return reading.GetTotalFactor(filterByOreCode) > PropickReading.MentionThreshold;
         }
 
 

--- a/Systems/Prospecting/OreMapLayer/OreMapLayer.cs
+++ b/Systems/Prospecting/OreMapLayer/OreMapLayer.cs
@@ -75,8 +75,6 @@ namespace Vintagestory.GameContent
             string key = "worldmap-layer-" + LayerGroupCode;
 
             var dropdownData = GetOreFilterDropdownData();
-            var values = dropdownData.Select(e => e.Value).ToArray();
-            var names = dropdownData.Select(e => e.Name).ToArray();
 
             ElementBounds dlgBounds =
                 ElementStdBounds.AutosizedMainDialog
@@ -96,7 +94,7 @@ namespace Vintagestory.GameContent
                     .AddShadedDialogBG(bgBounds, false)
                     .AddDialogTitleBar(Lang.Get("maplayer-prospecting"), () => { guiDialogWorldMap.Composers[key].Enabled = false; })
                     .BeginChildElements(bgBounds)
-                        .AddDropDown(values, names, Math.Max(0, values.IndexOf(filterByOreCode)), onSelectionChanged, ElementBounds.Fixed(0, 30, 160, 35))
+                        .AddDropDown(dropdownData, Math.Max(0, dropdownData.IndexOf(e => e.Value == filterByOreCode)), onSelectionChanged, ElementBounds.Fixed(0, 30, 160, 35))
                     .EndChildElements()
                     .Compose()
             ;
@@ -104,15 +102,15 @@ namespace Vintagestory.GameContent
             guiDialogWorldMap.Composers[key].Enabled = false;
         }
 
-        private (string Value, string Name)[] GetOreFilterDropdownData()
+        private DropDownEntry[] GetOreFilterDropdownData()
         {
             var readings = ownPropickReadings.SelectMany(val => val.OreReadings)
                 .Select(reading => reading.Key)
                 .Distinct()
-                .Select(code => (Code: code, Name: Lang.Get("ore-" + code)))
-                .OrderBy(reading => reading.Name, StringComparer.CurrentCulture);
+                .Select(code => new DropDownEntry(code, Lang.Get("ore-" + code)))
+                .OrderBy(e => e.Name, StringComparer.CurrentCulture);
 
-            return [(null, Lang.Get("worldmap-ores-everything")), ..readings];
+            return [new DropDownEntry(null, Lang.Get("worldmap-ores-everything")), ..readings];
         }
 
         private void onSelectionChanged(string code, bool selected)

--- a/Systems/Prospecting/OreMapLayer/OreMapLayer.cs
+++ b/Systems/Prospecting/OreMapLayer/OreMapLayer.cs
@@ -35,7 +35,8 @@ namespace Vintagestory.GameContent
         CreateIconTextureDelegate oremapIconDele;
         public LoadedTexture oremapTexture;
 
-        public string filterByOreCode;
+        string filterByOreCode;
+        public string FilterByOreCode => filterByOreCode;
 
         public OreMapLayer(ICoreAPI api, IWorldMapManager mapSink) : base(api, mapSink)
         {
@@ -103,22 +104,14 @@ namespace Vintagestory.GameContent
 
         private void GetOreFilterDropdownData(out string[] values, out string[] names)
         {
-            HashSet<string> readingCodes = [];
-            foreach (var reading in ownPropickReadings.SelectMany(val => val.OreReadings)) {
-                readingCodes.Add(reading.Key);
-            }
-
-            // The set in vanilla inherently expects only stripped ore-* values, which would make any nonstandard values annoying to handle
-            // Leaving it as is, but perhaps better to move towards storing the full ore-* code as the key/deposit code value,
-            // reducing the need to append the ore- here and in other such places
-            var sorted = readingCodes
-                .Select(code => (value: code, name: Lang.Get("ore-" + code)))
-                .OrderBy(p => p.name, StringComparer.CurrentCulture)
+            var readings = ownPropickReadings.SelectMany(val => val.OreReadings)
+                .Select(reading => reading.Key)
+                .Select(code => (Code: code, Name: Lang.Get("ore-" + code)))
+                .OrderBy(reading => reading.Name, StringComparer.CurrentCulture)
                 .ToArray();
 
-            // Perhaps instead we could zip these into list of pairs and deconstruct at the caller ? Easier sorting but more cpu processing
-            values = new string[] { null }.Concat(sorted.Select(p => p.value)).ToArray();
-            names = new string[] { Lang.Get("worldmap-ores-everything") }.Concat(sorted.Select(p => p.name)).ToArray();
+            values = [null, ..readings.Select(reading => reading.Code)];
+            names = [Lang.Get("worldmap-ores-everything"), ..readings.Select(reading => reading.Name)];
         }
 
         private void onSelectionChanged(string code, bool selected)

--- a/Systems/Prospecting/OreMapLayer/OreMapLayer.cs
+++ b/Systems/Prospecting/OreMapLayer/OreMapLayer.cs
@@ -74,7 +74,9 @@ namespace Vintagestory.GameContent
         {
             string key = "worldmap-layer-" + LayerGroupCode;
 
-            GetOreFilterDropdownData(out string[] values, out string[] names);
+            var dropdownData = GetOreFilterDropdownData();
+            var values = dropdownData.Select(e => e.Value).ToArray();
+            var names = dropdownData.Select(e => e.Name).ToArray();
 
             ElementBounds dlgBounds =
                 ElementStdBounds.AutosizedMainDialog
@@ -102,16 +104,15 @@ namespace Vintagestory.GameContent
             guiDialogWorldMap.Composers[key].Enabled = false;
         }
 
-        private void GetOreFilterDropdownData(out string[] values, out string[] names)
+        private (string Value, string Name)[] GetOreFilterDropdownData()
         {
             var readings = ownPropickReadings.SelectMany(val => val.OreReadings)
                 .Select(reading => reading.Key)
+                .Distinct()
                 .Select(code => (Code: code, Name: Lang.Get("ore-" + code)))
-                .OrderBy(reading => reading.Name, StringComparer.CurrentCulture)
-                .ToArray();
+                .OrderBy(reading => reading.Name, StringComparer.CurrentCulture);
 
-            values = [null, ..readings.Select(reading => reading.Code)];
-            names = [Lang.Get("worldmap-ores-everything"), ..readings.Select(reading => reading.Name)];
+            return [(null, Lang.Get("worldmap-ores-everything")), ..readings];
         }
 
         private void onSelectionChanged(string code, bool selected)


### PR DESCRIPTION
The main intent behind this PR is to make ore map layer modifications easier by externalizing methods that provide data for ore map layer and its components into separate methods that mods can hook with harmony.
Additionally, sorts the dropdown values by user's locale.

Possible use cases are adding group-like tags ( iron-* which can be captured to allow display of limonite/magnetite/etc ), easier change of displayed text. 

Would simplify patching [dialog extras](https://github.com/KnewOne/BetterErProspecting/blob/main/BetterErProspecting/Patches/Stone/ComposeDialogExtrasPatch.cs), [ore map component](https://github.com/KnewOne/BetterErProspecting/blob/main/BetterErProspecting/Patches/Stone/OreMapComponentCtorPatch.cs) and [map rebuild](https://github.com/KnewOne/BetterErProspecting/blob/main/BetterErProspecting/Patches/Stone/RebuildMapComponentsPatch.cs) - transpilers would be fragile here since multiple mods would want to operate on this data batch

Also adds sorting of elements in the dropdown by their localized name. Respects "everyone" as the first option