### PR TITLE
Fixing mechanical block texture issues caused by texture atlases

### DIFF
--- a/Systems/MechanicalPower/Renderer/AngledCageGearRenderer.cs
+++ b/Systems/MechanicalPower/Renderer/AngledCageGearRenderer.cs
@@ -1,4 +1,5 @@
-﻿using Vintagestory.API.Client;
+using System.Collections.Generic;
+using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;
 
@@ -9,11 +10,10 @@ namespace Vintagestory.GameContent.Mechanics
     public class AngledCageGearRenderer : MechBlockRenderer
     {
         CustomMeshDataPartFloat matrixAndLightFloats;
-        MeshRef blockMeshRef;
+        List<MeshGroup> meshGroups;
 
         public AngledCageGearRenderer(ICoreClientAPI capi, MechanicalPowerMod mechanicalPowerMod, Block textureSoureBlock, CompositeShape shapeLoc) : base(capi, mechanicalPowerMod)
         {
-
             AssetLocation loc = shapeLoc.Base.Clone().WithPathPrefixOnce("shapes/").WithPathAppendixOnce(".json");
 
             Shape shape = API.Common.Shape.TryGet(capi, loc);
@@ -27,16 +27,14 @@ namespace Vintagestory.GameContent.Mechanics
                 {
                     CompositeShape ovShapeCmp = shapeLoc.Overlays[i];
                     rot = new Vec3f(ovShapeCmp.rotateX, ovShapeCmp.rotateY, ovShapeCmp.rotateZ);
-                    
+
                     Shape ovshape = API.Common.Shape.TryGet(capi, ovShapeCmp.Base.Clone().WithPathPrefixOnce("shapes/").WithPathAppendixOnce(".json"));
                     capi.Tesselator.TesselateShape(textureSoureBlock, ovshape, out MeshData overlayMesh, rot);
                     blockMesh.AddMeshData(overlayMesh);
                 }
             }
 
-            //blockMesh.Rgba2 = null;
-
-            // 16 floats matrix, 4 floats light rgbs
+            // 16 floats matrix, 4 floats light rgba
             blockMesh.CustomFloats = matrixAndLightFloats = new CustomMeshDataPartFloat((16 + 4) * 10100)
             {
                 Instanced = true,
@@ -47,10 +45,9 @@ namespace Vintagestory.GameContent.Mechanics
             };
             blockMesh.CustomFloats.SetAllocationSize((16 + 4) * 10100);
 
-            this.blockMeshRef = capi.Render.UploadMesh(blockMesh);
+            meshGroups = UploadMeshGrouped(blockMesh, matrixAndLightFloats);
         }
 
-        
         protected override void UpdateLightAndTransformMatrix(int index, Vec3f distToCamera, float rotation, IMechanicalPowerRenderable dev)
         {
             BEBehaviorMPAngledGears gear = dev as BEBehaviorMPAngledGears;
@@ -69,18 +66,14 @@ namespace Vintagestory.GameContent.Mechanics
 
             if (quantityBlocks > 0)
             {
-                matrixAndLightFloats.Count = quantityBlocks * 20;
-                updateMesh.CustomFloats = matrixAndLightFloats;
-                capi.Render.UpdateMesh(blockMeshRef, updateMesh);
-                capi.Render.RenderMeshInstanced(blockMeshRef, quantityBlocks);
+                RenderGroups(prog, meshGroups, matrixAndLightFloats, quantityBlocks);
             }
         }
 
         public override void Dispose()
         {
             base.Dispose();
-
-            blockMeshRef?.Dispose();
+            DisposeGroups(meshGroups);
         }
     }
 }

--- a/Systems/MechanicalPower/Renderer/AngledGearBlockRenderer.cs
+++ b/Systems/MechanicalPower/Renderer/AngledGearBlockRenderer.cs
@@ -1,4 +1,5 @@
-﻿using Vintagestory.API.Client;
+using System.Collections.Generic;
+using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;
 
@@ -8,12 +9,11 @@ namespace Vintagestory.GameContent.Mechanics
 {
     public class AngledGearsBlockRenderer : MechBlockRenderer
     {
-        MeshRef gearboxCage;
-        MeshRef gearboxPeg;
+        List<MeshGroup> pegGroups;
+        List<MeshGroup> cageGroups;
 
         CustomMeshDataPartFloat floatsPeg;
         CustomMeshDataPartFloat floatsCage;
-
 
         public AngledGearsBlockRenderer(ICoreClientAPI capi, MechanicalPowerMod mechanicalPowerMod, Block textureSoureBlock, CompositeShape shapeLoc) : base(capi, mechanicalPowerMod)
         {
@@ -22,8 +22,8 @@ namespace Vintagestory.GameContent.Mechanics
             capi.Tesselator.TesselateShape(textureSoureBlock, API.Common.Shape.TryGet(capi, "shapes/block/wood/mechanics/angledgearbox-cage.json"), out MeshData gearboxCageMesh, rot);
             capi.Tesselator.TesselateShape(textureSoureBlock, API.Common.Shape.TryGet(capi, "shapes/block/wood/mechanics/angledgearbox-peg.json"), out MeshData gearboxPegMesh, rot);
 
-            
-            // 16 floats matrix, 4 floats light rgbs
+            // 16 floats matrix, 4 floats light rgba
+            // Cage and peg rotate independently so they need separate float buffers.
             gearboxPegMesh.CustomFloats = floatsPeg = new CustomMeshDataPartFloat((16 + 4) * 10100)
             {
                 Instanced = true,
@@ -34,10 +34,11 @@ namespace Vintagestory.GameContent.Mechanics
             };
             gearboxPegMesh.CustomFloats.SetAllocationSize((16 + 4) * 10100);
 
+            // Clone so cage transform data is independent from peg transform data
             gearboxCageMesh.CustomFloats = floatsCage = floatsPeg.Clone();
 
-            this.gearboxPeg = capi.Render.UploadMesh(gearboxPegMesh);
-            this.gearboxCage = capi.Render.UploadMesh(gearboxCageMesh);
+            pegGroups = UploadMeshGrouped(gearboxPegMesh, floatsPeg);
+            cageGroups = UploadMeshGrouped(gearboxCageMesh, floatsCage);
         }
 
         protected override void UpdateLightAndTransformMatrix(int index, Vec3f distToCamera, float rotationRad, IMechanicalPowerRenderable dev)
@@ -51,16 +52,17 @@ namespace Vintagestory.GameContent.Mechanics
                     rotationRad = -rotationRad;
                 }
             }
+
             float rotX = rotationRad * dev.AxisSign[0];
             float rotY = rotationRad * dev.AxisSign[1];
             float rotZ = rotationRad * dev.AxisSign[2];
-            UpdateLightAndTransformMatrix(floatsPeg.Values, index, distToCamera, dev.LightRgba, rotX, rotY, rotZ);// - 0.08f);
+            UpdateLightAndTransformMatrix(floatsPeg.Values, index, distToCamera, dev.LightRgba, rotX, rotY, rotZ);
 
             if (dev.AxisSign.Length < 4)
             {
-                //System.Diagnostics.Debug.WriteLine("3 length AxisSign");
                 return;
             }
+
             rotX = rotationRad * dev.AxisSign[3];
             rotY = rotationRad * dev.AxisSign[4];
             rotZ = rotationRad * dev.AxisSign[5];
@@ -73,26 +75,16 @@ namespace Vintagestory.GameContent.Mechanics
 
             if (quantityBlocks > 0)
             {
-                floatsPeg.Count = quantityBlocks * 20;
-                floatsCage.Count = quantityBlocks * 20;
-
-                updateMesh.CustomFloats = floatsPeg;
-                capi.Render.UpdateMesh(gearboxPeg, updateMesh);
-
-                updateMesh.CustomFloats = floatsCage;
-                capi.Render.UpdateMesh(gearboxCage, updateMesh);
-
-                capi.Render.RenderMeshInstanced(gearboxPeg, quantityBlocks);
-                capi.Render.RenderMeshInstanced(gearboxCage, quantityBlocks);
+                RenderGroups(prog, pegGroups, floatsPeg, quantityBlocks);
+                RenderGroups(prog, cageGroups, floatsCage, quantityBlocks);
             }
         }
 
         public override void Dispose()
         {
             base.Dispose();
-
-            gearboxCage?.Dispose();
-            gearboxPeg?.Dispose();
+            DisposeGroups(cageGroups);
+            DisposeGroups(pegGroups);
         }
     }
 }

