### PR TITLE
Fixing lightning-induced fire

### DIFF
--- a/BlockEntityBehavior/BEBehaviorAttractsLightning.cs
+++ b/BlockEntityBehavior/BEBehaviorAttractsLightning.cs
@@ -66,7 +66,7 @@ namespace Vintagestory.GameContent
             var world = Blockentity.Api.World;
             var ourPos = Blockentity.Pos;
             
-            var ourRainHeight = world.BlockAccessor.GetRainMapHeightAt(ourPos.X, ourPos.Z);
+            var ourRainHeight = world.BlockAccessor.GetRainMapHeightAt(ourPos);
 
             // Something may be above us blocking line of sight to the sky
             if (ourRainHeight != ourPos.Y) return;
@@ -81,7 +81,8 @@ namespace Vintagestory.GameContent
 
             yDiff = GameMath.Min(40, yDiff);
 
-            var posA = new Vec2d(Blockentity.Pos.X, Blockentity.Pos.Z);
+            //Centers the protective area on the lightning rod
+            var posA = new Vec2d(ourPos.X + 0.5, OurPos.Z + 0.5);
             if (posA.DistanceTo(impactPos.X, impactPos.Z) > yDiff) return;
 
             impactPos = Blockentity.Pos.ToVec3d();

--- a/Systems/FireFromLightning.cs
+++ b/Systems/FireFromLightning.cs
@@ -26,7 +26,7 @@ namespace Vintagestory.GameContent
             if (api.World.Config.GetBool("lightningFires", false))
             {
                 var rnd = api.World.Rand;
-                var npos = impactPos.AsBlockPos.Add(rnd.Next(2) - 1, rnd.Next(2) - 1, rnd.Next(2) - 1);
+                var npos = impactPos.AsBlockPos.Add(rnd.Next(3) - 1, rnd.Next(3) - 1, rnd.Next(3) - 1);
                 var block = api.World.BlockAccessor.GetBlock(npos);
                 var combustibleProps = block.GetCombustibleProperties(api.World, null, npos);
                 if (combustibleProps != null)


### PR DESCRIPTION
rand.Next is exclusive : current implementation issuing [-1; 0] offsets only allows fire to spawn north-west from the block hit x_x
rand.Next(3) will issue ints in [0; 2] leading to [-1; 1] offsets!
I wouldn't understand if the current implementation is an intended behavior : that would make no sense...