### PR TITLE
Use CanEat for meals and liquid containers

### DIFF
--- a/Block/BlockPie.cs
+++ b/Block/BlockPie.cs
@@ -117,31 +117,11 @@ namespace Vintagestory.GameContent
             displayContentsInfo = false;
         }
 
-
-        public override void OnHeldInteractStart(ItemSlot slot, EntityAgent byEntity, BlockSelection blockSel, EntitySelection entitySel, bool firstEvent, ref EnumHandHandling handHandling)
+        public override bool CanEat(ItemSlot slot, EntityAgent byEntity)
         {
-            if (!canEat(slot)) return;
-            base.OnHeldInteractStart(slot, byEntity, blockSel, entitySel, firstEvent, ref handHandling);
-        }
-
-        public override bool OnHeldInteractStep(float secondsUsed, ItemSlot slot, EntityAgent byEntity, BlockSelection blockSel, EntitySelection entitySel)
-        {
-            if (!canEat(slot)) return false;
-
-            return base.OnHeldInteractStep(secondsUsed, slot, byEntity, blockSel, entitySel);
-        }
-
-        public override void OnHeldInteractStop(float secondsUsed, ItemSlot slot, EntityAgent byEntity, BlockSelection blockSel, EntitySelection entitySel)
-        {
-            if (!canEat(slot)) return;
-
-            base.OnHeldInteractStop(secondsUsed, slot, byEntity, blockSel, entitySel);
-        }
-
-
-        protected bool canEat(ItemSlot slot)
-        {
-            return slot.Itemstack?.Attributes?.GetAsInt("pieSize") == 1 && State != "raw";
+            return slot.Itemstack?.Attributes?.GetAsInt("pieSize") == 1
+                && State != "raw"
+                && base.CanEat(slot, byEntity);
         }
 
 

--- a/Systems/Cooking/BlockMeal.cs
+++ b/Systems/Cooking/BlockMeal.cs
@@ -76,7 +76,7 @@ namespace Vintagestory.GameContent
 
         public override string GetHeldTpUseAnimation(ItemSlot activeHotbarSlot, Entity forEntity)
         {
-            return "eat";
+            return CanEat(activeHotbarSlot, forEntity as EntityAgent) ? "eat" : base.GetHeldTpUseAnimation(activeHotbarSlot, forEntity);
         }
 
         /// <summary>
@@ -132,12 +132,21 @@ namespace Vintagestory.GameContent
             tryFinishEatMeal(secondsUsed, slot, byEntity, true);
         }
 