--- a/Systems/MechanicalPower/Renderer/ClutchBlockRenderer.cs
+++ b/Systems/MechanicalPower/Renderer/ClutchBlockRenderer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;
@@ -10,27 +11,20 @@ namespace Vintagestory.GameContent.Mechanics
     {
         CustomMeshDataPartFloat matrixAndLightFloats1;
         CustomMeshDataPartFloat matrixAndLightFloats2;
-        MeshRef blockMeshRef1;
-        MeshRef blockMeshRef2;
+        List<MeshGroup> meshGroups1;
+        List<MeshGroup> meshGroups2;
 
         public ClutchBlockRenderer(ICoreClientAPI capi, MechanicalPowerMod mechanicalPowerMod, Block textureSoureBlock, CompositeShape shapeLoc) : base(capi, mechanicalPowerMod)
         {
-
-            AssetLocation loc = new AssetLocation("shapes/block/wood/mechanics/clutch-arm.json");
-
-            Shape shape = API.Common.Shape.TryGet(capi, loc);
             Vec3f rot = new Vec3f(shapeLoc.rotateX, shapeLoc.rotateY, shapeLoc.rotateZ);
 
-            capi.Tesselator.TesselateShape(textureSoureBlock, shape, out MeshData blockMesh1, rot);
-
-            rot = new Vec3f(shapeLoc.rotateX, shapeLoc.rotateY, shapeLoc.rotateZ);
+            Shape shape = API.Common.Shape.TryGet(capi, new AssetLocation("shapes/block/wood/mechanics/clutch-arm.json"));
             Shape ovshape = API.Common.Shape.TryGet(capi, new AssetLocation("shapes/block/wood/mechanics/clutch-drum.json"));
+
+            capi.Tesselator.TesselateShape(textureSoureBlock, shape, out MeshData blockMesh1, rot);
             capi.Tesselator.TesselateShape(textureSoureBlock, ovshape, out MeshData blockMesh2, rot);
 
-            //blockMesh1.Rgba2 = null;
-            //blockMesh2.Rgba2 = null;
-
-            // 16 floats matrix, 4 floats light rgbs
+            // 16 floats matrix, 4 floats light rgba
             blockMesh1.CustomFloats = matrixAndLightFloats1 = new CustomMeshDataPartFloat((16 + 4) * 10100)
             {
                 Instanced = true,
@@ -40,6 +34,7 @@ namespace Vintagestory.GameContent.Mechanics
                 StaticDraw = false,
             };
             blockMesh1.CustomFloats.SetAllocationSize((16 + 4) * 10100);
+
             blockMesh2.CustomFloats = matrixAndLightFloats2 = new CustomMeshDataPartFloat((16 + 4) * 10100)
             {
                 Instanced = true,
@@ -50,15 +45,15 @@ namespace Vintagestory.GameContent.Mechanics
             };
             blockMesh2.CustomFloats.SetAllocationSize((16 + 4) * 10100);
 
-            this.blockMeshRef1 = capi.Render.UploadMesh(blockMesh1);
-            this.blockMeshRef2 = capi.Render.UploadMesh(blockMesh2);
+            meshGroups1 = UploadMeshGrouped(blockMesh1, matrixAndLightFloats1);
+            meshGroups2 = UploadMeshGrouped(blockMesh2, matrixAndLightFloats2);
         }
-
 
         protected override void UpdateLightAndTransformMatrix(int index, Vec3f distToCamera, float rotation, IMechanicalPowerRenderable dev)
         {
             BEClutch clutch = dev as BEClutch;
             if (clutch == null) return;
+
             float rot1 = clutch.AngleRad;
             float rot2 = clutch.RotationNeighbour();
 
@@ -95,7 +90,6 @@ namespace Vintagestory.GameContent.Mechanics
             Mat4f.MulQuat(tmpMat, quat);
 
             Mat4f.Translate(tmpMat, tmpMat, -axis.X, -axis.Y, -axis.Z);
-            //if (xtraTransform != null) Mat4f.Mul(tmpMat, tmpMat, xtraTransform);
 
             int j = index * 20;
             values[j] = lightRgba.R;
@@ -104,9 +98,8 @@ namespace Vintagestory.GameContent.Mechanics
             values[++j] = lightRgba.A;
 
             for (int i = 0; i < 16; i++)
-            {
                 values[++j] = tmpMat[i];
-            }
+
             return tmpMat;
         }
 
@@ -116,23 +109,16 @@ namespace Vintagestory.GameContent.Mechanics
 
             if (quantityBlocks > 0)
             {
-                matrixAndLightFloats1.Count = quantityBlocks * 20;
-                updateMesh.CustomFloats = matrixAndLightFloats1;
-                capi.Render.UpdateMesh(blockMeshRef1, updateMesh);
-                capi.Render.RenderMeshInstanced(blockMeshRef1, quantityBlocks);
-                matrixAndLightFloats2.Count = quantityBlocks * 20;
-                updateMesh.CustomFloats = matrixAndLightFloats2;
-                capi.Render.UpdateMesh(blockMeshRef2, updateMesh);
-                capi.Render.RenderMeshInstanced(blockMeshRef2, quantityBlocks);
+                RenderGroups(prog, meshGroups1, matrixAndLightFloats1, quantityBlocks);
+                RenderGroups(prog, meshGroups2, matrixAndLightFloats2, quantityBlocks);
             }
         }
 
         public override void Dispose()
         {
             base.Dispose();
-
-            blockMeshRef1?.Dispose();
-            blockMeshRef2?.Dispose();
+            DisposeGroups(meshGroups1);
+            DisposeGroups(meshGroups2);
         }
     }
 }

--- a/Systems/MechanicalPower/Renderer/CreativeRotorRenderer.cs
+++ b/Systems/MechanicalPower/Renderer/CreativeRotorRenderer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;
@@ -14,52 +15,42 @@ namespace Vintagestory.GameContent.Mechanics
         CustomMeshDataPartFloat matrixAndLightFloats3;
         CustomMeshDataPartFloat matrixAndLightFloats4;
         CustomMeshDataPartFloat matrixAndLightFloats5;
-        MeshRef blockMeshRef1;
-        MeshRef blockMeshRef2;
-        MeshRef blockMeshRef3;
-        MeshRef blockMeshRef4;
+
+        List<MeshGroup> meshGroups1;   // axle
+        List<MeshGroup> meshGroups2;   // contra-rotating parts
+        List<MeshGroup> meshGroups3;   // spinbar
+        List<MeshGroup> meshGroups4;   // spinball (same mesh, used for both ball instances)
+
         Vec3f axisCenter = new Vec3f(0.5f, 0.5f, 0.5f);
 
         public CreativeRotorRenderer(ICoreClientAPI capi, MechanicalPowerMod mechanicalPowerMod, Block textureSoureBlock, CompositeShape shapeLoc) : base(capi, mechanicalPowerMod)
         {
-
-            AssetLocation loc = new AssetLocation("shapes/block/metal/mechanics/creativerotor-axle.json");
-
-            Shape shape = API.Common.Shape.TryGet(capi, loc);
             Vec3f rot = new Vec3f(shapeLoc.rotateX, shapeLoc.rotateY, shapeLoc.rotateZ);
 
-            capi.Tesselator.TesselateShape(textureSoureBlock, shape, out MeshData blockMesh1, rot);
-
-            rot = new Vec3f(shapeLoc.rotateX, shapeLoc.rotateY, shapeLoc.rotateZ);
-            Shape ovshape = API.Common.Shape.TryGet(capi, new AssetLocation("shapes/block/metal/mechanics/creativerotor-contra.json"));
-            capi.Tesselator.TesselateShape(textureSoureBlock, ovshape, out MeshData blockMesh2, rot);
-            Shape ovshape2 = API.Common.Shape.TryGet(capi, new AssetLocation("shapes/block/metal/mechanics/creativerotor-spinbar.json"));
-            capi.Tesselator.TesselateShape(textureSoureBlock, ovshape2, out MeshData blockMesh3, rot);
-            Shape ovshape3 = API.Common.Shape.TryGet(capi, new AssetLocation("shapes/block/metal/mechanics/creativerotor-spinball.json"));
-            capi.Tesselator.TesselateShape(textureSoureBlock, ovshape3, out MeshData blockMesh4, rot);
-
-            //blockMesh1.Rgba2 = null;
-            //blockMesh2.Rgba2 = null;
-            //blockMesh3.Rgba2 = null;
-            //blockMesh4.Rgba2 = null;
+            capi.Tesselator.TesselateShape(textureSoureBlock, API.Common.Shape.TryGet(capi, new AssetLocation("shapes/block/metal/mechanics/creativerotor-axle.json")), out MeshData blockMesh1, rot);
+            capi.Tesselator.TesselateShape(textureSoureBlock, API.Common.Shape.TryGet(capi, new AssetLocation("shapes/block/metal/mechanics/creativerotor-contra.json")), out MeshData blockMesh2, rot);
+            capi.Tesselator.TesselateShape(textureSoureBlock, API.Common.Shape.TryGet(capi, new AssetLocation("shapes/block/metal/mechanics/creativerotor-spinbar.json")), out MeshData blockMesh3, rot);
+            capi.Tesselator.TesselateShape(textureSoureBlock, API.Common.Shape.TryGet(capi, new AssetLocation("shapes/block/metal/mechanics/creativerotor-spinball.json")), out MeshData blockMesh4, rot);
 
             int count = (16 + 4) * 2100;
-            // 16 floats matrix, 4 floats light rgbs
-            blockMesh1.CustomFloats = matrixAndLightFloats1 = createCustomFloats(count);
-            blockMesh2.CustomFloats = matrixAndLightFloats2 = createCustomFloats(count);
-            blockMesh3.CustomFloats = matrixAndLightFloats3 = createCustomFloats(count);
-            blockMesh4.CustomFloats = matrixAndLightFloats4 = createCustomFloats(count);
-            matrixAndLightFloats5 = createCustomFloats(count);
 
-            this.blockMeshRef1 = capi.Render.UploadMesh(blockMesh1);
-            this.blockMeshRef2 = capi.Render.UploadMesh(blockMesh2);
-            this.blockMeshRef3 = capi.Render.UploadMesh(blockMesh3);
-            this.blockMeshRef4 = capi.Render.UploadMesh(blockMesh4);
+            blockMesh1.CustomFloats = matrixAndLightFloats1 = CreateCustomFloats(count);
+            blockMesh2.CustomFloats = matrixAndLightFloats2 = CreateCustomFloats(count);
+            blockMesh3.CustomFloats = matrixAndLightFloats3 = CreateCustomFloats(count);
+            blockMesh4.CustomFloats = matrixAndLightFloats4 = CreateCustomFloats(count);
+            // Ball 5 shares the same mesh groups as ball 4 but uses an independent transform buffer
+            matrixAndLightFloats5 = CreateCustomFloats(count);
+
+            meshGroups1 = UploadMeshGrouped(blockMesh1, matrixAndLightFloats1);
+            meshGroups2 = UploadMeshGrouped(blockMesh2, matrixAndLightFloats2);
+            meshGroups3 = UploadMeshGrouped(blockMesh3, matrixAndLightFloats3);
+            // meshGroups4 is uploaded once; rendered twice with different float buffers (ball 4 and ball 5)
+            meshGroups4 = UploadMeshGrouped(blockMesh4, matrixAndLightFloats4);
         }
 
