### PR TITLE
Genericize ore smashing into groundstoredprocess, add json properties

### DIFF
--- a/CollectibleBehavior/BehaviorGroundStoredProcessable.cs
+++ b/CollectibleBehavior/BehaviorGroundStoredProcessable.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Vintagestory.API;
 using Vintagestory.API.Client;
@@ -187,6 +188,20 @@ namespace Vintagestory.GameContent
             RemainingItem?.Resolve(api.World, "remainingItem of item ", collObj.Code);
         }
 
+        /// <summary>
+        /// For ItemOre, computes the output quantity per input item based on metalUnits.
+        /// Returns 0 if not applicable (caller should use the default quantity).
+        /// </summary>
+        int GetOreOutputQuantity(ItemSlot slot)
+        {
+            if (slot.Itemstack?.Collectible is ItemOre && slot.Itemstack.ItemAttributes?["metalUnits"].Exists == true)
+            {
+                int metalUnits = slot.Itemstack.ItemAttributes["metalUnits"].AsInt(5);
+                return Math.Max(1, metalUnits / 5);
+            }
+            return 0;
+        }
+
         bool CheckSurfaceMaterial(BlockEntityContainer be, IPlayer byPlayer)
         {
             if (RequiredSurfaceMaterials == null) return true;
@@ -272,6 +287,7 @@ namespace Vintagestory.GameContent
 
                 if (ToolDamagePerItem && toolSlot != null && MaxProcessedAtOnce > 0)
                 {
+                    int oreOutputQty = GetOreOutputQuantity(slot);
                     int processed = 0;
                     for (int i = 0; i < itemsToProcess; i++)
                     {
@@ -281,6 +297,7 @@ namespace Vintagestory.GameContent
                         {
                             ItemStack? stack = processedStack.GetNextItemStack(1);
                             if (stack == null) return;
+                            if (oreOutputQty > 0) stack.StackSize = oreOutputQty;
                             var origStack = stack.Clone();
                             var quantity = stack.StackSize;
                             if (!byPlayer.InventoryManager.TryGiveItemstack(stack))
@@ -310,10 +327,12 @@ namespace Vintagestory.GameContent
                 }
                 else
                 {
+                    int oreOutputQty = GetOreOutputQuantity(slot);
                     ProcessedStacks?.Foreach(processedStack =>
                     {
                         ItemStack? stack = processedStack.GetNextItemStack(itemsToProcess);
                         if (stack == null) return;
+                        if (oreOutputQty > 0) stack.StackSize = oreOutputQty * itemsToProcess;
                         var origStack = stack.Clone();
                         var quantity = stack.StackSize;
                         if (!byPlayer.InventoryManager.TryGiveItemstack(stack))

--- a/CollectibleBehavior/BehaviorGroundStoredProcessable.cs
+++ b/CollectibleBehavior/BehaviorGroundStoredProcessable.cs
@@ -1,6 +1,8 @@
+using System.Linq;
 using Vintagestory.API;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
+using Vintagestory.API.Config;
 using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Util;
@@ -27,7 +29,10 @@ namespace Vintagestory.GameContent
     ///				    "type": "item",
     ///				    "code": "bowstave-recurve-raw"
     ///				},
-    ///				"tool": "knife"
+    ///				"tool": "knife",
+    ///				"requiredSurfaceMaterials": ["Stone", "Metal", "Brick"],
+    ///				"maxProcessedAtOnce": 4,
+    ///				"toolDamagePerItem": true
 	///			}
 	///		}
 	///	]
@@ -90,10 +95,48 @@ namespace Vintagestory.GameContent
         public EnumTool? Tool;
 
         /// <summary>
-        /// If set, changes how much damage is done to the tool in the process.
+        /// If set, changes how much damage is done to the tool per processing action.
+        /// When toolDamagePerItem is false (default), this damage is applied once per interaction.
+        /// When toolDamagePerItem is true, this damage is applied per item processed.
         /// </summary>
         [DocumentAsJson("Optional", "1")]
          int toolDamage = 1;
+
+        /// <summary>
+        /// If set, the block below the ground storage must be one of these materials for processing to work.
+        /// Valid values: Stone, Metal, Mantle, Brick, Ore, Ceramic, Wood, etc.
+        /// If null (default), processing works on any surface.
+        /// </summary>
+        [DocumentAsJson("Optional", "None")]
+        public EnumBlockMaterial[]? RequiredSurfaceMaterials;
+
+        /// <summary>
+        /// The lang key for the error message shown when the surface material requirement is not met.
+        /// </summary>
+        [DocumentAsJson("Optional", "itemore-needssolid-error")]
+        string? surfaceErrorLangCode;
+
+        /// <summary>
+        /// Maximum number of items from the stack to process per interaction.
+        /// 0 (default) means process the entire stack at once.
+        /// When set to a positive value, only up to this many items are processed, and if
+        /// toolDamagePerItem is true, the tool is damaged for each item (stopping early if the tool breaks).
+        /// </summary>
+        [DocumentAsJson("Optional", "0")]
+        public int MaxProcessedAtOnce;
+
+        /// <summary>
+        /// When true, tool durability is consumed per item processed (relevant when maxProcessedAtOnce > 0).
+        /// When false (default), tool durability is consumed once per interaction regardless of stack size.
+        /// </summary>
+        [DocumentAsJson("Optional", "false")]
+        public bool ToolDamagePerItem;
+
+        /// <summary>
+        /// A sound to play when processing completes. If not set, ProcessingSound is used.
+        /// </summary>
+        [DocumentAsJson("Optional", "None")]
+        public AssetLocation? CompletionSound;
 
         public CollectibleBehaviorGroundStoredProcessable(CollectibleObject collObj) : base(collObj)
         {
@@ -114,10 +157,20 @@ namespace Vintagestory.GameContent
                 ProcessingSound = AssetLocation.Create(code, collObj.Code.Domain);
             }
 
+            string? completionCode = properties["completionSound"].AsString();
+            if (completionCode != null) {
+                CompletionSound = AssetLocation.Create(completionCode, collObj.Code.Domain);
+            }
+
             RemainingItem = properties["remainingItem"].AsObject<JsonItemStack?>();
 
             Tool = properties["tool"].AsObject<EnumTool?>();
             toolDamage = properties["toolDurabilityCost"].AsInt(1);
+
+            RequiredSurfaceMaterials = properties["requiredSurfaceMaterials"].AsObject<EnumBlockMaterial[]?>();
+            surfaceErrorLangCode = properties["surfaceErrorLangCode"].AsString("itemore-needssolid-error");
+            MaxProcessedAtOnce = properties["maxProcessedAtOnce"].AsInt(0);
+            ToolDamagePerItem = properties["toolDamagePerItem"].AsBool(false);
         }
 
         public override void OnLoaded(ICoreAPI api)
@@ -134,6 +187,17 @@ namespace Vintagestory.GameContent
             RemainingItem?.Resolve(api.World, "remainingItem of item ", collObj.Code);
         }
 
+        bool CheckSurfaceMaterial(BlockEntityContainer be, IPlayer byPlayer)
+        {
+            if (RequiredSurfaceMaterials == null) return true;
+
+            var belowMaterial = be.Api.World.BlockAccessor.GetBlock(be.Pos.DownCopy()).BlockMaterial;
+            if (RequiredSurfaceMaterials.Contains(belowMaterial)) return true;
+
+            (be.Api as ICoreClientAPI)?.TriggerIngameError(this, "needssolidsurface", Lang.Get(surfaceErrorLangCode));
+            return false;
+        }
+
         public bool OnContainedInteractStart(BlockEntityContainer be, ItemSlot slot, IPlayer byPlayer, BlockSelection blockSel)
         {
             if (Tool != null && byPlayer.InventoryManager.ActiveTool != Tool) return false;
@@ -144,6 +208,8 @@ namespace Vintagestory.GameContent
             {
                 return false;
             }
+
+            if (!CheckSurfaceMaterial(be, byPlayer)) return false;
 
             if (ProcessedStacks != null || RemainingItem != null)
             {
@@ -161,6 +227,12 @@ namespace Vintagestory.GameContent
             if (!byPlayer.Entity.Controls.ShiftKey) return false;
 
             if (blockSel == null) return false;
+
+            if (RequiredSurfaceMaterials != null && !RequiredSurfaceMaterials.Contains(
+                be.Api.World.BlockAccessor.GetBlock(be.Pos.DownCopy()).BlockMaterial))
+            {
+                return false;
+            }
 
             if (ProcessingAnimationCode != null && byPlayer.Entity.World is IClientWorldAccessor) byPlayer.Entity.StartAnimation(ProcessingAnimationCode);
 
@@ -182,45 +254,107 @@ namespace Vintagestory.GameContent
             byPlayer.Entity.StopAnimation(ProcessingAnimationCode);
             if (Tool != null && byPlayer.InventoryManager.ActiveTool != Tool) return;
 
+            if (RequiredSurfaceMaterials != null && !RequiredSurfaceMaterials.Contains(
+                be.Api.World.BlockAccessor.GetBlock(be.Pos.DownCopy()).BlockMaterial))
+            {
+                return;
+            }
+
             if (secondsUsed > ProcessTime - 0.05f && (ProcessedStacks != null || RemainingItem != null) && be.Api.World.Side == EnumAppSide.Server)
             {
-                ProcessedStacks?.Foreach(processedStack =>
+                int itemsToProcess = slot.StackSize;
+                if (MaxProcessedAtOnce > 0 && itemsToProcess > MaxProcessedAtOnce)
                 {
-                    ItemStack? stack = processedStack.GetNextItemStack(slot.Itemstack.StackSize);
-                    if (stack == null) return;
-                    var origStack = stack.Clone();
-                    var quantity = stack.StackSize;
-                    if (!byPlayer.InventoryManager.TryGiveItemstack(stack))
+                    itemsToProcess = MaxProcessedAtOnce;
+                }
+
+                var toolSlot = (Tool != null) ? byPlayer.InventoryManager.ActiveHotbarSlot : null;
+
+                if (ToolDamagePerItem && toolSlot != null && MaxProcessedAtOnce > 0)
+                {
+                    int processed = 0;
+                    for (int i = 0; i < itemsToProcess; i++)
                     {
-                        be.Api.World.SpawnItemEntity(stack, blockSel.Position);
+                        if (toolSlot.Empty) break;
+
+                        ProcessedStacks?.Foreach(processedStack =>
+                        {
+                            ItemStack? stack = processedStack.GetNextItemStack(1);
+                            if (stack == null) return;
+                            var origStack = stack.Clone();
+                            var quantity = stack.StackSize;
+                            if (!byPlayer.InventoryManager.TryGiveItemstack(stack))
+                            {
+                                be.Api.World.SpawnItemEntity(stack, blockSel.Position);
+                            }
+                            be.Api.World.Logger.Audit("{0} Took {1}x{2} from {3} at {4}.",
+                                byPlayer.PlayerName,
+                                quantity,
+                                stack.Collectible.Code,
+                                collObj.Code,
+                                blockSel.Position
+                            );
+
+                            TreeAttribute tree = new TreeAttribute();
+                            tree["itemstack"] = new ItemstackAttribute(origStack.Clone());
+                            tree["byentityid"] = new LongAttribute(byPlayer.Entity.EntityId);
+                            be.Api.World.Api.Event.PushEvent("onitemcollected", tree);
+                        });
+
+                        toolSlot.Itemstack?.Collectible.DamageItem(be.Api.World, byPlayer.Entity, toolSlot, toolDamage);
+                        processed++;
                     }
-                    be.Api.World.Logger.Audit("{0} Took {1}x{2} from {3} at {4}.",
-                        byPlayer.PlayerName,
-                        quantity,
-                        stack.Collectible.Code,
-                        collObj.Code,
-                        blockSel.Position
-                    );
 
-                    TreeAttribute tree = new TreeAttribute();
-                    tree["itemstack"] = new ItemstackAttribute(origStack.Clone());
-                    tree["byentityid"] = new LongAttribute(byPlayer.Entity.EntityId);
-                    be.Api.World.Api.Event.PushEvent("onitemcollected", tree);
-                });
+                    if (slot.StackSize <= processed) slot.Itemstack = null;
+                    else slot.Itemstack.StackSize -= processed;
+                }
+                else
+                {
+                    ProcessedStacks?.Foreach(processedStack =>
+                    {
+                        ItemStack? stack = processedStack.GetNextItemStack(itemsToProcess);
+                        if (stack == null) return;
+                        var origStack = stack.Clone();
+                        var quantity = stack.StackSize;
+                        if (!byPlayer.InventoryManager.TryGiveItemstack(stack))
+                        {
+                            be.Api.World.SpawnItemEntity(stack, blockSel.Position);
+                        }
+                        be.Api.World.Logger.Audit("{0} Took {1}x{2} from {3} at {4}.",
+                            byPlayer.PlayerName,
+                            quantity,
+                            stack.Collectible.Code,
+                            collObj.Code,
+                            blockSel.Position
+                        );
 
-                int stacksize = slot.StackSize;
-                slot.Itemstack = RemainingItem?.ResolvedItemstack?.Clone();
-                slot.Itemstack?.StackSize *= stacksize;
+                        TreeAttribute tree = new TreeAttribute();
+                        tree["itemstack"] = new ItemstackAttribute(origStack.Clone());
+                        tree["byentityid"] = new LongAttribute(byPlayer.Entity.EntityId);
+                        be.Api.World.Api.Event.PushEvent("onitemcollected", tree);
+                    });
+
+                    int stacksize = slot.StackSize;
+                    if (stacksize <= itemsToProcess)
+                    {
+                        slot.Itemstack = RemainingItem?.ResolvedItemstack?.Clone();
+                        slot.Itemstack?.StackSize *= stacksize;
+                    }
+                    else
+                    {
+                        slot.Itemstack.StackSize -= itemsToProcess;
+                    }
+
+                    if (toolSlot != null)
+                    {
+                        toolSlot.Itemstack?.Collectible.DamageItem(be.Api.World, byPlayer.Entity, toolSlot, toolDamage);
+                    }
+                }
+
                 be.MarkDirty(true);
                 if (be.Inventory.Empty) be.Api.World.BlockAccessor.SetBlock(0, blockSel.Position);
 
-                if (Tool != null)
-                {
-                    var toolSlot = byPlayer.InventoryManager.ActiveHotbarSlot;
-                    toolSlot.Itemstack?.Collectible.DamageItem(be.Api.World, byPlayer.Entity, toolSlot, toolDamage);
-                }
-
-                be.Api.World.PlaySoundAt(ProcessingSound, blockSel.Position, 0, byPlayer);
+                be.Api.World.PlaySoundAt(CompletionSound ?? ProcessingSound, blockSel.Position, 0, byPlayer);
             }
         }
 
@@ -235,6 +369,12 @@ namespace Vintagestory.GameContent
         {
             if (ProcessedStacks != null || RemainingItem != null)
             {
+                if (RequiredSurfaceMaterials != null && !RequiredSurfaceMaterials.Contains(
+                    be.Api.World.BlockAccessor.GetBlock(be.Pos.DownCopy()).BlockMaterial))
+                {
+                    return [];
+                }
+
                 bool notProtected = true;
 
                 if (be.Api.World.Claims != null && be.Api.World is IClientWorldAccessor clientWorld && clientWorld.Player?.WorldData.CurrentGameMode == EnumGameMode.Survival)

--- a/Item/ItemOre.cs
+++ b/Item/ItemOre.cs
@@ -10,7 +10,7 @@ using Vintagestory.API.Util;
 
 namespace Vintagestory.GameContent
 {
-    public class ItemOre : ItemPileable, IContainedInteractable
+    public class ItemOre : ItemPileable
     {
         public bool IsCoal => Variant["ore"] == "lignite" || Variant["ore"] == "bituminouscoal" || Variant["ore"] == "anthracite";
         public override bool IsPileable => IsCoal;
@@ -98,131 +98,6 @@ namespace Vintagestory.GameContent
             }
 
             return base.GetHeldItemName(itemStack);
-        }
-
-        bool CanBreakOnMaterial(EnumBlockMaterial blockMaterial)
-        {
-            return blockMaterial is EnumBlockMaterial.Stone or EnumBlockMaterial.Metal or EnumBlockMaterial.Mantle or EnumBlockMaterial.Brick or EnumBlockMaterial.Ore;
-        }
-
-        public bool OnContainedInteractStart(BlockEntityContainer be, ItemSlot slot, IPlayer byPlayer, BlockSelection blockSel)
-        {
-            if (Attributes?["metalUnits"].Exists != true ||
-                byPlayer.InventoryManager.ActiveTool != EnumTool.Hammer ||
-                !byPlayer.Entity.Controls.ShiftKey ||
-                !be.Api.World.Claims.TryAccess(byPlayer, blockSel.Position, EnumBlockAccessFlags.Use))
-            {
-                return false;
-            }
-
-            if (!CanBreakOnMaterial(be.Api.World.BlockAccessor.GetBlock(be.Pos.DownCopy()).BlockMaterial))
-            {
-                (be.Api as ICoreClientAPI)?.TriggerIngameError(this, "needssolidsurface", Lang.Get("itemore-needssolid-error"));
-                return false;
-            }
-
-            return true;
-        }
-
-        public bool OnContainedInteractStep(float secondsUsed, BlockEntityContainer be, ItemSlot slot, IPlayer byPlayer, BlockSelection blockSel)
-        {
-            if (Attributes?["metalUnits"].Exists != true ||
-                !CanBreakOnMaterial(be.Api.World.BlockAccessor.GetBlock(be.Pos.DownCopy()).BlockMaterial) ||
-                byPlayer.InventoryManager.ActiveTool != EnumTool.Hammer ||
-                !byPlayer.Entity.Controls.ShiftKey ||
-                blockSel == null)
-            {
-                return false;
-            }
-
-            if (byPlayer is IClientPlayer) byPlayer.Entity.StartAnimation("hammerhit-fp");
-
-            if (be.Api.World.Rand.NextDouble() < 0.1)
-            {
-                be.Api.World.PlaySoundAt("sounds/block/rock-hit-pickaxe", blockSel.Position, 0);
-            }
-
-            if (be.Api.World.Side == EnumAppSide.Client && be.Api.World.Rand.NextDouble() < 0.25)
-            {
-                be.Api.World.SpawnCubeParticles(blockSel.Position.ToVec3d().Add(blockSel.HitPosition), slot.Itemstack, 0.25f, 1, 0.5f, byPlayer, new Vec3f(0, 1, 0));
-            }
-
-            return secondsUsed < 2f;
-        }
-
-        public void OnContainedInteractStop(float secondsUsed, BlockEntityContainer be, ItemSlot slot, IPlayer byPlayer, BlockSelection blockSel)
-        {
-            if (Attributes?["metalUnits"].Exists != true ||
-                !CanBreakOnMaterial(be.Api.World.BlockAccessor.GetBlock(be.Pos.DownCopy()).BlockMaterial) ||
-                byPlayer.InventoryManager.ActiveTool != EnumTool.Hammer)
-            {
-                return;
-            }
-
-            if (secondsUsed > 2f - 0.05f && be.Api.World.Side == EnumAppSide.Server)
-            {
-                byPlayer.Entity.StopAnimation("hammerhit-fp");
-
-                var toolSlot = byPlayer.InventoryManager.ActiveHotbarSlot;
-                int units = slot.Itemstack.ItemAttributes["metalUnits"].AsInt(5);
-                string type = slot.Itemstack.Collectible.Variant["ore"].Replace("quartz_", "").Replace("galena_", "");
-
-                ItemStack outStack = new ItemStack(api.World.GetItem("nugget-" + type), Math.Max(1, units / 5));
-                int smashed = 0;
-                for (; smashed < slot.StackSize; smashed++)
-                {
-                    if (toolSlot.Empty || smashed >= 4) break;
-
-                    for (int k = 0; k < outStack.StackSize; k++)
-                    {
-                        ItemStack stack = outStack.Clone();
-                        stack.StackSize = 1;
-                        be.Api.World.SpawnItemEntity(stack, blockSel.Position);
-                    }
-                    toolSlot.Itemstack.Collectible.DamageItem(be.Api.World, byPlayer.Entity, toolSlot);
-                }
-
-                if (slot.StackSize <= smashed) slot.Itemstack = null;
-                else slot.Itemstack.StackSize -= smashed;
-                be.MarkDirty(true);
-                if (be.Inventory.Empty) be.Api.World.BlockAccessor.SetBlock(0, blockSel.Position);
-
-                be.Api.World.PlaySoundAt("sounds/block/rock-break-pickaxe", blockSel.Position, 0);
-            }
-        }
-
-        public bool OnContainedInteractCancel(float secondsUsed, BlockEntityContainer be, ItemSlot slot, IPlayer byPlayer, BlockSelection blockSel, EnumItemUseCancelReason cancelReason)
-        {
-            byPlayer.Entity.StopAnimation("hammerhit-fp");
-            return true;
-        }
-
-
-        public WorldInteraction[] GetContainedInteractionHelp(BlockEntityContainer be, ItemSlot slot, IPlayer byPlayer, BlockSelection blockSel)
-        {
-            if (Attributes?["metalUnits"].Exists == true && CanBreakOnMaterial(be.Api.World.BlockAccessor.GetBlock(be.Pos.DownCopy()).BlockMaterial))
-            {
-                bool notProtected = true;
-
-                if (be.Api.World.Claims != null && be.Api.World is IClientWorldAccessor clientWorld && clientWorld.Player?.WorldData.CurrentGameMode == EnumGameMode.Survival)
-                {
-                    EnumWorldAccessResponse resp = clientWorld.Claims.TestAccess(clientWorld.Player, blockSel.Position, EnumBlockAccessFlags.Use);
-                    if (resp != EnumWorldAccessResponse.Granted) notProtected = false;
-                }
-
-                if (notProtected) return
-                [
-                    new()
-                    {
-                        ActionLangCode = "itemhelp-ore-smash",
-                        MouseButton = EnumMouseButton.Right,
-                        HotKeyCode = "shift",
-                        Itemstacks = ObjectCacheUtil.GetToolStacks(api, EnumTool.Hammer)
-                    }
-                ];
-            }
-
-            return [];
         }
 
     }

--- a/Systems/Handbook/CollectibleBehaviorHandbookTextAndExtraInfo.cs
+++ b/Systems/Handbook/CollectibleBehaviorHandbookTextAndExtraInfo.cs
@@ -817,25 +817,6 @@ namespace Vintagestory.GameContent
                 }
             }
 
-            // Ore smashes into
-            if (stack.Collectible is ItemOre)
-            {
-                int units = stack.ItemAttributes["metalUnits"].AsInt(5);
-                string type = stack.Collectible.Variant["ore"].Replace("quartz_", "").Replace("galena_", "");
-
-                if (capi.World.GetItem(new AssetLocation("nugget-" + type)) is { } item)
-                {
-                    AddHeading(components, capi, "oresmasheddesc-title", ref haveText);
-
-                    components.Add(new ItemstackTextComponent(capi, new(item, Math.Max(1, units / 5)), 40, 10, EnumFloat.Inline, (cs) => openDetailPageFor(getPageCodeForStack(capi, cs)))
-                    {
-                        ShowStacksize = true,
-                        PaddingLeft = TinyIndent
-                    });
-                    components.Add(new ClearFloatTextComponent(capi, marginBottom));  //nice margin below the item graphic
-                }
-            }
-
             // Distills into
             DistillationProps dprops = getDistillationProps(stack);
             if (dprops != null)
@@ -1474,7 +1455,6 @@ namespace Vintagestory.GameContent
             List<ItemStack> squeezables = [];
             Dictionary<string, List<ItemStack>> groundstoredprocessables = [];
             List<ItemStack> distillables = [];
-            List<ItemStack> smashables = [];
             List<ItemStack> fluxes = [];
             Dictionary<EnumTransitionType, List<ItemStack>> transitionables = [];
             List<ItemStack> validanvils = anvils;
@@ -1578,20 +1558,6 @@ namespace Vintagestory.GameContent
                 if (crushedStack != null && crushedStack.Equals(capi.World, stack, GlobalConstants.IgnoredStackAttributes))
                 {
                     addToListUniquely(capi, crushables, val);
-                }
-
-                if (val.Collectible is ItemOre)
-                {
-                    string type = val.Collectible.Variant["ore"].Replace("quartz_", "").Replace("galena_", "");
-
-                    if (capi.World.GetItem(new AssetLocation("nugget-" + type)) is { } item)
-                    {
-                        ItemStack outStack = new(item);
-                        if (outStack.Equals(capi.World, stack, GlobalConstants.IgnoredStackAttributes))
-                        {
-                            addToListUniquely(capi, smashables, val);
-                        }
-                    }
                 }
 
                 if (val.ItemAttributes?["juiceableProperties"].Exists == true && getjuiceableProps(val) is JuiceableProperties fjprops)
@@ -1721,7 +1687,7 @@ namespace Vintagestory.GameContent
             string customCreatedBy = stack.Collectible.Attributes?["handbook"]?["createdBy"]?.AsString(null);
             string bakingInitialIngredient = collObj.Attributes?["bakingProperties"]?.AsObject<BakingProperties>()?.InitialCode;
 
-            if (grecipes.Count > 0 || cookrecipes.Count > 0 || (metalmoldables.Count > 0 && moldStacks.Count > 0) || (metalworkables.Count > 0 && validanvils.Count > 0) || knappables.Count > 0 || clayformables.Count > 0 || anvilweldable || customCreatedBy != null || bakables.Count > 0 || bloomeryables.Count > 0 || kilnables.Count > 0 || carburizables.Count > 0 || (allQuerns.Count > 0 && grindables.Count > 0) || transitionables.Count > 0 || crushables.Count > 0 || barrelRecipestext.Count > 0 || bakingInitialIngredient != null || (juiceables.Count > 0 && allFruitpresses.Count > 0) || squeezables.Count > 0 || groundstoredprocessables.Count > 0 || distillables.Count > 0 || smashables.Count > 0)
+            if (grecipes.Count > 0 || cookrecipes.Count > 0 || (metalmoldables.Count > 0 && moldStacks.Count > 0) || (metalworkables.Count > 0 && validanvils.Count > 0) || knappables.Count > 0 || clayformables.Count > 0 || anvilweldable || customCreatedBy != null || bakables.Count > 0 || bloomeryables.Count > 0 || kilnables.Count > 0 || carburizables.Count > 0 || (allQuerns.Count > 0 && grindables.Count > 0) || transitionables.Count > 0 || crushables.Count > 0 || barrelRecipestext.Count > 0 || bakingInitialIngredient != null || (juiceables.Count > 0 && allFruitpresses.Count > 0) || squeezables.Count > 0 || groundstoredprocessables.Count > 0 || distillables.Count > 0)
             {
                 AddHeading(components, capi, "Created by", ref haveText);
 
@@ -1960,17 +1926,6 @@ namespace Vintagestory.GameContent
                     verticalSpace = verticalSpaceSmall;
                     AddSubHeading(components, capi, openDetailPageFor, "Crushing", null);
                     AddSlideShowComponent(components, capi, crushables, openDetailPageFor, true);
-
-                    components.Add(new RichTextComponent(capi, "\n", CairoFont.WhiteSmallText()));
-                }
-
-
-                if (smashables.Count > 0)
-                {
-                    components.Add(verticalSpace);
-                    verticalSpace = verticalSpaceSmall;
-                    AddSubHeading(components, capi, openDetailPageFor, "handbook-createdby-smashing", null);
-                    AddSlideShowComponent(components, capi, smashables, openDetailPageFor, true);
 
                     components.Add(new RichTextComponent(capi, "\n", CairoFont.WhiteSmallText()));
                 }


### PR DESCRIPTION
Currently ItemOre.cs implements its own GroundStoredProcessable logic through IContainedInteractable. This is unnecessary and also means this behavior is not available to modders via json properties. This PR migrates that logic to BehaviorGroundStoredProcessable.cs, genericizes it, and implements json properties so that modders can control it. It also makes the necessary changes to CollectibleBehaviorHandbookTextAndExtraInfo.cs to handle this, fixing the previous handbook inconsistency.

NOTE: Some lang keys call out itemore (ex: "itemore-needssolid-error"). Since this behavior is no longer unique to itemore, the team should rename the lang keys.

This feature is clearly not fully implemented yet, but considering how IContainedInteractable was used in the rest of the codebase, and the limitations of placing recipe logic inside an item definition, I figured I could safely assume that migrating the logic to the new(er) BehaviorGroundStoredProcessable.cs file would fly.