+        public override bool CanEat(ItemSlot slot, EntityAgent byEntity)
+        {
+            // Can't look up container contents without a world accessor
+            if (byEntity?.World == null)
+            {
+                return false;
+            }
 
+            return !slot.Empty && GetContentNutritionProperties(byEntity.World, slot, byEntity) != null;
+        }
 
 
         protected virtual bool tryHeldBeginEatMeal(ItemSlot slot, EntityAgent byEntity, ref EnumHandHandling handHandling)
         {
-            if (!byEntity.Controls.ShiftKey && GetContentNutritionProperties(api.World, slot, byEntity) != null)
+            if (!byEntity.Controls.ShiftKey && CanEat(slot, byEntity))
             {
                 byEntity.World.RegisterCallback((dt) =>
                 {
@@ -154,29 +163,27 @@ namespace Vintagestory.GameContent
             return false;
         }
 
+
         protected bool tryPlacedBeginEatMeal(ItemSlot slot, IPlayer byPlayer)
         {
-            if (GetContentNutritionProperties(api.World, slot, byPlayer.Entity) != null)
+            if (!CanEat(slot, byPlayer as EntityAgent)) return false;
+
+            api.World.RegisterCallback((dt) =>
             {
-                api.World.RegisterCallback((dt) =>
+                if (byPlayer.Entity.Controls.HandUse == EnumHandInteract.BlockInteract)
                 {
-                    if (byPlayer.Entity.Controls.HandUse == EnumHandInteract.BlockInteract)
-                    {
-                        byPlayer.Entity.PlayEntitySound("eat", byPlayer);
-                    }
-                }, 500);
+                    byPlayer.Entity.PlayEntitySound("eat", byPlayer);
+                }
+            }, 500);
 
-                byPlayer.Entity.StartAnimation("eat");
+            byPlayer.Entity.StartAnimation("eat");
 
-                return true;
-            }
-
-            return false;
+            return true;
         }
 
         protected virtual bool tryHeldContinueEatMeal(float secondsUsed, ItemSlot slot, EntityAgent byEntity)
         {
-            if (GetContentNutritionProperties(byEntity.World, slot, byEntity) == null) return false;
+            if (!CanEat(slot, byEntity)) return false;
 
             Vec3d pos = byEntity.Pos.AheadCopy(0.4f).XYZ.Add(byEntity.LocalEyePos);
             pos.Y -= 0.4f;
@@ -219,58 +226,53 @@ namespace Vintagestory.GameContent
 
         protected bool tryPlacedContinueEatMeal(float secondsUsed, ItemSlot slot, IPlayer byPlayer, BlockSelection blockSel)
         {
-            if (!byPlayer.Entity.Controls.ShiftKey || GetContentNutritionProperties(api.World, slot, byPlayer.Entity) == null || slot.Itemstack is not ItemStack stack) return false;
+            if (!byPlayer.Entity.Controls.ShiftKey || slot.Itemstack is not ItemStack stack || !CanEat(slot, byPlayer as EntityAgent)) return false;
 
-            if (api.Side == EnumAppSide.Client)
+            // Let the client decide when to finish eating
+            if (api.Side.IsServer()) return true;
+
+            ModelTransform tf = new ModelTransform();
+            tf.Origin.Set(1.1f, 0.5f, 0.5f);
+            tf.EnsureDefaultValues();
+
+            if (ItemClass == EnumItemClass.Item)
             {
-                ModelTransform tf = new ModelTransform();
-                tf.Origin.Set(1.1f, 0.5f, 0.5f);
-                tf.EnsureDefaultValues();
-
-                if (ItemClass == EnumItemClass.Item)
+                if (secondsUsed > 0.5f)
                 {
-                    if (secondsUsed > 0.5f)
-                    {
-                        tf.Translation.X = GameMath.Sin(30 * secondsUsed) / 10;
-                    }
-
-                    tf.Translation.Z += -Math.Min(1.6f, secondsUsed * 4 * 1.57f);
-                    tf.Translation.Y += Math.Min(0.15f, secondsUsed * 2);
-
-                    tf.Rotation.Y -= Math.Min(85f, secondsUsed * 350 * 1.5f);
-                    tf.Rotation.X += Math.Min(40f, secondsUsed * 350 * 0.75f);
-                    tf.Rotation.Z += Math.Min(30f, secondsUsed * 350 * 0.75f);
-                }
-                else
-                {
-                    tf.Translation.X -= Math.Min(1.7f, secondsUsed * 4 * 1.8f) / FpHandTransform.ScaleXYZ.X;
-                    tf.Translation.Y += Math.Min(0.4f, secondsUsed * 1.8f) / FpHandTransform.ScaleXYZ.X;
-                    tf.Scale = 1 + Math.Min(0.5f, secondsUsed * 4 * 1.8f) / FpHandTransform.ScaleXYZ.X;
-                    tf.Rotation.X += Math.Min(40f, secondsUsed * 350 * 0.75f) / FpHandTransform.ScaleXYZ.X;
-
-                    if (secondsUsed > 0.5f)
-                    {
-                        tf.Translation.Y += GameMath.Sin(30 * secondsUsed) / 10 / FpHandTransform.ScaleXYZ.Y;
-                    }
+                    tf.Translation.X = GameMath.Sin(30 * secondsUsed) / 10;
                 }
 
+                tf.Translation.Z += -Math.Min(1.6f, secondsUsed * 4 * 1.57f);
+                tf.Translation.Y += Math.Min(0.15f, secondsUsed * 2);
 
+                tf.Rotation.Y -= Math.Min(85f, secondsUsed * 350 * 1.5f);
+                tf.Rotation.X += Math.Min(40f, secondsUsed * 350 * 0.75f);
+                tf.Rotation.Z += Math.Min(30f, secondsUsed * 350 * 0.75f);
+            }
+            else
+            {
+                tf.Translation.X -= Math.Min(1.7f, secondsUsed * 4 * 1.8f) / FpHandTransform.ScaleXYZ.X;
+                tf.Translation.Y += Math.Min(0.4f, secondsUsed * 1.8f) / FpHandTransform.ScaleXYZ.X;
+                tf.Scale = 1 + Math.Min(0.5f, secondsUsed * 4 * 1.8f) / FpHandTransform.ScaleXYZ.X;
+                tf.Rotation.X += Math.Min(40f, secondsUsed * 350 * 0.75f) / FpHandTransform.ScaleXYZ.X;
 
-                if (secondsUsed > 0.5f && (int)(30 * secondsUsed) % 7 == 1)
+                if (secondsUsed > 0.5f)
                 {
-                    ItemStack[] contents = GetNonEmptyContents(api.World, stack);
-                    if (contents.Length > 0)
-                    {
-                        ItemStack rndStack = contents[api.World.Rand.Next(contents.Length)];
-                        api.World.SpawnCubeParticles(blockSel.Position.ToVec3d().Add(0.5f, 2 / 16f, 0.5f), rndStack, 0.2f, 4, 0.5f);
-                    }
+                    tf.Translation.Y += GameMath.Sin(30 * secondsUsed) / 10 / FpHandTransform.ScaleXYZ.Y;
                 }
-
-                return secondsUsed <= 1.5f;
             }
 
-            // Let the client decide when he is done eating
-            return true;
+            if (secondsUsed > 0.5f && (int)(30 * secondsUsed) % 7 == 1)
+            {
+                ItemStack[] contents = GetNonEmptyContents(api.World, stack);
+                if (contents.Length > 0)
+                {
+                    ItemStack rndStack = contents[api.World.Rand.Next(contents.Length)];
+                    api.World.SpawnCubeParticles(blockSel.Position.ToVec3d().Add(0.5f, 2 / 16f, 0.5f), rndStack, 0.2f, 4, 0.5f);
+                }
+            }
+
+            return secondsUsed <= 1.5f;
         }
 
 

--- a/Systems/Liquid/BlockLiquidContainerBase.cs
+++ b/Systems/Liquid/BlockLiquidContainerBase.cs
@@ -730,7 +730,7 @@ namespace Vintagestory.GameContent
             {
                 if (byEntity.Controls.ShiftKey) base.OnHeldInteractStart(itemslot, byEntity, blockSel, entitySel, firstEvent, ref handHandling);
 
-                if (handHandling != EnumHandHandling.PreventDefaultAction && CanDrinkFrom && GetNutritionPropertiesPerLitre(byEntity.World, itemslot.Itemstack, byEntity) != null)
+                if (handHandling != EnumHandHandling.PreventDefaultAction && CanEat(itemslot, byEntity))
                 {
                     tryEatBegin(itemslot, byEntity, ref handHandling, "drink", 4);
                     return;
@@ -779,7 +779,7 @@ namespace Vintagestory.GameContent
                 }
             }
 
-            if (CanDrinkFrom && GetNutritionPropertiesPerLitre(byEntity.World, itemslot.Itemstack, byEntity) != null)
+            if (CanEat(itemslot, byEntity))
             {
                 tryEatBegin(itemslot, byEntity, ref handHandling, "drink", 4);
                 return;
@@ -869,6 +869,11 @@ namespace Vintagestory.GameContent
             (nutriProps.EatenStack.ResolvedItemstack.Collectible as BlockLiquidContainerBase)?.SetContent(nutriProps.EatenStack.ResolvedItemstack, null);
 
             return nutriProps;
+        }
+
+        public override bool CanEat(ItemSlot slot, EntityAgent byEntity)
+        {
+            return !slot.Empty && CanDrinkFrom && GetNutritionPropertiesPerLitre(byEntity.World, slot.Itemstack, byEntity) != null;
         }
 
         public FoodNutritionProperties GetNutritionPropertiesPerLitre(IWorldAccessor world, ItemStack itemstack, Entity forEntity)


### PR DESCRIPTION
Use the proposed CanEat method from anegostudios/vsapi#77 in meal and liquid container code.

Meals now use their default HeldTpUseAnimation if they are currently inedible.

It may be preferred for pies to have `twohandplaceblock` as their use animation now, since `interactstatic` looks a little bit weird.