-        private CustomMeshDataPartFloat createCustomFloats(int count)
+        private CustomMeshDataPartFloat CreateCustomFloats(int count)
         {
-            CustomMeshDataPartFloat result = new CustomMeshDataPartFloat(count)
+            var result = new CustomMeshDataPartFloat(count)
             {
                 Instanced = true,
                 InterleaveOffsets = new int[] { 0, 16, 32, 48, 64 },
@@ -79,53 +70,40 @@ namespace Vintagestory.GameContent.Mechanics
             float axX = -Math.Abs(dev.AxisSign[0]);
             float axZ = -Math.Abs(dev.AxisSign[2]);
 
-            //axle
-            float rotX = rot1 * axX;
-            float rotZ = rot1 * axZ;
-            UpdateLightAndTransformMatrix(matrixAndLightFloats1.Values, index, distToCamera, dev.LightRgba, rotX, rotZ, axisCenter, null);
+            // Axle
+            UpdateLightAndTransformMatrix(matrixAndLightFloats1.Values, index, distToCamera, dev.LightRgba, rot1 * axX, rot1 * axZ, axisCenter, null);
 
-            //contra-rotating axle parts
-            rotX = rot2 * axX;
-            rotZ = rot2 * axZ;
-            UpdateLightAndTransformMatrix(matrixAndLightFloats2.Values, index, distToCamera, dev.LightRgba, rotX, rotZ, axisCenter, null);
+            // Contra-rotating axle
+            UpdateLightAndTransformMatrix(matrixAndLightFloats2.Values, index, distToCamera, dev.LightRgba, rot2 * axX, rot2 * axZ, axisCenter, null);
 
-            //the spin bar
-            rotX = rot3 * axX;
-            rotZ = rot3 * axZ;
-            UpdateLightAndTransformMatrix(matrixAndLightFloats3.Values, index, distToCamera, dev.LightRgba, rotX, rotZ, axisCenter, null);
+            // Spinbar
+            UpdateLightAndTransformMatrix(matrixAndLightFloats3.Values, index, distToCamera, dev.LightRgba, rot3 * axX, rot3 * axZ, axisCenter, null);
 
-            //position the ball on the spin bar (45 degrees ahead of the spinbar)
-            rotX = (rot3 + GameMath.PI / 4) * axX;
-            rotZ = (rot3 + GameMath.PI / 4) * axZ;
-            TransformMatrix(distToCamera, rotX, rotZ, axisCenter);
+            // Ball 4: position on spinbar (45° ahead), then apply its own spin
+            TransformMatrix(distToCamera, (rot3 + GameMath.PI / 4) * axX, (rot3 + GameMath.PI / 4) * axZ, axisCenter);
+            float b4rotX = axX == 0 ? rot1 * 2f : 0f;
+            float b4rotZ = axZ == 0 ? -rot1 * 2f : 0f;
+            float offX4 = dev.AxisSign[0] * 0.05f;
+            float offZ4 = dev.AxisSign[2] * 0.05f;
+            UpdateLightAndTransformMatrix(matrixAndLightFloats4.Values, index, distToCamera, dev.LightRgba, b4rotX, b4rotZ, new Vec3f(0.5f + offX4, 0.5f, 0.5f + offZ4), (float[])tmpMat.Clone());
 
-            rotX = axX == 0 ? rot1 * 2f : 0f;
-            rotZ = axZ == 0 ? -rot1 * 2f : 0f;
-            axX = dev.AxisSign[0] * 0.05f;
-            axZ = dev.AxisSign[2] * 0.05f;
-            UpdateLightAndTransformMatrix(matrixAndLightFloats4.Values, index, distToCamera, dev.LightRgba, rotX, rotZ, new Vec3f(0.5f + axX, 0.5f, 0.5f + axZ), (float[])tmpMat.Clone());
-
-            //position the other ball on the spin bar (225 degrees ahead of the spinbar i.e. opposite side from the first one)
-            rotX = (rot3 + GameMath.PI * 1.25f) * -Math.Abs(dev.AxisSign[0]);
-            rotZ = (rot3 + GameMath.PI * 1.25f) * -Math.Abs(dev.AxisSign[2]);
-            TransformMatrix(distToCamera, rotX, rotZ, axisCenter);
-
-            rotX = axX == 0 ? rot1 * 2f : 0f;
-            rotZ = axZ == 0 ? -rot1 * 2f : 0f;
-            UpdateLightAndTransformMatrix(matrixAndLightFloats5.Values, index, distToCamera, dev.LightRgba, rotX, rotZ, new Vec3f(0.5f + axX, 0.5f, 0.5f + axZ), (float[])tmpMat.Clone());
+            // Ball 5: opposite side of spinbar (225° ahead)
+            TransformMatrix(distToCamera, (rot3 + GameMath.PI * 1.25f) * -Math.Abs(dev.AxisSign[0]), (rot3 + GameMath.PI * 1.25f) * -Math.Abs(dev.AxisSign[2]), axisCenter);
+            float b5rotX = offX4 == 0 ? rot1 * 2f : 0f;
+            float b5rotZ = offZ4 == 0 ? -rot1 * 2f : 0f;
+            UpdateLightAndTransformMatrix(matrixAndLightFloats5.Values, index, distToCamera, dev.LightRgba, b5rotX, b5rotZ, new Vec3f(0.5f + offX4, 0.5f, 0.5f + offZ4), (float[])tmpMat.Clone());
         }
 
         /// <summary>
-        /// Set up tmpMat - expected to be used with a later call to UpdateLightAndTransformMatrix passing in tmpMat as an initial matrix
+        /// Builds tmpMat representing the current world-space position of a sub-element
+        /// before its own local rotation is applied. Pass the result as initialTransform to
+        /// the overload of UpdateLightAndTransformMatrix that accepts an initial matrix.
         /// </summary>
         private void TransformMatrix(Vec3f distToCamera, float rotX, float rotZ, Vec3f axis)
         {
             Mat4f.Identity(tmpMat);
             Mat4f.Translate(tmpMat, tmpMat, distToCamera.X + axis.X, distToCamera.Y + axis.Y, distToCamera.Z + axis.Z);
-            quat[0] = 0;
-            quat[1] = 0;
-            quat[2] = 0;
-            quat[3] = 1;
+            quat[0] = 0; quat[1] = 0; quat[2] = 0; quat[3] = 1;
             if (rotX != 0f) Quaterniond.RotateX(quat, quat, rotX);
             if (rotZ != 0f) Quaterniond.RotateZ(quat, quat, rotZ);
             Mat4f.MulQuat(tmpMat, quat);
@@ -133,7 +111,8 @@ namespace Vintagestory.GameContent.Mechanics
         }
 
         /// <summary>
-        /// The initialTransform parameter is either null, to start with the Identity matrix and apply the camera transform, or for movable+rotating sub-elements can pass in an existing matrix which represents the current positioning of the sub-element (prior to the sub-element's own rotation)
+        /// When initialTransform is null: starts from Identity + camera translation.
+        /// When initialTransform is provided: continues from that matrix (for compound-rotating sub-elements).
         /// </summary>
         protected void UpdateLightAndTransformMatrix(float[] values, int index, Vec3f distToCamera, Vec4f lightRgba, float rotX, float rotZ, Vec3f axis, float[] initialTransform)
         {
@@ -145,15 +124,11 @@ namespace Vintagestory.GameContent.Mechanics
             else
                 Mat4f.Translate(tmpMat, tmpMat, axis.X, axis.Y, axis.Z);
 
-            quat[0] = 0;
-            quat[1] = 0;
-            quat[2] = 0;
-            quat[3] = 1;
+            quat[0] = 0; quat[1] = 0; quat[2] = 0; quat[3] = 1;
             if (rotX != 0f) Quaterniond.RotateX(quat, quat, rotX);
             if (rotZ != 0f) Quaterniond.RotateZ(quat, quat, rotZ);
 
             Mat4f.MulQuat(tmpMat, quat);
-
             Mat4f.Translate(tmpMat, tmpMat, -axis.X, -axis.Y, -axis.Z);
 
             int j = index * 20;
@@ -161,11 +136,7 @@ namespace Vintagestory.GameContent.Mechanics
             values[++j] = lightRgba.G;
             values[++j] = lightRgba.B;
             values[++j] = lightRgba.A;
-
-            for (int i = 0; i < 16; i++)
-            {
-                values[++j] = tmpMat[i];
-            }
+            for (int i = 0; i < 16; i++) values[++j] = tmpMat[i];
         }
 
         public override void OnRenderFrame(float deltaTime, IShaderProgram prog)
@@ -174,39 +145,25 @@ namespace Vintagestory.GameContent.Mechanics
 
             if (quantityBlocks > 0)
             {
-                matrixAndLightFloats1.Count = quantityBlocks * 20;
-                updateMesh.CustomFloats = matrixAndLightFloats1;
-                capi.Render.UpdateMesh(blockMeshRef1, updateMesh);
-                capi.Render.RenderMeshInstanced(blockMeshRef1, quantityBlocks);
-                matrixAndLightFloats2.Count = quantityBlocks * 20;
-                updateMesh.CustomFloats = matrixAndLightFloats2;
-                capi.Render.UpdateMesh(blockMeshRef2, updateMesh);
-                capi.Render.RenderMeshInstanced(blockMeshRef2, quantityBlocks);
-                matrixAndLightFloats3.Count = quantityBlocks * 20;
-                updateMesh.CustomFloats = matrixAndLightFloats3;
-                capi.Render.UpdateMesh(blockMeshRef3, updateMesh);
-                capi.Render.RenderMeshInstanced(blockMeshRef3, quantityBlocks);
+                RenderGroups(prog, meshGroups1, matrixAndLightFloats1, quantityBlocks);
+                RenderGroups(prog, meshGroups2, matrixAndLightFloats2, quantityBlocks);
+                RenderGroups(prog, meshGroups3, matrixAndLightFloats3, quantityBlocks);
 
-                //Sub elements 4 and 5 are the two spinbar balls, each has the exact same mesh (blockMeshRef4) but a different transform
-                matrixAndLightFloats4.Count = quantityBlocks * 20;
-                updateMesh.CustomFloats = matrixAndLightFloats4;
-                capi.Render.UpdateMesh(blockMeshRef4, updateMesh);
-                capi.Render.RenderMeshInstanced(blockMeshRef4, quantityBlocks);
-                matrixAndLightFloats5.Count = quantityBlocks * 20;
-                updateMesh.CustomFloats = matrixAndLightFloats5;
-                capi.Render.UpdateMesh(blockMeshRef4, updateMesh);
-                capi.Render.RenderMeshInstanced(blockMeshRef4, quantityBlocks);
+                // Both spinbar balls share the same mesh geometry (meshGroups4) but have
+                // independent transform buffers, so we render the groups twice.
+                RenderGroups(prog, meshGroups4, matrixAndLightFloats4, quantityBlocks);
+                RenderGroups(prog, meshGroups4, matrixAndLightFloats5, quantityBlocks);
             }
         }
 
         public override void Dispose()
         {
             base.Dispose();
-
-            blockMeshRef1?.Dispose();
-            blockMeshRef2?.Dispose();
-            blockMeshRef3?.Dispose();
-            blockMeshRef4?.Dispose();
+            DisposeGroups(meshGroups1);
+            DisposeGroups(meshGroups2);
+            DisposeGroups(meshGroups3);
+            DisposeGroups(meshGroups4);
+            // meshGroups5 does not exist: it reuses meshGroups4's MeshRefs, already disposed above
         }
     }
 }

