### PR TITLE
Check that items has tongOpening attributes before rendering

### DIFF
--- a/Item/ItemTongs.cs
+++ b/Item/ItemTongs.cs
@@ -156,8 +156,10 @@ namespace Vintagestory.GameContent
                 var stack = eplr.RightHandItemSlot.Itemstack;
                 if (stack.Collectible.GetTemperature(forEntity.World, stack) > GlobalConstants.TooHotToTouchTemperature)
                 {
-                    var opening = stack.Collectible.Attributes["tongOpening"].AsString("1");
-                    tpIdleAnim = "holdbothhands-tongs" + opening;
+                    var opening = stack.Collectible.Attributes?["tongOpening"]?.AsString("1");
+                    if (!string.IsNullOrEmpty(opening)) {
+                        tpIdleAnim = "holdbothhands-tongs" + opening;
+                    }
                     return true;
                 }
             }


### PR DESCRIPTION
FIxes https://github.com/anegostudios/VintageStory-Issues/issues/8664

Sort of. There are checks in other places, but not here. Some modded items don't have tongOpening attribute (yet?) and it's not the worst idea to not trust them...