--- a/Systems/MechanicalPower/Renderer/GenericMechBlockRenderer.cs
+++ b/Systems/MechanicalPower/Renderer/GenericMechBlockRenderer.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;
@@ -8,10 +10,12 @@ namespace Vintagestory.GameContent.Mechanics
 {
     public class GenericMechBlockRenderer : MechBlockRenderer
     {
-        CustomMeshDataPartFloat matrixAndLightFloats;
-        MeshRef blockMeshRef;
+        private CustomMeshDataPartFloat matrixAndLightFloats;
+        private readonly List<MeshRef> blockMeshRefs = new List<MeshRef>();
+        private readonly List<int> blockMeshTextureIds = new List<int>();
 
-        public GenericMechBlockRenderer(ICoreClientAPI capi, MechanicalPowerMod mechanicalPowerMod, Block textureSoureBlock, CompositeShape shapeLoc) : base(capi, mechanicalPowerMod)
+        public GenericMechBlockRenderer(ICoreClientAPI capi, MechanicalPowerMod mechanicalPowerMod, Block textureSoureBlock, CompositeShape shapeLoc)
+            : base(capi, mechanicalPowerMod)
         {
             AssetLocation loc = shapeLoc.Base.Clone().WithPathPrefixOnce("shapes/").WithPathAppendixOnce(".json");
 
@@ -19,14 +23,14 @@ namespace Vintagestory.GameContent.Mechanics
             Vec3f rot = new Vec3f(shapeLoc.rotateX, shapeLoc.rotateY, shapeLoc.rotateZ);
 
             capi.Tesselator.TesselateShape(textureSoureBlock, shape, out MeshData blockMesh, rot, shapeLoc.QuantityElements, shapeLoc.SelectiveElements);
-            
+
             if (shapeLoc.Overlays != null)
             {
                 for (int i = 0; i < shapeLoc.Overlays.Length; i++)
                 {
                     CompositeShape ovShapeCmp = shapeLoc.Overlays[i];
                     rot = new Vec3f(ovShapeCmp.rotateX, ovShapeCmp.rotateY, ovShapeCmp.rotateZ);
-                    
+
                     Shape ovshape = API.Common.Shape.TryGet(capi, ovShapeCmp.Base.Clone().WithPathPrefixOnce("shapes/").WithPathAppendixOnce(".json"));
                     capi.Tesselator.TesselateShape(textureSoureBlock, ovshape, out MeshData overlayMesh, rot);
                     blockMesh.AddMeshData(overlayMesh);
@@ -44,15 +48,38 @@ namespace Vintagestory.GameContent.Mechanics
             };
             blockMesh.CustomFloats.SetAllocationSize((16 + 4) * 10100);
 
-            this.blockMeshRef = capi.Render.UploadMesh(blockMesh);
+            MeshData[] splitMeshes = blockMesh.SplitByTextureId();
+
+            for (int i = 0; i < splitMeshes.Length; i++)
+            {
+                MeshData mesh = splitMeshes[i];
+                if (mesh == null || mesh.VerticesCount == 0) continue;
+
+                if (mesh.CustomFloats == null)
+                {
+                    mesh.CustomFloats = matrixAndLightFloats;
+                }
+                else
+                {
+                    // keep the same instanced float layout for every split mesh
+                    mesh.CustomFloats = matrixAndLightFloats;
+                }
+
+                int atlasTextureId = (mesh.TextureIds != null && mesh.TextureIds.Length > 0)
+                    ? mesh.TextureIds[0]
+                    : capi.BlockTextureAtlas.Positions[0].atlasTextureId;
+
+                blockMeshTextureIds.Add(atlasTextureId);
+                blockMeshRefs.Add(capi.Render.UploadMesh(mesh));
+            }
         }
 
-        
         protected override void UpdateLightAndTransformMatrix(int index, Vec3f distToCamera, float rotation, IMechanicalPowerRenderable dev)
         {
             float rotX = rotation * dev.AxisSign[0];
             float rotY = rotation * dev.AxisSign[1];
             float rotZ = rotation * dev.AxisSign[2];
+
             if (dev is BEBehaviorMPToggle tog && (rotX == 0 ^ tog.IsRotationReversed()))
             {
                 rotY = GameMath.PI;
@@ -66,12 +93,16 @@ namespace Vintagestory.GameContent.Mechanics
         {
             UpdateCustomFloatBuffer();
 
-            if (quantityBlocks > 0)
+            if (quantityBlocks <= 0 || blockMeshRefs.Count == 0) return;
+
+            matrixAndLightFloats.Count = quantityBlocks * 20;
+            updateMesh.CustomFloats = matrixAndLightFloats;
+
+            for (int i = 0; i < blockMeshRefs.Count; i++)
             {
-                matrixAndLightFloats.Count = quantityBlocks * 20;
-                updateMesh.CustomFloats = matrixAndLightFloats;
-                capi.Render.UpdateMesh(blockMeshRef, updateMesh);
-                capi.Render.RenderMeshInstanced(blockMeshRef, quantityBlocks);
+                prog.BindTexture2D("tex", blockMeshTextureIds[i], 0);
+                capi.Render.UpdateMesh(blockMeshRefs[i], updateMesh);
+                capi.Render.RenderMeshInstanced(blockMeshRefs[i], quantityBlocks);
             }
         }
 
@@ -79,7 +110,13 @@ namespace Vintagestory.GameContent.Mechanics
         {
             base.Dispose();
 
-            blockMeshRef?.Dispose();
+            for (int i = 0; i < blockMeshRefs.Count; i++)
+            {
+                blockMeshRefs[i]?.Dispose();
+            }
+
+            blockMeshRefs.Clear();
+            blockMeshTextureIds.Clear();
         }
     }
 }

--- a/Systems/MechanicalPower/Renderer/GenericMechBlockRenderer.cs
+++ b/Systems/MechanicalPower/Renderer/GenericMechBlockRenderer.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
@@ -11,8 +10,7 @@ namespace Vintagestory.GameContent.Mechanics
     public class GenericMechBlockRenderer : MechBlockRenderer
     {
         private CustomMeshDataPartFloat matrixAndLightFloats;
-        private readonly List<MeshRef> blockMeshRefs = new List<MeshRef>();
-        private readonly List<int> blockMeshTextureIds = new List<int>();
+        private List<MeshGroup> meshGroups;
 
         public GenericMechBlockRenderer(ICoreClientAPI capi, MechanicalPowerMod mechanicalPowerMod, Block textureSoureBlock, CompositeShape shapeLoc)
             : base(capi, mechanicalPowerMod)
@@ -37,7 +35,7 @@ namespace Vintagestory.GameContent.Mechanics
                 }
             }
 
-            // 16 floats matrix, 4 floats light rgbs
+            // 16 floats matrix, 4 floats light rgba
             blockMesh.CustomFloats = matrixAndLightFloats = new CustomMeshDataPartFloat((16 + 4) * 10100)
             {
                 Instanced = true,
@@ -48,30 +46,9 @@ namespace Vintagestory.GameContent.Mechanics
             };
             blockMesh.CustomFloats.SetAllocationSize((16 + 4) * 10100);
 
-            MeshData[] splitMeshes = blockMesh.SplitByTextureId();
-
-            for (int i = 0; i < splitMeshes.Length; i++)
-            {
-                MeshData mesh = splitMeshes[i];
-                if (mesh == null || mesh.VerticesCount == 0) continue;
-
-                if (mesh.CustomFloats == null)
-                {
-                    mesh.CustomFloats = matrixAndLightFloats;
-                }
-                else
-                {
-                    // keep the same instanced float layout for every split mesh
-                    mesh.CustomFloats = matrixAndLightFloats;
-                }
-
-                int atlasTextureId = (mesh.TextureIds != null && mesh.TextureIds.Length > 0)
-                    ? mesh.TextureIds[0]
-                    : capi.BlockTextureAtlas.Positions[0].atlasTextureId;
-
-                blockMeshTextureIds.Add(atlasTextureId);
-                blockMeshRefs.Add(capi.Render.UploadMesh(mesh));
-            }
+            // UploadMeshGrouped splits by atlas and uploads each part,
+            // all parts sharing matrixAndLightFloats as their instanced buffer.
+            meshGroups = UploadMeshGrouped(blockMesh, matrixAndLightFloats);
         }
 
         protected override void UpdateLightAndTransformMatrix(int index, Vec3f distToCamera, float rotation, IMechanicalPowerRenderable dev)
@@ -93,30 +70,16 @@ namespace Vintagestory.GameContent.Mechanics
         {
             UpdateCustomFloatBuffer();
 
-            if (quantityBlocks <= 0 || blockMeshRefs.Count == 0) return;
-
-            matrixAndLightFloats.Count = quantityBlocks * 20;
-            updateMesh.CustomFloats = matrixAndLightFloats;
-
-            for (int i = 0; i < blockMeshRefs.Count; i++)
+            if (quantityBlocks > 0)
             {
-                prog.BindTexture2D("tex", blockMeshTextureIds[i], 0);
-                capi.Render.UpdateMesh(blockMeshRefs[i], updateMesh);
-                capi.Render.RenderMeshInstanced(blockMeshRefs[i], quantityBlocks);
+                RenderGroups(prog, meshGroups, matrixAndLightFloats, quantityBlocks);
             }
         }
 
         public override void Dispose()
         {
             base.Dispose();
-
-            for (int i = 0; i < blockMeshRefs.Count; i++)
-            {
-                blockMeshRefs[i]?.Dispose();
-            }
-
-            blockMeshRefs.Clear();
-            blockMeshTextureIds.Clear();
+            DisposeGroups(meshGroups);
         }
     }
 }

--- a/Systems/MechanicalPower/Renderer/MechBlockRenderer.cs
+++ b/Systems/MechanicalPower/Renderer/MechBlockRenderer.cs
@@ -6,6 +6,15 @@ using Vintagestory.API.MathTools;
 
 namespace Vintagestory.GameContent.Mechanics
 {
+    /// <summary>
+    /// Represents a single GPU mesh upload tied to a specific texture atlas.
+    /// </summary>
+    public struct MeshGroup
+    {
+        public MeshRef Ref;
+        public int AtlasTextureId;
+    }
+
     public abstract class MechBlockRenderer
     {
         protected ICoreClientAPI capi;
@@ -28,7 +37,7 @@ namespace Vintagestory.GameContent.Mechanics
             this.mechanicalPowerMod = mechanicalPowerMod;
             this.capi = capi;
         }
-        
+
         public void AddDevice(IMechanicalPowerRenderable device)
         {
             renderedDevices[device.Position] = device;
@@ -42,6 +51,66 @@ namespace Vintagestory.GameContent.Mechanics
             return ok;
         }
 
+        /// <summary>
+        /// Splits mesh by texture atlas ID and uploads each part as a MeshGroup.
+        /// All resulting groups share the same CustomMeshDataPartFloat (instanced transform buffer),
+        /// so a single UpdateLightAndTransformMatrix call covers all atlas parts of the same logical mesh.
+        /// </summary>
+        protected List<MeshGroup> UploadMeshGrouped(MeshData mesh, CustomMeshDataPartFloat floats)
+        {
+            var groups = new List<MeshGroup>();
+
+            MeshData[] splitMeshes = mesh.SplitByTextureId();
+            for (int i = 0; i < splitMeshes.Length; i++)
+            {
+                MeshData split = splitMeshes[i];
+                if (split == null || split.VerticesCount == 0) continue;
+
+                split.CustomFloats = floats;
+
+                int atlasId = (split.TextureIds != null && split.TextureIds.Length > 0)
+                    ? split.TextureIds[0]
+                    : capi.BlockTextureAtlas.Positions[0].atlasTextureId;
+
+                groups.Add(new MeshGroup
+                {
+                    Ref = capi.Render.UploadMesh(split),
+                    AtlasTextureId = atlasId
+                });
+            }
+
+            return groups;
+        }
+
+        /// <summary>
+        /// Updates the instanced float buffer and issues one instanced draw call per atlas group.
+        /// Call this instead of manual UpdateMesh + RenderMeshInstanced in OnRenderFrame.
+        /// </summary>
+        protected void RenderGroups(IShaderProgram prog, List<MeshGroup> groups, CustomMeshDataPartFloat floats, int quantity)
+        {
+            floats.Count = quantity * 20;
+            updateMesh.CustomFloats = floats;
+
+            for (int i = 0; i < groups.Count; i++)
+            {
+                MeshGroup group = groups[i];
+                prog.BindTexture2D("tex", group.AtlasTextureId, 0);
+                capi.Render.UpdateMesh(group.Ref, updateMesh);
+                capi.Render.RenderMeshInstanced(group.Ref, quantity);
+            }
+        }
+
+        /// <summary>
+        /// Disposes all MeshRefs in a group list and clears it.
+        /// </summary>
+        protected static void DisposeGroups(List<MeshGroup> groups)
+        {
+            if (groups == null) return;
+            for (int i = 0; i < groups.Count; i++)
+                groups[i].Ref?.Dispose();
+            groups.Clear();
+        }
+
         protected virtual void UpdateCustomFloatBuffer()
         {
             Vec3d pos = capi.World.Player.Entity.CameraPos;
@@ -49,9 +118,13 @@ namespace Vintagestory.GameContent.Mechanics
             int i = 0;
             foreach (var dev in renderedDevices.Values)
             {
-                //double precision int-double subtraction is needed here (even though the desired result is a float).  
-                // It's needed to have enough significant figures in the result, as the integer size could be large e.g. 50000 but the difference should be small (can easily be less than 5)
-                tmp.Set((float)(dev.Position.X - pos.X), (float)(dev.Position.InternalY - pos.Y), (float)(dev.Position.Z - pos.Z));  
+                // Double-precision subtraction is critical here: block positions can be very large
+                // (e.g. 50000), but the camera-relative offset must stay accurate to sub-block scale.
+                tmp.Set(
+                    (float)(dev.Position.X - pos.X),
+                    (float)(dev.Position.InternalY - pos.Y),
+                    (float)(dev.Position.Z - pos.Z)
+                );
 
                 UpdateLightAndTransformMatrix(i, tmp, dev.AngleRad % GameMath.TWOPI, dev);
                 i++;
@@ -85,21 +158,14 @@ namespace Vintagestory.GameContent.Mechanics
             values[++j] = lightRgba.A;
 
             for (int i = 0; i < 16; i++)
-            {
                 values[++j] = tmpMat[i];
-            }
         }
-
 
         public virtual void OnRenderFrame(float deltaTime, IShaderProgram prog)
         {
             UpdateCustomFloatBuffer();
         }
 
-        public virtual void Dispose()
-        {
-
-        }
+        public virtual void Dispose() { }
     }
 }
-

--- a/Systems/MechanicalPower/Renderer/MechNetworkRenderer.cs
+++ b/Systems/MechanicalPower/Renderer/MechNetworkRenderer.cs
@@ -13,12 +13,12 @@ namespace Vintagestory.GameContent.Mechanics
     /// </summary>
     public class MechNetworkRenderer : IRenderer
     {
-        MechanicalPowerMod mechanicalPowerMod;
-        ICoreClientAPI capi;
-        IShaderProgram prog;
+        private readonly MechanicalPowerMod mechanicalPowerMod;
+        private readonly ICoreClientAPI capi;
+        private IShaderProgram prog;
 
-        List<MechBlockRenderer> MechBlockRenderer = new List<MechBlockRenderer>();
-        Dictionary<int, int> MechBlockRendererByShape = new Dictionary<int, int>();
+        private readonly List<MechBlockRenderer> mechBlockRenderers = new List<MechBlockRenderer>();
+        private readonly Dictionary<int, int> mechBlockRendererByShape = new Dictionary<int, int>();
 
         public static Dictionary<string, Type> RendererByCode = new Dictionary<string, Type>()
         {
@@ -30,7 +30,7 @@ namespace Vintagestory.GameContent.Mechanics
             { "pulverizer", typeof(PulverizerRenderer) },
             { "autorotor", typeof(CreativeRotorRenderer) }
         };
-        
+
         public MechNetworkRenderer(ICoreClientAPI capi, MechanicalPowerMod mechanicalPowerMod)
         {
             this.mechanicalPowerMod = mechanicalPowerMod;
@@ -43,8 +43,6 @@ namespace Vintagestory.GameContent.Mechanics
             // This shader is created by the essentials mod in Core.cs
             prog = capi.Shader.GetProgramByName("instanced");
         }
-
-
 
         public void AddDevice(IMechanicalPowerRenderable device)
         {
@@ -59,29 +57,26 @@ namespace Vintagestory.GameContent.Mechanics
 
             int hashCode = device.Shape.GetHashCode() + device.Block.Textures.Values.GetHashCode() + rendererCode.GetHashCode();
 
-            if (!MechBlockRendererByShape.TryGetValue(hashCode, out index))
+            if (!mechBlockRendererByShape.TryGetValue(hashCode, out index))
             {
                 object obj = Activator.CreateInstance(RendererByCode[rendererCode], capi, mechanicalPowerMod, device.Block, device.Shape);
-                MechBlockRenderer.Add((MechBlockRenderer)obj);
-                MechBlockRendererByShape[hashCode] = index = MechBlockRenderer.Count - 1;
+                mechBlockRenderers.Add((MechBlockRenderer)obj);
+                mechBlockRendererByShape[hashCode] = index = mechBlockRenderers.Count - 1;
             }
 
-            MechBlockRenderer[index].AddDevice(device);
+            mechBlockRenderers[index].AddDevice(device);
         }
-
-        
 
         public void RemoveDevice(IMechanicalPowerRenderable device)
         {
             if (device.Shape == null) return;
 
-            foreach (var val in MechBlockRenderer)
+            foreach (var val in mechBlockRenderers)
             {
                 if (val.RemoveDevice(device)) return;
             }
         }
 
-        
         public void OnRenderFrame(float deltaTime, EnumRenderStage stage)
         {
             if (prog.Disposed) prog = capi.Shader.GetProgramByName("instanced");
@@ -90,9 +85,9 @@ namespace Vintagestory.GameContent.Mechanics
 
             if (stage == EnumRenderStage.Opaque)
             {
-                capi.Render.GlToggleBlend(false); // Seems to break SSAO without
+                capi.Render.GlToggleBlend(false);
                 prog.Use();
-                prog.BindTexture2D("tex", capi.BlockTextureAtlas.Positions[0].atlasTextureId, 0);
+
                 prog.Uniform("rgbaFogIn", capi.Render.FogColor);
                 prog.Uniform("rgbaAmbientIn", capi.Render.AmbientColor);
                 prog.Uniform("fogMinIn", capi.Render.FogMin);
@@ -100,9 +95,9 @@ namespace Vintagestory.GameContent.Mechanics
                 prog.UniformMatrix("projectionMatrix", capi.Render.CurrentProjectionMatrix);
                 prog.UniformMatrix("modelViewMatrix", capi.Render.CameraMatrixOriginf);
 
-                for (int i = 0; i < MechBlockRenderer.Count; i++)
+                for (int i = 0; i < mechBlockRenderers.Count; i++)
                 {
-                    MechBlockRenderer[i].OnRenderFrame(deltaTime, prog);
+                    mechBlockRenderers[i].OnRenderFrame(deltaTime, prog);
                 }
 
                 prog.Stop();
@@ -114,7 +109,7 @@ namespace Vintagestory.GameContent.Mechanics
                 rapi.CurrentActiveShader.BindTexture2D("tex2d", capi.BlockTextureAtlas.Positions[0].atlasTextureId, 0);
 
                 float[] mvpMat = Mat4f.Mul(Mat4f.Create(), capi.Render.CurrentProjectionMatrix, capi.Render.CurrentModelviewMatrix);
-                
+
                 capi.Render.CurrentActiveShader.UniformMatrix("mvpMatrix", mvpMat);
                 //capi.Render.CurrentActiveShader.Uniform("origin", new Vec3f());
 
@@ -124,32 +119,19 @@ namespace Vintagestory.GameContent.Mechanics
                 }*/
             }
 
-
             capi.Render.GlEnableCullFace();
         }
 
+        public double RenderOrder => 0.5;
 
-        public double RenderOrder
-        {
-            get
-            {
-                return 0.5;
-            }
-        }
-
-        public int RenderRange
-        {
-            get { return 100; }
-        }
+        public int RenderRange => 100;
 
         public void Dispose()
         {
-            for (int i = 0; i < MechBlockRenderer.Count; i++)
+            for (int i = 0; i < mechBlockRenderers.Count; i++)
             {
-                MechBlockRenderer[i].Dispose();
+                mechBlockRenderers[i].Dispose();
             }
         }
-
     }
 }
-

--- a/Systems/MechanicalPower/Renderer/MechNetworkRenderer.cs
+++ b/Systems/MechanicalPower/Renderer/MechNetworkRenderer.cs
@@ -22,13 +22,13 @@ namespace Vintagestory.GameContent.Mechanics
 
         public static Dictionary<string, Type> RendererByCode = new Dictionary<string, Type>()
         {
-            { "generic", typeof(GenericMechBlockRenderer) },
-            { "angledgears", typeof(AngledGearsBlockRenderer) },
-            { "angledgearcage", typeof(AngledCageGearRenderer) },
-            { "transmission", typeof(TransmissionBlockRenderer) },
-            { "clutch", typeof(ClutchBlockRenderer) },
-            { "pulverizer", typeof(PulverizerRenderer) },
-            { "autorotor", typeof(CreativeRotorRenderer) }
+            { "generic",       typeof(GenericMechBlockRenderer) },
+            { "angledgears",   typeof(AngledGearsBlockRenderer) },
+            { "angledgearcage",typeof(AngledCageGearRenderer) },
+            { "transmission",  typeof(TransmissionBlockRenderer) },
+            { "clutch",        typeof(ClutchBlockRenderer) },
+            { "pulverizer",    typeof(PulverizerRenderer) },
+            { "autorotor",     typeof(CreativeRotorRenderer) }
         };
 
         public MechNetworkRenderer(ICoreClientAPI capi, MechanicalPowerMod mechanicalPowerMod)
@@ -40,7 +40,6 @@ namespace Vintagestory.GameContent.Mechanics
             capi.Event.RegisterRenderer(this, EnumRenderStage.ShadowFar, "mechnetwork");
             capi.Event.RegisterRenderer(this, EnumRenderStage.ShadowNear, "mechnetwork");
 
-            // This shader is created by the essentials mod in Core.cs
             prog = capi.Shader.GetProgramByName("instanced");
         }
 
@@ -85,7 +84,7 @@ namespace Vintagestory.GameContent.Mechanics
 
             if (stage == EnumRenderStage.Opaque)
             {
-                capi.Render.GlToggleBlend(false); // Seems to break SSAO without
+                capi.Render.GlToggleBlend(false);
                 prog.Use();
 
                 prog.Uniform("rgbaFogIn", capi.Render.FogColor);
@@ -95,6 +94,10 @@ namespace Vintagestory.GameContent.Mechanics
                 prog.UniformMatrix("projectionMatrix", capi.Render.CurrentProjectionMatrix);
                 prog.UniformMatrix("modelViewMatrix", capi.Render.CameraMatrixOriginf);
 
+                // NOTE: BindTexture2D is intentionally NOT called here.
+                // Each MechBlockRenderer is responsible for binding the correct atlas
+                // per mesh group via RenderGroups(), which correctly handles meshes
+                // whose faces span multiple texture atlases.
                 for (int i = 0; i < mechBlockRenderers.Count; i++)
                 {
                     mechBlockRenderers[i].OnRenderFrame(deltaTime, prog);
@@ -105,18 +108,6 @@ namespace Vintagestory.GameContent.Mechanics
             else
             {
                 // TODO: Needs a custom shadow map shader
-                /*IRenderAPI rapi = capi.Render;
-                rapi.CurrentActiveShader.BindTexture2D("tex2d", capi.BlockTextureAtlas.Positions[0].atlasTextureId, 0);
-
-                float[] mvpMat = Mat4f.Mul(Mat4f.Create(), capi.Render.CurrentProjectionMatrix, capi.Render.CurrentModelviewMatrix);
-
-                capi.Render.CurrentActiveShader.UniformMatrix("mvpMatrix", mvpMat);
-                //capi.Render.CurrentActiveShader.Uniform("origin", new Vec3f());
-
-                for (int i = 0; i < MechBlockRenderer.Count; i++)
-                {
-                    MechBlockRenderer[i].OnRenderFrame(deltaTime, prog);
-                }*/
             }
 
             capi.Render.GlEnableCullFace();

--- a/Systems/MechanicalPower/Renderer/MechNetworkRenderer.cs
+++ b/Systems/MechanicalPower/Renderer/MechNetworkRenderer.cs
@@ -85,7 +85,7 @@ namespace Vintagestory.GameContent.Mechanics
 
             if (stage == EnumRenderStage.Opaque)
             {
-                capi.Render.GlToggleBlend(false);
+                capi.Render.GlToggleBlend(false); // Seems to break SSAO without
                 prog.Use();
 
                 prog.Uniform("rgbaFogIn", capi.Render.FogColor);

--- a/Systems/MechanicalPower/Renderer/PulverizerRenderer.cs
+++ b/Systems/MechanicalPower/Renderer/PulverizerRenderer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;
@@ -16,11 +17,11 @@ namespace Vintagestory.GameContent.Mechanics
         CustomMeshDataPartFloat[] matrixAndLightFloatsLPounder = new CustomMeshDataPartFloat[metals.Length];
         CustomMeshDataPartFloat[] matrixAndLightFloatsRPounder = new CustomMeshDataPartFloat[metals.Length];
 
-        readonly MeshRef toggleMeshref;
-        readonly MeshRef[] lPoundMeshrefs = new MeshRef[metals.Length];
-        readonly MeshRef[] rPounderMeshrefs = new MeshRef[metals.Length];
-        readonly Vec3f axisCenter = new Vec3f(0.5f, 0.5f, 0.5f);
+        readonly List<MeshGroup> toggleGroups;
+        readonly List<MeshGroup>[] lPoundGroups = new List<MeshGroup>[metals.Length];
+        readonly List<MeshGroup>[] rPoundGroups = new List<MeshGroup>[metals.Length];
 
+        readonly Vec3f axisCenter = new Vec3f(0.5f, 0.5f, 0.5f);
 
         int quantityAxles = 0;
         int[] quantityLPounders = new int[metals.Length];
@@ -28,67 +29,57 @@ namespace Vintagestory.GameContent.Mechanics
 
         public Size2i AtlasSize => capi.BlockTextureAtlas.Size;
 
-        public TextureAtlasPosition this[string textureCode] {
+        public TextureAtlasPosition this[string textureCode]
+        {
             get
             {
                 if (textureCode == "cap")
-                {
                     return texSource["capmetal-" + metal];
-                }
-
                 return texSource[textureCode];
             }
         }
-
 
         ITexPositionSource texSource;
         string metal;
 
         public PulverizerRenderer(ICoreClientAPI capi, MechanicalPowerMod mechanicalPowerMod, Block textureSoureBlock, CompositeShape shapeLoc) : base(capi, mechanicalPowerMod)
         {
-
-            // 16 floats matrix, 4 floats light rgbs
             int count = (16 + 4) * 200;
 
-
-            AssetLocation loc = new AssetLocation("shapes/block/wood/mechanics/pulverizer-moving.json");
-            Shape shape = API.Common.Shape.TryGet(capi, loc);
-            Vec3f rot = new Vec3f(shapeLoc.rotateX, shapeLoc.rotateY + 90F, shapeLoc.rotateZ);
+            // Axle / toggle mesh
+            Shape shape = API.Common.Shape.TryGet(capi, new AssetLocation("shapes/block/wood/mechanics/pulverizer-moving.json"));
+            Vec3f rot = new Vec3f(shapeLoc.rotateX, shapeLoc.rotateY + 90f, shapeLoc.rotateZ);
             capi.Tesselator.TesselateShape(textureSoureBlock, shape, out MeshData toggleMesh, rot);
-            toggleMesh.CustomFloats = matrixAndLightFloatsAxle = createCustomFloats(count);
-            toggleMeshref = capi.Render.UploadMesh(toggleMesh);
+            toggleMesh.CustomFloats = matrixAndLightFloatsAxle = CreateCustomFloats(count);
+            toggleGroups = UploadMeshGrouped(toggleMesh, matrixAndLightFloatsAxle);
 
-
-            AssetLocation locPounderL = new AssetLocation("shapes/block/wood/mechanics/pulverizer-pounder-l.json");
-            AssetLocation locPounderR = new AssetLocation("shapes/block/wood/mechanics/pulverizer-pounder-r.json"); 
-            
-            Shape shapel = API.Common.Shape.TryGet(capi, locPounderL);
-            Shape shaper = API.Common.Shape.TryGet(capi, locPounderR);
+            // Pounder meshes – one set per metal cap variant
+            Shape shapel = API.Common.Shape.TryGet(capi, new AssetLocation("shapes/block/wood/mechanics/pulverizer-pounder-l.json"));
+            Shape shaper = API.Common.Shape.TryGet(capi, new AssetLocation("shapes/block/wood/mechanics/pulverizer-pounder-r.json"));
 
             texSource = capi.Tesselator.GetTextureSource(textureSoureBlock);
-
-            
 
             for (int i = 0; i < metals.Length; i++)
             {
                 metal = metals[i];
 
-                matrixAndLightFloatsLPounder[i] = createCustomFloats(count);
-                matrixAndLightFloatsRPounder[i] = createCustomFloats(count);
+                matrixAndLightFloatsLPounder[i] = CreateCustomFloats(count);
+                matrixAndLightFloatsRPounder[i] = CreateCustomFloats(count);
 
                 capi.Tesselator.TesselateShape("pulverizer-pounder-l", shapel, out MeshData lPounderMesh, this, rot);
                 capi.Tesselator.TesselateShape("pulverizer-pounder-r", shaper, out MeshData rPounderMesh, this, rot);
+
                 lPounderMesh.CustomFloats = matrixAndLightFloatsLPounder[i];
                 rPounderMesh.CustomFloats = matrixAndLightFloatsRPounder[i];
-                lPoundMeshrefs[i] = capi.Render.UploadMesh(lPounderMesh);
-                rPounderMeshrefs[i] = capi.Render.UploadMesh(rPounderMesh);
-            }
 
+                lPoundGroups[i] = UploadMeshGrouped(lPounderMesh, matrixAndLightFloatsLPounder[i]);
+                rPoundGroups[i] = UploadMeshGrouped(rPounderMesh, matrixAndLightFloatsRPounder[i]);
+            }
         }
 
-        private CustomMeshDataPartFloat createCustomFloats(int count)
+        private CustomMeshDataPartFloat CreateCustomFloats(int count)
         {
-            CustomMeshDataPartFloat result = new CustomMeshDataPartFloat(count)
+            var result = new CustomMeshDataPartFloat(count)
             {
                 Instanced = true,
                 InterleaveOffsets = new int[] { 0, 16, 32, 48, 64 },
@@ -111,30 +102,24 @@ namespace Vintagestory.GameContent.Mechanics
             // Axle
             if (bhpu.bepu.hasAxle)
             {
-                float rotX = rot * axX;
-                float rotZ = rot * axZ;
-                UpdateLightAndTransformMatrix(matrixAndLightFloatsAxle.Values, quantityAxles, distToCamera, dev.LightRgba, rotX, rotZ, axisCenter, 0f);
+                UpdateLightAndTransformMatrix(matrixAndLightFloatsAxle.Values, quantityAxles, distToCamera, dev.LightRgba, rot * axX, rot * axZ, axisCenter, 0f);
                 quantityAxles++;
             }
 
-            //if ((dev.Block as BlockPulverizer).InvertPoundersOnRender) rot = -rot; - creates inverted animation. This should instead rather cause tons of resistance 
             if (bhpu.IsRotationReversed()) rot = -rot;
 
-            // Pounder-left
+            // Left pounder
             int metalIndexLeft = bhpu.bepu.CapMetalIndexL;
             if (bhpu.bepu.hasLPounder && metalIndexLeft >= 0)
             {
                 bool leftEmpty = bhpu.bepu.Inventory[1].Empty;
-
                 float progress = GetProgress(bhpu.bepu.hasAxle ? rot - 0.45f + GameMath.PIHALF / 2f : 0f, 0f);
+
                 UpdateLightAndTransformMatrix(matrixAndLightFloatsLPounder[metalIndexLeft].Values, quantityLPounders[metalIndexLeft], distToCamera, dev.LightRgba, 0f, 0f, axisCenter, Math.Max(progress / 6f + 0.0071f, leftEmpty ? -1 : 1 / 32f));
 
                 if (progress < bhpu.prevProgressLeft && progress < 0.25f)
                 {
-                    if (bhpu.leftDir == 1)
-                    {
-                        bhpu.OnClientSideImpact(false);
-                    }
+                    if (bhpu.leftDir == 1) bhpu.OnClientSideImpact(false);
                     bhpu.leftDir = -1;
                 }
                 else bhpu.leftDir = 1;
@@ -143,22 +128,18 @@ namespace Vintagestory.GameContent.Mechanics
                 quantityLPounders[metalIndexLeft]++;
             }
 
-
-            // Pounder-right
+            // Right pounder
             int metalIndexRight = bhpu.bepu.CapMetalIndexR;
             if (bhpu.bepu.hasRPounder && metalIndexRight >= 0)
             {
                 bool rightEmpty = bhpu.bepu.Inventory[0].Empty;
-
                 float progress = GetProgress(bhpu.bepu.hasAxle ? rot - 0.45f : 0f, 0f);
+
                 UpdateLightAndTransformMatrix(matrixAndLightFloatsRPounder[metalIndexRight].Values, quantityRPounders[metalIndexRight], distToCamera, dev.LightRgba, 0f, 0f, axisCenter, Math.Max(progress / 6f + 0.0071f, rightEmpty ? -1 : 1 / 32f));
 
                 if (progress < bhpu.prevProgressRight && progress < 0.25f)
                 {
-                    if (bhpu.rightDir == 1)
-                    {
-                        bhpu.OnClientSideImpact(true);
-                    }
+                    if (bhpu.rightDir == 1) bhpu.OnClientSideImpact(true);
                     bhpu.rightDir = -1;
                 }
                 else bhpu.rightDir = 1;
@@ -169,16 +150,16 @@ namespace Vintagestory.GameContent.Mechanics
         }
 
         /// <summary>
-        /// Calculate pounder vertical motion from axle angle
+        /// Converts axle angle to a vertical translation value for pounder motion.
+        /// Applies a slight curve to mimic the physical toggle mechanism.
         /// </summary>
         private float GetProgress(float rot, float offset)
         {
             float progress = (rot % GameMath.PIHALF) / GameMath.PIHALF;
             if (progress < 0f) progress += 1f;
-            progress = 0.6355f * (float) Math.Atan(2.2f * progress - 1.2f) + 0.5f;   //give it a bit of a curve to reflect the toggle motion
+            progress = 0.6355f * (float)Math.Atan(2.2f * progress - 1.2f) + 0.5f;
             if (progress > 0.9f)
             {
-                //drop it in 0.1 progress, accelerate in a parabola
                 progress = 2.7f - 3 * progress;
                 progress = 0.9f - progress * progress * 10f;
             }
@@ -187,22 +168,19 @@ namespace Vintagestory.GameContent.Mechanics
         }
 
         /// <summary>
-        /// The initialTransform parameter is either null, to start with the Identity matrix and apply the camera transform, or for movable+rotating sub-elements can pass in an existing matrix which represents the current positioning of the sub-element (prior to the sub-element's own rotation)
+        /// Overload used by pounder sub-elements: applies a vertical translation in addition to
+        /// the standard rotation, to animate the up/down pounding motion.
         /// </summary>
         protected void UpdateLightAndTransformMatrix(float[] values, int index, Vec3f distToCamera, Vec4f lightRgba, float rotX, float rotZ, Vec3f axis, float translate)
         {
             Mat4f.Identity(tmpMat);
             Mat4f.Translate(tmpMat, tmpMat, distToCamera.X + axis.X, distToCamera.Y + axis.Y + translate, distToCamera.Z + axis.Z);
 
-            quat[0] = 0;
-            quat[1] = 0;
-            quat[2] = 0;
-            quat[3] = 1;
+            quat[0] = 0; quat[1] = 0; quat[2] = 0; quat[3] = 1;
             if (rotX != 0f) Quaterniond.RotateX(quat, quat, rotX);
             if (rotZ != 0f) Quaterniond.RotateZ(quat, quat, rotZ);
 
             Mat4f.MulQuat(tmpMat, quat);
-
             Mat4f.Translate(tmpMat, tmpMat, -axis.X, -axis.Y, -axis.Z);
 
             int j = index * 20;
@@ -210,11 +188,7 @@ namespace Vintagestory.GameContent.Mechanics
             values[++j] = lightRgba.G;
             values[++j] = lightRgba.B;
             values[++j] = lightRgba.A;
-
-            for (int i = 0; i < 16; i++)
-            {
-                values[++j] = tmpMat[i];
-            }
+            for (int i = 0; i < 16; i++) values[++j] = tmpMat[i];
         }
 
         public override void OnRenderFrame(float deltaTime, IShaderProgram prog)
@@ -228,52 +202,30 @@ namespace Vintagestory.GameContent.Mechanics
 
             UpdateCustomFloatBuffer();
 
-            // axles
+            // Axle
             if (quantityAxles > 0)
-            {
-                matrixAndLightFloatsAxle.Count = quantityAxles * 20;
-                updateMesh.CustomFloats = matrixAndLightFloatsAxle;
-                capi.Render.UpdateMesh(toggleMeshref, updateMesh);
-                capi.Render.RenderMeshInstanced(toggleMeshref, quantityAxles);
-            }
+                RenderGroups(prog, toggleGroups, matrixAndLightFloatsAxle, quantityAxles);
 
-
-            // pounders
+            // Pounders per metal variant
             for (int i = 0; i < metals.Length; i++)
             {
-                int qLpounder = quantityLPounders[i];
-                int qRpounder = quantityRPounders[i];
+                if (quantityLPounders[i] > 0)
+                    RenderGroups(prog, lPoundGroups[i], matrixAndLightFloatsLPounder[i], quantityLPounders[i]);
 
-                if (qLpounder > 0)
-                {
-                    matrixAndLightFloatsLPounder[i].Count = qLpounder * 20;
-                    updateMesh.CustomFloats = matrixAndLightFloatsLPounder[i];
-                    capi.Render.UpdateMesh(lPoundMeshrefs[i], updateMesh);
-                    capi.Render.RenderMeshInstanced(lPoundMeshrefs[i], qLpounder);
-                }
-
-                if (qRpounder > 0)
-                {
-                    matrixAndLightFloatsRPounder[i].Count = qRpounder * 20;
-                    updateMesh.CustomFloats = matrixAndLightFloatsRPounder[i];
-                    capi.Render.UpdateMesh(rPounderMeshrefs[i], updateMesh);
-                    capi.Render.RenderMeshInstanced(rPounderMeshrefs[i], qRpounder);
-                }
+                if (quantityRPounders[i] > 0)
+                    RenderGroups(prog, rPoundGroups[i], matrixAndLightFloatsRPounder[i], quantityRPounders[i]);
             }
         }
 
         public override void Dispose()
         {
             base.Dispose();
-
-            toggleMeshref?.Dispose();
-
+            DisposeGroups(toggleGroups);
             for (int i = 0; i < metals.Length; i++)
             {
-                lPoundMeshrefs[i]?.Dispose();
-                rPounderMeshrefs[i]?.Dispose();
+                DisposeGroups(lPoundGroups[i]);
+                DisposeGroups(rPoundGroups[i]);
             }
         }
     }
 }
-

--- a/Systems/MechanicalPower/Renderer/TransmissionBlockRenderer.cs
+++ b/Systems/MechanicalPower/Renderer/TransmissionBlockRenderer.cs
@@ -1,4 +1,5 @@
-﻿using Vintagestory.API.Client;
+using System.Collections.Generic;
+using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;
 
@@ -10,29 +11,21 @@ namespace Vintagestory.GameContent.Mechanics
     {
         CustomMeshDataPartFloat matrixAndLightFloats1;
         CustomMeshDataPartFloat matrixAndLightFloats2;
-        MeshRef blockMeshRef1;
-        MeshRef blockMeshRef2;
+        List<MeshGroup> meshGroups1;
+        List<MeshGroup> meshGroups2;
 
         public TransmissionBlockRenderer(ICoreClientAPI capi, MechanicalPowerMod mechanicalPowerMod, Block textureSoureBlock, CompositeShape shapeLoc) : base(capi, mechanicalPowerMod)
         {
-
-            AssetLocation loc = shapeLoc.Base.Clone().WithPathPrefixOnce("shapes/").WithPathAppendixOnce(".json");
-
-            Shape shape = API.Common.Shape.TryGet(capi, loc);
             Vec3f rot = new Vec3f(shapeLoc.rotateX, shapeLoc.rotateY, shapeLoc.rotateZ);
 
+            AssetLocation loc = shapeLoc.Base.Clone().WithPathPrefixOnce("shapes/").WithPathAppendixOnce(".json");
+            Shape shape = API.Common.Shape.TryGet(capi, loc);
             capi.Tesselator.TesselateShape(textureSoureBlock, shape, out MeshData blockMesh1, rot);
 
-            CompositeShape ovShapeCmp = new CompositeShape() { Base = new AssetLocation("shapes/block/wood/mechanics/transmission-rightgear.json") };
-            //rot = new Vec3f(ovShapeCmp.rotateX, ovShapeCmp.rotateY, ovShapeCmp.rotateZ);
-            rot = new Vec3f(shapeLoc.rotateX, shapeLoc.rotateY, shapeLoc.rotateZ);
-            Shape ovshape = API.Common.Shape.TryGet(capi, ovShapeCmp.Base.Clone().WithPathPrefixOnce("shapes/").WithPathAppendixOnce(".json"));
+            Shape ovshape = API.Common.Shape.TryGet(capi, new AssetLocation("shapes/block/wood/mechanics/transmission-rightgear.json"));
             capi.Tesselator.TesselateShape(textureSoureBlock, ovshape, out MeshData blockMesh2, rot);
 
-            //blockMesh1.Rgba2 = null;
-            //blockMesh2.Rgba2 = null;
-
-            // 16 floats matrix, 4 floats light rgbs
+            // 16 floats matrix, 4 floats light rgba
             blockMesh1.CustomFloats = matrixAndLightFloats1 = new CustomMeshDataPartFloat((16 + 4) * 10100)
             {
                 Instanced = true,
@@ -42,6 +35,7 @@ namespace Vintagestory.GameContent.Mechanics
                 StaticDraw = false,
             };
             blockMesh1.CustomFloats.SetAllocationSize((16 + 4) * 10100);
+
             blockMesh2.CustomFloats = matrixAndLightFloats2 = new CustomMeshDataPartFloat((16 + 4) * 10100)
             {
                 Instanced = true,
@@ -52,15 +46,15 @@ namespace Vintagestory.GameContent.Mechanics
             };
             blockMesh2.CustomFloats.SetAllocationSize((16 + 4) * 10100);
 
-            this.blockMeshRef1 = capi.Render.UploadMesh(blockMesh1);
-            this.blockMeshRef2 = capi.Render.UploadMesh(blockMesh2);
+            meshGroups1 = UploadMeshGrouped(blockMesh1, matrixAndLightFloats1);
+            meshGroups2 = UploadMeshGrouped(blockMesh2, matrixAndLightFloats2);
         }
-
 
         protected override void UpdateLightAndTransformMatrix(int index, Vec3f distToCamera, float rotation, IMechanicalPowerRenderable dev)
         {
             BEBehaviorMPTransmission trans = dev as BEBehaviorMPTransmission;
             if (trans == null) return;
+
             float rot1 = trans.RotationNeighbour(1, true);
             float rot2 = trans.RotationNeighbour(0, true);
 
@@ -81,23 +75,16 @@ namespace Vintagestory.GameContent.Mechanics
 
             if (quantityBlocks > 0)
             {
-                matrixAndLightFloats1.Count = quantityBlocks * 20;
-                updateMesh.CustomFloats = matrixAndLightFloats1;
-                capi.Render.UpdateMesh(blockMeshRef1, updateMesh);
-                capi.Render.RenderMeshInstanced(blockMeshRef1, quantityBlocks);
-                matrixAndLightFloats2.Count = quantityBlocks * 20;
-                updateMesh.CustomFloats = matrixAndLightFloats2;
-                capi.Render.UpdateMesh(blockMeshRef2, updateMesh);
-                capi.Render.RenderMeshInstanced(blockMeshRef2, quantityBlocks);
+                RenderGroups(prog, meshGroups1, matrixAndLightFloats1, quantityBlocks);
+                RenderGroups(prog, meshGroups2, matrixAndLightFloats2, quantityBlocks);
             }
         }
 
         public override void Dispose()
         {
             base.Dispose();
-
-            blockMeshRef1?.Dispose();
-            blockMeshRef2?.Dispose();
+            DisposeGroups(meshGroups1);
+            DisposeGroups(meshGroups2);
         }
     }
 }


### PR DESCRIPTION
When installing a large number of mods, or when setting "maxTextureAtlasWidth" and "maxTextureAtlasHeight" to low values, the textures of mechanical blocks are displayed incorrectly. This is because the textures of the same model can be scattered across different texture atlases. By default, only one of them was always used.
What's been done:
- **Splitting the mesh by atlas.** SplitByTextureId() → one mesh turns into several, each with a single atlasTextureId.
- **Switching to multiple MeshRefs**. Instead of a single MeshRef, there's now a list—one for each atlas.
- **Correct texture binding.** Before each draw call, a specific atlasTextureId is bound, not a single shared one.
- **Preserved instanced rendering**. The same CustomFloats is used for all parts → animations and transformations are not broken.
- **Removed hard binding to atlas[0].** Rendering no longer depends on a single texture atlas → all textures are displayed correctly.

This solution may not be perfect, as I'm not very knowledgeable about graphics. But it works.

**Before:** 
<img width="1920" height="1017" alt="2026-04-04_17-56-56" src="https://github.com/user-attachments/assets/e4c36e46-fff4-4383-a65a-2acdf52de7b7" />

**After**
<img width="1920" height="1017" alt="2026-04-04_17-54-38" src="https://github.com/user-attachments/assets/92c1a073-7bd2-49a6-a74a-5010c1bb781b" />
