### PR TITLE
Several improvements to pies and meals

### DIFF
--- a/Block/BlockCookedContainerBase.cs
+++ b/Block/BlockCookedContainerBase.cs
@@ -419,7 +419,17 @@ namespace Vintagestory.GameContent
                 }
                 else
                 {
-                    served = ServeIntoStack(targetSlot, slot, api.World);
+                    // Try to put meals into other crocks instead of taking them out.
+                    // Makes interacting with shelves nicer since you can put a semi-full
+                    // crock in front of a full one. Bowls, etc. behavior is unchanged.
+                    if (targetSlot.Itemstack.Block is BlockCrock)
+                    {
+                        served = ServeIntoStack(slot, targetSlot, api.World);
+                    }
+                    else
+                    {
+                        served = ServeIntoStack(targetSlot, slot, api.World);
+                    }
                 }
 
                 slot.MarkDirty();

--- a/Block/BlockCrock.cs
+++ b/Block/BlockCrock.cs
@@ -326,7 +326,17 @@ namespace Vintagestory.GameContent
                 {
                     if (quantityServings > 0)
                     {
-                        ServeIntoStack(gsslot, slot, byEntity.World);
+                        // Try to put meals into other crocks instead of taking them out.
+                        // Makes interacting with shelves nicer since you can put a semi-full
+                        // crock in front of a full one. Bowls, etc. behavior is unchanged.
+                        if (gsslot.Itemstack.Block is BlockCrock)
+                        {
+                            ServeIntoStack(slot, gsslot, byEntity.World);
+                        }
+                        else
+                        {
+                            ServeIntoStack(gsslot, slot, byEntity.World);
+                        }
                         gsslot.MarkDirty();
                         begs.MarkMeshesDirty();
                         begs.MarkDirty(true);

--- a/Block/BlockCrock.cs
+++ b/Block/BlockCrock.cs
@@ -33,7 +33,7 @@ namespace Vintagestory.GameContent
             {
                 shapeLocation = Shape.Base!.Clone().WithFilename("").WithPathPrefixOnce("shapes/").ToString();
             }
-            else if(API.Common.Shape.TryGet(api, AssetLocation.Create("shapes/block/clay/crock/base.json", Code.Domain)) != null)
+            else if (API.Common.Shape.TryGet(api, AssetLocation.Create("shapes/block/clay/crock/base.json", Code.Domain)) != null)
             {
                 shapeLocation = Code.Domain + ":shapes/block/clay/crock/";
             }
@@ -305,6 +305,7 @@ namespace Vintagestory.GameContent
             if (block?.Attributes?.IsTrue("mealContainer") == true)
             {
                 if (!byEntity.Controls.ShiftKey) return;
+
                 if (quantityServings > 0)
                 {
                     ServeIntoBowl(block, blockSel.Position, slot, byEntity.World);
@@ -359,10 +360,12 @@ namespace Vintagestory.GameContent
 
                 quantityServings -= movedServings;
 
-                if (quantityServings > 0) {
+                if (quantityServings > 0)
+                {
                     crockStack.Attributes.SetFloat("quantityServings", quantityServings);
-                } else {
-
+                }
+                else
+                {
                     crockStack.Attributes.RemoveAttribute("recipeCode");
                     crockStack.Attributes.RemoveAttribute("quantityServings");
                     crockStack.Attributes.RemoveAttribute("contents");
@@ -436,7 +439,7 @@ namespace Vintagestory.GameContent
         {
             ItemSlot hotbarSlot = byPlayer.InventoryManager.ActiveHotbarSlot;
 
-            if (!hotbarSlot.Empty && hotbarSlot.Itemstack.Collectible.Attributes?.IsTrue("mealContainer") == true && (!(hotbarSlot.Itemstack.Collectible is BlockCrock) || hotbarSlot.StackSize == 1))
+            if (!hotbarSlot.Empty && hotbarSlot.Itemstack.Collectible.Attributes?.IsTrue("mealContainer") == true && (hotbarSlot.Itemstack.Collectible is not BlockCrock || hotbarSlot.StackSize == 1))
             {
                 if (world.BlockAccessor.GetBlockEntity(blockSel.Position) is not BlockEntityCrock bec) return false;
 

--- a/Block/BlockCrock.cs
+++ b/Block/BlockCrock.cs
@@ -33,7 +33,7 @@ namespace Vintagestory.GameContent
             {
                 shapeLocation = Shape.Base!.Clone().WithFilename("").WithPathPrefixOnce("shapes/").ToString();
             }
-            else if(API.Common.Shape.TryGet(api, AssetLocation.Create("shapes/block/clay/crock/base.json", Code.Domain)) != null)
+            else if (API.Common.Shape.TryGet(api, AssetLocation.Create("shapes/block/clay/crock/base.json", Code.Domain)) != null)
             {
                 shapeLocation = Code.Domain + ":shapes/block/clay/crock/";
             }
@@ -305,6 +305,7 @@ namespace Vintagestory.GameContent
             if (block?.Attributes?.IsTrue("mealContainer") == true)
             {
                 if (!byEntity.Controls.ShiftKey) return;
+
                 if (quantityServings > 0)
                 {
                     ServeIntoBowl(block, blockSel.Position, slot, byEntity.World);
@@ -349,10 +350,12 @@ namespace Vintagestory.GameContent
 
                 quantityServings -= movedServings;
 
-                if (quantityServings > 0) {
+                if (quantityServings > 0)
+                {
                     crockStack.Attributes.SetFloat("quantityServings", quantityServings);
-                } else {
-
+                }
+                else
+                {
                     crockStack.Attributes.RemoveAttribute("recipeCode");
                     crockStack.Attributes.RemoveAttribute("quantityServings");
                     crockStack.Attributes.RemoveAttribute("contents");
@@ -426,7 +429,7 @@ namespace Vintagestory.GameContent
         {
             ItemSlot hotbarSlot = byPlayer.InventoryManager.ActiveHotbarSlot;
 
-            if (!hotbarSlot.Empty && hotbarSlot.Itemstack.Collectible.Attributes?.IsTrue("mealContainer") == true && (!(hotbarSlot.Itemstack.Collectible is BlockCrock) || hotbarSlot.StackSize == 1))
+            if (!hotbarSlot.Empty && hotbarSlot.Itemstack.Collectible.Attributes?.IsTrue("mealContainer") == true && (hotbarSlot.Itemstack.Collectible is not BlockCrock || hotbarSlot.StackSize == 1))
             {
                 if (world.BlockAccessor.GetBlockEntity(blockSel.Position) is not BlockEntityCrock bec) return false;
 

--- a/Block/BlockPie.cs
+++ b/Block/BlockPie.cs
@@ -699,7 +699,7 @@ namespace Vintagestory.GameContent
                 // [ "mixed", "type-trailing" ]
                 string[] pieMixCode = recipe?.Code?.Split("-", 2) ?? ["single", ""];
 
-                if (pieMixCode.Length > 1)
+                if (pieMixCode[0] == "mixed")
                 {
                     foreach (EnumFoodCategory cat in allFoodCategories)
                     {

--- a/Block/BlockPie.cs
+++ b/Block/BlockPie.cs
@@ -479,7 +479,7 @@ namespace Vintagestory.GameContent
                 return;
             }
 
-            var pieStack = stackInSlot!.Itemstack!.Clone();
+            ItemStack? pieStack = stackInSlot.Itemstack?.Clone();
             TakeSlice(ref pieStack);
             if (pieStack?.Attributes.GetAsInt("pieSize") == 1)
             {
@@ -622,16 +622,13 @@ namespace Vintagestory.GameContent
                     foreach (ItemStack? astack in ingredient.ValidStacks.Select(stack => stack.ResolvedItemstack))
                     {
                         if (ingredient.GetMatchingStack(astack) is not { } vstack) continue;
-                        if (astack?.Clone() is not { } stack) continue;
 
-                        stack.StackSize = vstack.StackSize;
-
-                        if (BlockLiquidContainerBase.GetContainableProps(stack) is { } props)
+                        if (astack?.Clone() is { } stack && BlockLiquidContainerBase.GetContainableProps(stack) is { } props)
                         {
-                            stack.StackSize *= (int)(props.ItemsPerLitre * ingredient.PortionSizeLitres);
+                            stack.StackSize = vstack.StackSize * (int)(props.ItemsPerLitre * ingredient.PortionSizeLitres);
+                            ingredientStacks.Add(stack);
                         }
-
-                        ingredientStacks.Add(stack);
+                        else ingredientStacks.Add(null);
                     }
 
                     if (ingredient.MinQuantity <= 0) ingredientStacks.Add(null);

--- a/Block/BlockPie.cs
+++ b/Block/BlockPie.cs
@@ -691,15 +691,50 @@ namespace Vintagestory.GameContent
                 // List that includes only food categories that are not already present
                 List<ItemStack?>? filteredValidStacks = allFoodCategories.Count > 1 ? new(validStacks) : [];
 
+
+
+                // For each food category, try to filter out non-matching mixing codes.
+                // If at least one ingredient is left, apply it to the actual ingredient
+                // list. Helps prevent incorrect mixing codes when multiple codes have
+                // the same food categories.
+                List<EnumFoodCategory> mixCodeFilterable = [];
+
+                // [ "mixed", "type-trailing" ]
+                string[] pieMixCode = recipe?.Code?.Split("-", 2) ?? ["single", ""];
+
+                if (pieMixCode.Length > 1)
+                {
+                    foreach (EnumFoodCategory cat in allFoodCategories)
+                    {
+                        int noOtherMixingCodesInCategory = filteredValidStacks
+                            .Where(stack =>
+                            {
+                                if (stack?.ItemAttributes["inPieProperties"].AsObject<InPieProperties>() is not { } props) return true;
+                                return props.FoodCategory == cat && props.MixingCodes.Except([pieMixCode[1]]).Count() == 0;
+                            })
+                            .Count();
+
+                        if (noOtherMixingCodesInCategory > 0)
+                        {
+                            // We can filter out non-matching mixing codes because we have at least one left for this category.
+                            filteredValidStacks = filteredValidStacks.Where(stack =>
+                            {
+                                if (stack?.ItemAttributes["inPieProperties"].AsObject<InPieProperties>() is not { } props) return true;
+                                return props.FoodCategory != cat || props.MixingCodes.Except([pieMixCode[1]]).Count() == 0;
+                            }).ToList();
+                        }
+                    }
+                }
+
+
                 while (ingredient.MinQuantity > 0)
                 {
+                    // Use the filtered list to fill out the other desired categories, if any remain.
                     if (ingredient.Code == "filling" && (filteredValidStacks?.Count ?? 0) > 0)
                     {
-                        // Use the filtered list to fill out the other desired categories.
                         ItemStack? newIngredient = filteredValidStacks![api.World.Rand.Next(filteredValidStacks!.Count)]?.Clone();
                         if (FillingFoodCategory(newIngredient) is EnumFoodCategory newCategory)
                         {
-                            Console.WriteLine($"Adding new included foodCat {newCategory}");
                             includedFoodCategories.Add(newCategory);
 
                             bool filterStackIfCategoryIncluded(ItemStack? stack)

--- a/Block/BlockPie.cs
+++ b/Block/BlockPie.cs
@@ -97,7 +97,7 @@ namespace Vintagestory.GameContent
                         ActionLangCode = "blockhelp-pie-addfilling",
                         MouseButton = EnumMouseButton.Right,
                         Itemstacks = fillStacks.ToArray(),
-                        GetMatchingStacks = (wi, bs, _) => GetBlockEntity<BlockEntityPie>(bs.Position) is { State: "raw", HasAllFilling: false } ? wi.Itemstacks : null
+                        GetMatchingStacks = (wi, bs, _) => GetBlockEntity<BlockEntityPie>(bs.Position) is { State: "raw", HasAllFilling: false } ? wi.Itemstacks.Where(stack => GetBlockEntity<BlockEntityPie>(bs.Position).CanAddIngredient(stack)).ToArray() : null
                     },
                     new() {
                         ActionLangCode = "blockhelp-pie-addcrust",
@@ -145,8 +145,6 @@ namespace Vintagestory.GameContent
         {
             return slot.Itemstack?.Attributes?.GetAsInt("pieSize") == 1 && State != "raw";
         }
-
-
 
 
         ModelTransform oneSliceTranformGui = new ModelTransform()

--- a/Block/BlockPie.cs
+++ b/Block/BlockPie.cs
@@ -10,6 +10,8 @@ using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Util;
 
+#nullable enable
+
 namespace Vintagestory.GameContent
 {
     public class PieTopCrustType
@@ -267,15 +269,15 @@ namespace Vintagestory.GameContent
 
             if (cstack == null) return Lang.Get("pie-empty");
 
-            bool equal = true;
-            bool foodCatEquals = true;
+            bool singleIngredient = true;
+            bool singleFoodCat = true;
             IEnumerable<string> mixCodes = cstack.ItemAttributes["inPieProperties"].AsObject<InPieProperties>()?.MixingCodes ?? [];
-            for (int i = 2; (equal || foodCatEquals || mixCodes.Any()) && i < cStacks.Length - 1; i++)
+            for (int i = 2; (singleIngredient || singleFoodCat || mixCodes.Any()) && i < cStacks.Length - 1; i++)
             {
                 if (cStacks[i] == null) continue;
 
-                equal &= cstack.Equals(api.World, cStacks[i], GlobalConstants.IgnoredStackAttributes);
-                foodCatEquals &= cStacks[i] == null || foodCats[i] == foodCat;
+                singleIngredient &= cstack.Equals(api.World, cStacks[i], GlobalConstants.IgnoredStackAttributes);
+                singleFoodCat &= cStacks[i] == null || foodCats[i] == foodCat;
                 mixCodes = cstack.ItemAttributes["inPieProperties"].AsObject<InPieProperties>()?.MixingCodes.Intersect(mixCodes) ?? [];
 
                 cstack = cStacks[i];
@@ -289,12 +291,12 @@ namespace Vintagestory.GameContent
                 return Lang.Get("pie-single-rotten");
             }
 
-            if (equal)
+            if (singleIngredient)
             {
                 return Lang.Get("pie-single-" + cstack.Collectible.Code.ToShortString() + "-" + state);
             }
 
-            if (!foodCatEquals && mixCodes.Any())
+            if (!singleFoodCat && mixCodes.Any())
             {
                 return Lang.Get("pie-mixed-" + mixCodes.First() + "-" + state);
             }
@@ -531,7 +533,7 @@ namespace Vintagestory.GameContent
                 return;
             }
 
-            var pieStack = stackInSlot.Itemstack.Clone();
+            var pieStack = stackInSlot!.Itemstack!.Clone();
             TakeSlice(ref pieStack);
             if (pieStack?.Attributes.GetAsInt("pieSize") == 1)
             {
@@ -671,11 +673,11 @@ namespace Vintagestory.GameContent
                     HashSet<ItemStack?> ingredientStacks = [];
 
                     ingredient.Resolve(api.World, "handbook meal recipes");
-                    foreach (var astack in ingredient.ValidStacks.Select(stack => stack.ResolvedItemstack))
+                    foreach (ItemStack? astack in ingredient.ValidStacks.Select(stack => stack.ResolvedItemstack))
                     {
                         if (ingredient.GetMatchingStack(astack) is not { } vstack) continue;
+                        if (astack?.Clone() is not { } stack) continue;
 
-                        ItemStack stack = astack.Clone();
                         stack.StackSize = vstack.StackSize;
 
                         if (BlockLiquidContainerBase.GetContainableProps(stack) is { } props)
@@ -696,100 +698,114 @@ namespace Vintagestory.GameContent
 
             if (validStacksByIngredient == null) return new ItemStack?[6];
 
-            List<ItemStack?> randomMeal = [];
 
-            while (!recipe.Matches(randomMeal.ToArray()))
+
+            void addIngredient(ref List<ItemStack?> pie, string code, ref Dictionary<CookingRecipeIngredient, List<ItemStack?>> valIngStacks, ref CookingRecipeIngredient? requestedIngredient)
+            {
+                (CookingRecipeIngredient ingredient, List<ItemStack?> validStacks) = valIngStacks.FirstOrDefault(entry => entry.Key.Code == code);
+
+                // We want to fill out all the possible food categories if possible so that
+                // the correct pie type will be displayed. For example, if we're making a
+                // random pot pie, but we end up only adding vegetables, it will show up
+                // as a vegetable pie, which is confusing.
+                HashSet<EnumFoodCategory> allFoodCategories = [];
+                HashSet<EnumFoodCategory> includedFoodCategories = [];
+
+                // Try to fulfill the ingredient request
+                if (ingredient.Code == requestedIngredient?.Code)
+                {
+                    if (validStacks.First(stack => stack?.Collectible.Code == ingredientStack?.Collectible.Code) is { } stack)
+                    {
+                        if (FillingFoodCategory(stack) is EnumFoodCategory cat)
+                        {
+                            includedFoodCategories.Add(cat);
+                        }
+
+                        pie.Add(stack.Clone());
+
+                        ingredient.MinQuantity--;
+                        ingredient.MaxQuantity--;
+                    }
+
+                    requestedIngredient = null;
+                }
+
+                // Get all the available categories
+                if (ingredient.Code == "filling")
+                {
+                    foreach (ItemStack? stack in validStacks)
+                    {
+                        if (FillingFoodCategory(stack) is EnumFoodCategory cat && cat != EnumFoodCategory.NoNutrition)
+                        {
+                            allFoodCategories.Add(cat);
+                        }
+                    }
+                }
+
+                // List that includes only food categories that are not already present
+                List<ItemStack?>? filteredValidStacks = allFoodCategories.Count > 1 ? new(validStacks) : [];
+
+                while (ingredient.MinQuantity > 0)
+                {
+                    if (ingredient.Code == "filling" && (filteredValidStacks?.Count ?? 0) > 0)
+                    {
+                        // Use the filtered list to fill out the other desired categories.
+                        ItemStack? newIngredient = filteredValidStacks![api.World.Rand.Next(filteredValidStacks!.Count)]?.Clone();
+                        if (FillingFoodCategory(newIngredient) is EnumFoodCategory newCategory)
+                        {
+                            Console.WriteLine($"Adding new included foodCat {newCategory}");
+                            includedFoodCategories.Add(newCategory);
+
+                            bool filterStackIfCategoryIncluded(ItemStack? stack)
+                            {
+                                if (FillingFoodCategory(stack) is EnumFoodCategory category)
+                                {
+                                    return includedFoodCategories.Contains(category);
+                                }
+                                else { return false; }
+                            }
+
+                            filteredValidStacks!.RemoveAll(filterStackIfCategoryIncluded);
+                        }
+
+                        pie.Add(newIngredient);
+                    }
+                    else
+                    {
+                        // Otherwise, just pull any ingredient.
+                        pie.Add(validStacks[api.World.Rand.Next(validStacks.Count)]?.Clone());
+                    }
+
+                    ingredient.MinQuantity--;
+                    ingredient.MaxQuantity--;
+                }
+            }
+
+
+
+            List<ItemStack?> randomPie = [];
+            while (!recipe.Matches([.. randomPie]))
             {
                 var valIngStacks = new Dictionary<CookingRecipeIngredient, List<ItemStack?>>();
-                foreach (var entry in validStacksByIngredient) valIngStacks.Add(entry.Key.Clone(), entry.Value.ToList());
+                foreach (var entry in validStacksByIngredient) valIngStacks.Add(entry.Key.Clone(), [.. entry.Value]);
                 valIngStacks = valIngStacks.OrderBy(x => api.World.Rand.Next()).ToDictionary(item => item.Key, item => item.Value);
 
                 CookingRecipeIngredient? requestedIngredient = null;
                 if (ingredientStack != null)
                 {
-                    var validIngredients = recipe.Ingredients.Where(ingredient => ingredient.Matches(ingredientStack)).ToList();
+                    List<CookingRecipeIngredient> validIngredients = [.. recipe.Ingredients.Where(ingredient => ingredient.Matches(ingredientStack))];
                     requestedIngredient = validIngredients[api.World.Rand.Next(validIngredients.Count)].Clone();
                 }
 
-                randomMeal = [];
+                randomPie = [];
+                addIngredient(ref randomPie, "dough", ref valIngStacks, ref requestedIngredient);
+                addIngredient(ref randomPie, "filling", ref valIngStacks, ref requestedIngredient);
+                addIngredient(ref randomPie, "crust", ref valIngStacks, ref requestedIngredient);
 
-                var ingredient = valIngStacks.FirstOrDefault(entry => entry.Key.Code == "dough").Key;
-                var validStacks = valIngStacks.FirstOrDefault(entry => entry.Key.Code == "dough").Value;
-
-                if (ingredient.Code == requestedIngredient?.Code)
-                {
-                    if (validStacks.First(stack => stack?.Collectible.Code == ingredientStack?.Collectible.Code) is { } stack)
-                    {
-                        randomMeal.Add(stack.Clone());
-
-                        ingredient.MinQuantity--;
-                        ingredient.MaxQuantity--;
-                    }
-                    requestedIngredient = null;
-                }
-
-                while (ingredient.MinQuantity > 0)
-                {
-                    randomMeal.Add(validStacks[api.World.Rand.Next(validStacks.Count)]?.Clone());
-
-                    ingredient.MinQuantity--;
-                    ingredient.MaxQuantity--;
-                }
-
-                ingredient = valIngStacks.FirstOrDefault(entry => entry.Key.Code == "filling").Key;
-                validStacks = valIngStacks.FirstOrDefault(entry => entry.Key.Code == "filling").Value;
-
-                if (ingredient.Code == requestedIngredient?.Code)
-                {
-                    if (validStacks.First(stack => stack?.Collectible.Code == ingredientStack?.Collectible.Code) is { } stack)
-                    {
-                        randomMeal.Add(stack.Clone());
-
-                        ingredient.MinQuantity--;
-                        ingredient.MaxQuantity--;
-                    }
-                    requestedIngredient = null;
-                }
-
-                while (ingredient.MinQuantity > 0)
-                {
-                    randomMeal.Add(validStacks[api.World.Rand.Next(validStacks.Count)]?.Clone());
-
-                    ingredient.MinQuantity--;
-                    ingredient.MaxQuantity--;
-                }
-
-                ingredient = valIngStacks.FirstOrDefault(entry => entry.Key.Code == "crust").Key;
-                validStacks = valIngStacks.FirstOrDefault(entry => entry.Key.Code == "crust").Value;
-
-                if (requestedIngredient != null)
-                {
-                    if (ingredient.Code == requestedIngredient?.Code)
-                    {
-                        if (validStacks.First(stack => stack?.Collectible.Code == ingredientStack?.Collectible.Code) is { } stack)
-                        {
-                            randomMeal.Add(stack.Clone());
-                            ingredient.MaxQuantity--;
-
-                            requestedIngredient = null;
-                        }
-                    }
-                }
-                else if (ingredient.MaxQuantity > 0)
-                {
-                    var stack = validStacks[api.World.Rand.Next(validStacks.Count)];
-
-                    if (stack != null)
-                    {
-                        randomMeal.Add(stack.Clone());
-                        ingredient.MaxQuantity--;
-                    }
-                }
-
-                while (randomMeal.Count < 6) randomMeal.Add(null);
+                while (randomPie.Count < 6) randomPie.Add(null);
             }
 
-            return randomMeal.ToArray();
+            return [.. randomPie];
         }
 
         [return: NotNullIfNotNull(nameof(pieStack))]

--- a/Block/BlockPie.cs
+++ b/Block/BlockPie.cs
@@ -554,8 +554,8 @@ namespace Vintagestory.GameContent
 
         public override WorldInteraction[] GetPlacedBlockInteractionHelp(IWorldAccessor world, BlockSelection selection, IPlayer forPlayer)
         {
-            var baseinteractions = base.GetPlacedBlockInteractionHelp(world, selection, forPlayer);
-            baseinteractions = baseinteractions.RemoveAt(1);
+            WorldInteraction[] baseinteractions = [ .. base.GetPlacedBlockInteractionHelp(world, selection, forPlayer)
+                .Where(bi => bi.ActionLangCode != "blockhelp-meal-eat" && bi.ActionLangCode != "blockhelp-behavior-rightclickpickup")];
 
             var allinteractions = interactions.Append(baseinteractions);
             return allinteractions;

--- a/Block/BlockPie.cs
+++ b/Block/BlockPie.cs
@@ -296,7 +296,7 @@ namespace Vintagestory.GameContent
 
             if (!foodCatEquals && mixCodes.Any())
             {
-                return Lang.Get("pie-mixed-" + mixCodes.First() + "-" +state);
+                return Lang.Get("pie-mixed-" + mixCodes.First() + "-" + state);
             }
 
             return Lang.Get("pie-mixed-" + FillingFoodCategory(cStacks[1]).ToString().ToLowerInvariant() + "-" + state);

--- a/Block/BlockPie.cs
+++ b/Block/BlockPie.cs
@@ -331,7 +331,7 @@ namespace Vintagestory.GameContent
 
             int pieSize = pieStack.Attributes.GetAsInt("pieSize");
             float servingsLeft = GetQuantityServings(world, pieStack);
-            if (!pieStack.Attributes.HasAttribute("quantityServings")) servingsLeft = 1;
+            if (pieStack.Attributes?.HasAttribute("quantityServings") == false) servingsLeft = pieStack.Attributes.GetAsInt("pieSize") / 4f;
 
             if (pieSize == 1)
             {

--- a/Block/BlockPie.cs
+++ b/Block/BlockPie.cs
@@ -365,8 +365,8 @@ namespace Vintagestory.GameContent
             ItemStack[] stacks = GetContents(api.World, pieStack);
             StringBuilder sb = new StringBuilder();
 
-            TransitionableProperties[] propsm = pieStack.Collectible.GetTransitionableProperties(api.World, pieStack, null);
-            if (propsm != null && propsm.Length > 0)
+            TransitionableProperties[]? propsm = pieStack.Collectible.GetTransitionableProperties(api.World, pieStack, null);
+            if (propsm?.Length > 0)
             {
                 pieStack.Collectible.AppendPerishableInfoText(bepInv[0], sb, api.World);
             }
@@ -383,62 +383,10 @@ namespace Vintagestory.GameContent
             return str;
         }
 
-        public override TransitionState? UpdateAndGetTransitionState(IWorldAccessor world, ItemSlot inslot, EnumTransitionType type)
-        {
-            ItemStack[] cstacks = GetContents(world, inslot.Itemstack);
-            UnspoilContents(world, cstacks);
-            SetContents(inslot.Itemstack, cstacks);
-
-            return base.UpdateAndGetTransitionState(world, inslot, type);
-        }
-
         public override TransitionState[]? UpdateAndGetTransitionStates(IWorldAccessor world, ItemSlot inslot)
         {
-            ItemStack[] cstacks = GetContents(world, inslot.Itemstack);
-            UnspoilContents(world, cstacks);
-            SetContents(inslot.Itemstack, cstacks);
-
-
-            return base.UpdateAndGetTransitionStatesNative(world, inslot);
+            return UpdateAndGetTransitionStatesNative(world, inslot);
         }
-
-
-        public override string GetContentNutritionFacts(IWorldAccessor world, ItemSlot inSlotorFirstSlot, ItemStack[] contentStacks, EntityAgent? forEntity, bool mulWithStacksize = false, float nutritionMul = 1, float healthMul = 1)
-        {
-            UnspoilContents(world, contentStacks);
-
-            return base.GetContentNutritionFacts(world, inSlotorFirstSlot, contentStacks, forEntity, mulWithStacksize, nutritionMul, healthMul);
-        }
-
-
-        protected void UnspoilContents(IWorldAccessor world, ItemStack[] cstacks)
-        {
-            // Dont spoil the pie contents, the pie itself has a spoilage timer. Semi hacky fix reset their spoil timers each update
-
-            for (int i = 0; i < cstacks.Length; i++)
-            {
-                ItemStack cstack = cstacks[i];
-                if (cstack == null) continue;
-
-                if (!(cstack.Attributes["transitionstate"] is ITreeAttribute))
-                {
-                    cstack.Attributes["transitionstate"] = new TreeAttribute();
-                }
-                ITreeAttribute attr = (ITreeAttribute)cstack.Attributes["transitionstate"];
-
-                if (attr.HasAttribute("createdTotalHours"))
-                {
-                    attr.SetDouble("createdTotalHours", world.Calendar.TotalHours);
-                    attr.SetDouble("lastUpdatedTotalHours", world.Calendar.TotalHours);
-                    var transitionedHours = (attr["transitionedHours"] as FloatArrayAttribute)?.value;
-                    for (int j = 0; transitionedHours != null && j < transitionedHours.Length; j++)
-                    {
-                        transitionedHours[j] = 0;
-                    }
-                }
-            }
-        }
-
 
         public override float[] GetNutritionHealthMul(BlockPos? pos, ItemSlot? slot, EntityAgent? forEntity)
         {

--- a/Block/BlockPie.cs
+++ b/Block/BlockPie.cs
@@ -59,6 +59,26 @@ namespace Vintagestory.GameContent
 
         public static PieTopCrustType[] TopCrustTypes = null!;
 
+        protected static HashSet<string> reportedMissingPieProps = [];
+
+        /// <summary>
+        /// Report that an object in a pie is missing its InPieProperties.
+        /// Use this to prevent repeated error spam.
+        /// </summary>
+        /// <param name="logger">The logger to use.</param>
+        /// <param name="code">The collectible code.</param>
+        /// <returns>true if the element is added to the HashSet object; false if the element is already present.</returns>
+        public static bool ReportMissingPieProps(ILogger logger, string code)
+        {
+            if (!reportedMissingPieProps.Contains(code))
+            {
+                logger.Error($"{code} is already in a pie, but it no longer has inPieProperties. It's still edible, but some things will break.");
+            }
+
+            return reportedMissingPieProps.Add(code);
+        }
+
+
         [MemberNotNull(nameof(ms), nameof(interactions))]
         public override void OnLoaded(ICoreAPI api)
         {
@@ -300,39 +320,45 @@ namespace Vintagestory.GameContent
 
         public override string GetHeldItemName(ItemStack? itemStack)
         {
-            ItemStack[] cStacks = GetContents(api.World, itemStack);
+            ItemStack?[] cStacks = GetContents(api.World, itemStack);
             if (cStacks.Length <= 1 || cStacks[1] == null) return Lang.Get("pie-empty");
 
+            // Use null-forgiving in this method in case the pie is malformed,
+            // e.g. an ingredient lost its pie props. Report it because its
+            // a content error.
+            for (int i = 0; i < 6; i++)
+            {
+                if (cStacks[i] != null && InPieProperties.ReadFrom(cStacks[i]) == null)
+                {
+                    ReportMissingPieProps(api.Logger, cStacks[i]!.Collectible.Code);
+                }
+            }
+
             bool singleIngredient = true;
-            IEnumerable<string> mixCodes = InPieProperties.ReadFrom(cStacks[1])!.MixingCodes ?? [];
+            IEnumerable<string> mixCodes = InPieProperties.ReadFrom(cStacks[1])?.MixingCodes ?? [];
             for (int i = 2; i < cStacks.Length - 1; i++)
             {
                 if (cStacks[i] == null) continue;
 
-                singleIngredient &= cStacks[i].Equals(api.World, cStacks[1], GlobalConstants.IgnoredStackAttributes);
-                mixCodes = InPieProperties.ReadFrom(cStacks[i])!.MixingCodes.Intersect(mixCodes) ?? [];
+                singleIngredient &= cStacks[i]?.Equals(api.World, cStacks[1], GlobalConstants.IgnoredStackAttributes) ?? true;
+                mixCodes = InPieProperties.ReadFrom(cStacks[i])?.MixingCodes.Intersect(mixCodes) ?? [];
 
                 if (!singleIngredient && !mixCodes.Any()) break;
             }
 
             string state = Variant["state"];
 
-            if (MealMeshCache.ContentsRotten(cStacks))
-            {
-                return Lang.Get("pie-single-rotten");
-            }
-
             string pieName = Lang.Get(singleIngredient
-                ? "pie-single-" + cStacks[1].Collectible.Code.ToShortString() + "-" + state
+                ? "pie-single-" + cStacks[1]!.Collectible.Code.ToShortString() + "-" + state
                 : "pie-mixed-" + mixCodes.First() + "-" + state);
 
-            if (cStacks[5] != null && InPieProperties.ReadFrom(cStacks[5])!.PartType != EnumPiePartType.Crust)
+            if (cStacks[5] != null && InPieProperties.ReadFrom(cStacks[5])?.PartType != EnumPiePartType.Crust)
             {
-                return Lang.Get("meal-topping-ingredient-format", cStacks[5].Collectible.GetHeldItemName(cStacks[5]), pieName.ToLowerInvariant());
+                return Lang.Get("meal-topping-ingredient-format", cStacks[5]?.Collectible.GetHeldItemName(cStacks[5]), pieName.ToLowerInvariant());
             }
             else
             {
-                return pieName;
+                return Lang.Get("pie-mixed-" + mixCodes.First() + "-" + state);
             }
         }
 
@@ -550,7 +576,7 @@ namespace Vintagestory.GameContent
             List<ItemStack> crusts = [];
             List<ItemStack> noMixFillings = [];
             Dictionary<string, List<ItemStack>> mixedFillings = [];
-            List<ItemStack> toppings = [];
+            Dictionary<string, List<ItemStack>> toppingsByCode = [];
 
             foreach (ItemStack stack in allStacks)
             {
@@ -560,7 +586,7 @@ namespace Vintagestory.GameContent
                 {
                     case EnumPiePartType.Crust:
                         crusts.Add(stack);
-                        toppings.Add(stack);
+
                         break;
                     case EnumPiePartType.Filling:
                         if (pieProps.AllowMixing)
@@ -577,15 +603,53 @@ namespace Vintagestory.GameContent
                         }
                         break;
                     case EnumPiePartType.Topping:
-                        toppings.Add(stack);
+                        foreach (string mixCode in pieProps.MixingCodes)
+                        {
+                            if (toppingsByCode.TryGetValue(mixCode, out List<ItemStack>? value)) value.Add(stack);
+                            else toppingsByCode.Add(mixCode, [stack]);
+                        }
                         break;
                 }
             }
 
             return
             [
-                .. mixedFillings.Select(entry => CreateRecipe(api.World, "mixed-" + entry.Key.ToLowerInvariant(), crusts, [.. entry.Value], toppings)),
-                .. noMixFillings.Select(stack => CreateRecipe(api.World, "single-" + stack.Collectible.Code.ToShortString(), crusts, [stack], toppings))
+                .. mixedFillings.Select(entry =>
+                    {
+                        List<ItemStack> toppings = toppingsByCode
+                            .Where(topping => topping.Key == entry.Key)
+                            .SelectMany(topping => topping.Value)
+                            .ToList();
+                        
+                        // Crusts apply to all mixing codes, so always add them
+                        toppings.AddRange(crusts);
+
+                        return CreateRecipe(
+                            api.World,
+                            "mixed-" + entry.Key.ToLowerInvariant(),
+                            crusts,
+                            [.. entry.Value],
+                            toppings);
+                    }
+                ),
+                .. noMixFillings.Select(stack =>
+                {
+                    List<ItemStack> toppings = toppingsByCode
+                        .Where(topping => InPieProperties.ReadFrom(stack)!.MixingCodes.Contains(topping.Key))
+                        .SelectMany(topping => topping.Value)
+                        .ToList();
+
+                    // Crusts apply to all mixing codes, so always add them
+                    toppings.AddRange(crusts);
+
+                    return CreateRecipe(
+                        api.World,
+                        "single-" + stack.Collectible.Code.ToShortString(),
+                        crusts,
+                        [stack],
+                        toppings
+                    );
+                })
             ];
         }
 
@@ -679,7 +743,7 @@ namespace Vintagestory.GameContent
                 }
 
                 cachedValidStacksByIngredient = validStacksByIngredient;
-            };
+            }
 
 
             void addIngredient(ref List<ItemStack?> pie, string code, ref Dictionary<CookingRecipeIngredient, List<ItemStack?>> valIngStacks, ref CookingRecipeIngredient? requestedIngredient)
@@ -698,6 +762,10 @@ namespace Vintagestory.GameContent
                     }
 
                     requestedIngredient = null;
+
+                    // Without this, we could add a requested dough/topping and
+                    // then another, which breaks the pie.
+                    if (ingredient.MaxQuantity <= 0) return;
                 }
 
                 // Only fillings need the code below here for filtering, so we skip the
@@ -731,29 +799,36 @@ namespace Vintagestory.GameContent
                 }
             }
 
-
+            Dictionary<CookingRecipeIngredient, List<ItemStack?>> valIngStacks = [];
+            foreach (var entry in validStacksByIngredient) valIngStacks.Add(entry.Key.Clone(), [.. entry.Value]);
+            valIngStacks = valIngStacks.OrderBy(x => api.World.Rand.Next()).ToDictionary(item => item.Key, item => item.Value);
+            CookingRecipeIngredient? requestedIngredient = null;
+            if (ingredientStack != null)
+            {
+                List<CookingRecipeIngredient> validIngredients = [.. recipe.Ingredients.Where(ingredient => ingredient.Matches(ingredientStack))];
+                requestedIngredient = validIngredients[api.World.Rand.Next(validIngredients.Count)].Clone();
+            }
 
             List<ItemStack?> randomPie = [];
-            while (!recipe.Matches([.. randomPie]))
+            addIngredient(ref randomPie, "dough", ref valIngStacks, ref requestedIngredient);
+            addIngredient(ref randomPie, "filling", ref valIngStacks, ref requestedIngredient);
+            addIngredient(ref randomPie, "crust", ref valIngStacks, ref requestedIngredient);
+
+            if (randomPie.Count > 6)
             {
-                Dictionary<CookingRecipeIngredient, List<ItemStack?>> valIngStacks = [];
-                foreach (var entry in validStacksByIngredient) valIngStacks.Add(entry.Key.Clone(), [.. entry.Value]);
-                valIngStacks = valIngStacks.OrderBy(x => api.World.Rand.Next()).ToDictionary(item => item.Key, item => item.Value);
+                api.Logger.Error($"Random pie [ {string.Join(", ", randomPie)} ] has a length greater than 6. Making it completely empty to prevent worse issues. This is a coding error, so please report it.");
+                return [null, null, null, null, null, null];
+            }
 
-                CookingRecipeIngredient? requestedIngredient = null;
-                if (ingredientStack != null)
-                {
-                    List<CookingRecipeIngredient> validIngredients = [.. recipe.Ingredients.Where(ingredient => ingredient.Matches(ingredientStack))];
-                    requestedIngredient = validIngredients[api.World.Rand.Next(validIngredients.Count)].Clone();
-                }
+            while (randomPie.Count < 6) randomPie.Add(null);
 
+            if (!recipe.Matches([.. randomPie]))
+            {
+                api.Logger.Error($"Random pie [ {string.Join(", ", randomPie)} ] is invalid or does not match recipe {recipe.Code}. Making it completely empty to prevent worse issues. This is a coding error, so please report it.");
                 randomPie = [];
-                addIngredient(ref randomPie, "dough", ref valIngStacks, ref requestedIngredient);
-                addIngredient(ref randomPie, "filling", ref valIngStacks, ref requestedIngredient);
-                addIngredient(ref randomPie, "crust", ref valIngStacks, ref requestedIngredient);
-
                 while (randomPie.Count < 6) randomPie.Add(null);
             }
+
             return [.. randomPie];
         }
 
@@ -798,26 +873,37 @@ namespace Vintagestory.GameContent
 
         public override string HandbookPageCodeForStack(IWorldAccessor world, ItemStack stack)
         {
-            string? type = null;
+            ItemStack[] cStacks = GetContents(api.World, stack);
+            if (cStacks.Length <= 1 || cStacks[1] == null) return "craftinginfo-pie";
 
-            if (GetContents(world, stack) is ItemStack[] contents && contents.Length > 1)
+            // Use null-forgiving in this method in case the pie is malformed,
+            // e.g. an ingredient lost its pie props. Also report it because
+            // its a content error.
+            for (int i = 0; i < 6; i++)
             {
-                InPieProperties? pieProps = InPieProperties.ReadFrom(contents[1]);
-                if (pieProps?.AllowMixing == false)
+                if (cStacks[i] != null && InPieProperties.ReadFrom(cStacks[i]) == null)
                 {
-                    type = "single-" + contents[1].Collectible.Code.ToShortString();
+                    ReportMissingPieProps(api.Logger, cStacks[i].Collectible.Code);
                 }
-                else
-                {
-                    type = "mixed-" + IngredientFoodCategory(contents[1]).ToString().ToLowerInvariant();
-                }
+            }
 
-                return "handbook-mealrecipe-" + type + "-pie";
-            }
-            else
+            bool singleIngredient = true;
+            IEnumerable<string> mixCodes = InPieProperties.ReadFrom(cStacks[1])?.MixingCodes ?? [];
+            for (int i = 2; i < cStacks.Length - 1; i++)
             {
-                return "craftinginfo-pie";
+                if (cStacks[i] == null) continue;
+
+                singleIngredient &= cStacks[i].Equals(api.World, cStacks[1], GlobalConstants.IgnoredStackAttributes);
+                mixCodes = InPieProperties.ReadFrom(cStacks[i])?.MixingCodes.Intersect(mixCodes) ?? [];
+
+                if (!singleIngredient && !mixCodes.Any()) break;
             }
+
+            string pieType = singleIngredient
+                ? "single-" + cStacks[1].Collectible.Code.ToShortString()
+                : "mixed-" + mixCodes.FirstOrDefault("unknown").ToLowerInvariant();
+
+            return $"handbook-mealrecipe-{pieType}-pie";
         }
     }
 }

--- a/Block/BlockPie.cs
+++ b/Block/BlockPie.cs
@@ -701,22 +701,12 @@ namespace Vintagestory.GameContent
                 }
 
                 // Only fillings need the code below here for filtering, so we skip the
-                // list copying if possible.
+                // list copying for crusts and toppings.
                 if (code != "filling")
                 {
                     pie.Add(validStacks[api.World.Rand.Next(validStacks.Count)]?.Clone());
                     return;
                 }
-
-                // When we add an ingredient, we filter out all the other ingredients
-                // that have any of the same codes that aren't the recipe code.
-                // This ensures we get the widest selection possible
-                // in order to minimize the chance of accidentally getting a pie
-                // that is considered a different category than requested.
-                //
-                // We try to include as many codes as possible to avoid accidentally
-                // getting a more specific type of pie, e.g. we don't want to get all
-                // vegetables when we're trying to generate a pot pie.
 
                 List<ItemStack?> filteredValidStacks = validStacks;
                 string recipeCode = recipe.Code?.Split("-").ElementAtOrDefault(1) ?? "";

--- a/Block/BlockPie.cs
+++ b/Block/BlockPie.cs
@@ -273,7 +273,7 @@ namespace Vintagestory.GameContent
             if (cStacks.Length <= 1) return Lang.Get("pie-empty");
 
             ItemStack prevStack = cStacks[1];
-            EnumFoodCategory[] foodCats = cStacks.Select(FillingFoodCategory).ToArray();
+            EnumFoodCategory[] foodCats = cStacks.Select(IngredientFoodCategory).ToArray();
             EnumFoodCategory prevFoodCat = foodCats[1];
 
             if (prevStack == null) return Lang.Get("pie-empty");
@@ -312,25 +312,36 @@ namespace Vintagestory.GameContent
                 return Lang.Get("pie-mixed-" + mixCodes.First() + "-" + state);
             }
 
-            return Lang.Get("pie-mixed-" + FillingFoodCategory(cStacks[1]).ToString().ToLowerInvariant() + "-" + state);
+            return Lang.Get("pie-mixed-" + IngredientFoodCategory(cStacks[1]).ToString().ToLowerInvariant() + "-" + state);
         }
 
-        public static EnumFoodCategory FillingFoodCategory(ItemStack? stack)
+        /// <summary>
+        /// The food category of the ingredient when used in a pie.
+        ///
+        /// Checks in order, stopping once a value is found:
+        ///   1. If stack is null, default to vegetable
+        ///   2. InPieProperties.FoodCategory
+        ///   3. If stack has ContainableProps:
+        ///     3a. NutritionPropsPerLitreWhenInMeal.FoodCategory
+        ///     3b. NutritionPropsPerLitre.FoodCategory
+        ///   4. If stack has NutritionProps:
+        ///     4a. NutritionPropsWhenInMeal.FoodCategory
+        ///     4b. NutritionProps.FoodCategory
+        ///   5. Default to vegetable
+        /// </summary>
+        public static EnumFoodCategory IngredientFoodCategory(ItemStack? stack)
         {
             if (stack == null) return EnumFoodCategory.Vegetable;
             EnumFoodCategory? category = InPieProperties.ReadFrom(stack)?.FoodCategory;
 
-            if (category == null)
+            if (category == null && BlockLiquidContainerBase.GetContainableProps(stack) is WaterTightContainableProps liquidProps)
             {
-                var liquidProps = BlockLiquidContainerBase.GetContainableProps(stack);
-                if (liquidProps != null)
-                {
-                    category = liquidProps.NutritionPropsPerLitreWhenInMeal?.FoodCategory
-                            ?? liquidProps.NutritionPropsPerLitre?.FoodCategory;
-                }
+                category ??= liquidProps.NutritionPropsPerLitreWhenInMeal?.FoodCategory;
+                category ??= liquidProps.NutritionPropsPerLitre?.FoodCategory;
             }
-            category ??= stack.ItemAttributes?["nutritionPropsWhenInMeal"]?.AsObject<FoodNutritionProperties>()?.FoodCategory
-                      ?? stack.Collectible.GetNutritionProperties(null, stack, null)?.FoodCategory;
+
+            category ??= stack.ItemAttributes?["nutritionPropsWhenInMeal"]?.AsObject<FoodNutritionProperties>()?.FoodCategory;
+            category ??= stack.Collectible.GetNutritionProperties(null, stack, null)?.FoodCategory;
 
             return category ?? EnumFoodCategory.Vegetable;
         }
@@ -544,7 +555,7 @@ namespace Vintagestory.GameContent
                         else mixedFillings.Add(code, [stack]);
                     }
 
-                    var cat = FillingFoodCategory(stack);
+                    var cat = IngredientFoodCategory(stack);
                     if (cat is not EnumFoodCategory.NoNutrition and not EnumFoodCategory.Unknown)
                     {
                         if (categoryFillings.TryGetValue(cat, out var value)) value.Add(stack);
@@ -673,7 +684,7 @@ namespace Vintagestory.GameContent
                 {
                     if (validStacks.First(stack => stack?.Collectible.Code == ingredientStack?.Collectible.Code) is { } stack)
                     {
-                        if (FillingFoodCategory(stack) is EnumFoodCategory cat)
+                        if (IngredientFoodCategory(stack) is EnumFoodCategory cat)
                         {
                             includedFoodCategories.Add(cat);
                         }
@@ -692,7 +703,7 @@ namespace Vintagestory.GameContent
                 {
                     foreach (ItemStack? stack in validStacks)
                     {
-                        if (FillingFoodCategory(stack) is EnumFoodCategory cat && cat != EnumFoodCategory.NoNutrition)
+                        if (IngredientFoodCategory(stack) is EnumFoodCategory cat && cat != EnumFoodCategory.NoNutrition)
                         {
                             allFoodCategories.Add(cat);
                         }
@@ -744,13 +755,13 @@ namespace Vintagestory.GameContent
                     if (ingredient.Code == "filling" && (filteredValidStacks?.Count ?? 0) > 0)
                     {
                         ItemStack? newIngredient = filteredValidStacks![api.World.Rand.Next(filteredValidStacks!.Count)]?.Clone();
-                        if (FillingFoodCategory(newIngredient) is EnumFoodCategory newCategory)
+                        if (IngredientFoodCategory(newIngredient) is EnumFoodCategory newCategory)
                         {
                             includedFoodCategories.Add(newCategory);
 
                             bool filterStackIfCategoryIncluded(ItemStack? stack)
                             {
-                                if (FillingFoodCategory(stack) is EnumFoodCategory category)
+                                if (IngredientFoodCategory(stack) is EnumFoodCategory category)
                                 {
                                     return includedFoodCategories.Contains(category);
                                 }
@@ -849,7 +860,7 @@ namespace Vintagestory.GameContent
                 {
                     type = "single-" + contents[1].Collectible.Code.ToShortString();
                 }
-                else type = "mixed-" + FillingFoodCategory(contents[1]).ToString().ToLowerInvariant();
+                else type = "mixed-" + IngredientFoodCategory(contents[1]).ToString().ToLowerInvariant();
 
                 return "handbook-mealrecipe-" + type + "-pie";
             }

--- a/Block/BlockPie.cs
+++ b/Block/BlockPie.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
+using Vintagestory.API;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Config;
@@ -12,6 +13,16 @@ using Vintagestory.API.Util;
 
 namespace Vintagestory.GameContent
 {
+    /// <summary>
+    /// A definition for a top crust type, including its code and shape element.
+    /// </summary>
+    /// <example language="json">
+    /// {
+    ///     "code": "full",
+    ///     "shapeElement": "origin/base/top crust full/*"
+    /// }
+    /// </example>
+    [DocumentAsJson]
     public class PieTopCrustType
     {
         public required string Code;

--- a/Block/BlockPie.cs
+++ b/Block/BlockPie.cs
@@ -78,7 +78,7 @@ namespace Vintagestory.GameContent
                             doughStacks.Add(new ItemStack(obj, 2));
                         }
 
-                        if (obj.Attributes?["inPieProperties"].AsObject<InPieProperties?>(null, obj.Code.Domain)?.PartType == EnumPiePartType.Filling)
+                        if (InPieProperties.ReadFrom(obj)?.PartType == EnumPiePartType.Filling)
                         {
                             fillStacks.Add(new ItemStack(obj, 2));
                         }
@@ -234,8 +234,7 @@ namespace Vintagestory.GameContent
             IPlayer? byPlayer = (byEntity as EntityPlayer)?.Player;
             ItemSlot? hotbarSlot = byPlayer?.InventoryManager.ActiveHotbarSlot;
 
-            var pieprops = hotbarSlot?.Itemstack?.ItemAttributes["inPieProperties"]?.AsObject<InPieProperties>();
-            if (pieprops?.PartType != EnumPiePartType.Crust) return;
+            if (InPieProperties.ReadFrom(hotbarSlot?.Itemstack)?.PartType != EnumPiePartType.Crust) return;
 
             BlockPos abovePos = blockSel.Position.UpCopy();
 
@@ -269,14 +268,14 @@ namespace Vintagestory.GameContent
 
             bool singleIngredient = true;
             bool singleFoodCat = true;
-            IEnumerable<string> mixCodes = cstack.ItemAttributes["inPieProperties"].AsObject<InPieProperties>()?.MixingCodes ?? [];
+            IEnumerable<string> mixCodes = InPieProperties.ReadFrom(cstack)?.MixingCodes ?? [];
             for (int i = 2; (singleIngredient || singleFoodCat || mixCodes.Any()) && i < cStacks.Length - 1; i++)
             {
                 if (cStacks[i] == null) continue;
 
                 singleIngredient &= cstack.Equals(api.World, cStacks[i], GlobalConstants.IgnoredStackAttributes);
                 singleFoodCat &= cStacks[i] == null || foodCats[i] == foodCat;
-                mixCodes = cstack.ItemAttributes["inPieProperties"].AsObject<InPieProperties>()?.MixingCodes.Intersect(mixCodes) ?? [];
+                mixCodes = InPieProperties.ReadFrom(cstack)?.MixingCodes.Intersect(mixCodes) ?? [];
 
                 cstack = cStacks[i];
                 foodCat = foodCats[i];
@@ -305,7 +304,7 @@ namespace Vintagestory.GameContent
         public static EnumFoodCategory FillingFoodCategory(ItemStack? stack)
         {
             if (stack == null) return EnumFoodCategory.Vegetable;
-            EnumFoodCategory? category = stack.ItemAttributes["inPieProperties"].AsObject<InPieProperties>()?.FoodCategory;
+            EnumFoodCategory? category = InPieProperties.ReadFrom(stack)?.FoodCategory;
 
             if (category == null)
             {
@@ -519,7 +518,7 @@ namespace Vintagestory.GameContent
 
             foreach (var stack in allStacks)
             {
-                var pieProps = stack.ItemAttributes?["inPieProperties"]?.AsObject<InPieProperties>();
+                var pieProps = InPieProperties.ReadFrom(stack);
 
                 if (pieProps?.PartType == EnumPiePartType.Crust) doughs.Add(stack);
                 if (pieProps is { PartType: EnumPiePartType.Filling, AllowMixing: true })
@@ -706,7 +705,7 @@ namespace Vintagestory.GameContent
                         int noOtherMixingCodesInCategory = filteredValidStacks
                             .Where(stack =>
                             {
-                                if (stack?.ItemAttributes["inPieProperties"].AsObject<InPieProperties>() is not { } props) return true;
+                                if (InPieProperties.ReadFrom(stack) is not { } props) return true;
                                 return props.FoodCategory == cat && props.MixingCodes.Except([pieMixCode[1]]).Count() == 0;
                             })
                             .Count();
@@ -716,7 +715,7 @@ namespace Vintagestory.GameContent
                             // We can filter out non-matching mixing codes because we have at least one left for this category.
                             filteredValidStacks = filteredValidStacks.Where(stack =>
                             {
-                                if (stack?.ItemAttributes["inPieProperties"].AsObject<InPieProperties>() is not { } props) return true;
+                                if (InPieProperties.ReadFrom(stack) is not { } props) return true;
                                 return props.FoodCategory != cat || props.MixingCodes.Except([pieMixCode[1]]).Count() == 0;
                             }).ToList();
                         }
@@ -831,7 +830,7 @@ namespace Vintagestory.GameContent
 
             if (GetContents(world, stack) is ItemStack[] contents && contents.Length > 1)
             {
-                if (contents[1]?.ItemAttributes?["inPieProperties"]?.AsObject<InPieProperties>()?.AllowMixing == false)
+                if (InPieProperties.ReadFrom(contents[1])?.AllowMixing == false)
                 {
                     type = "single-" + contents[1].Collectible.Code.ToShortString();
                 }

--- a/Block/BlockPie.cs
+++ b/Block/BlockPie.cs
@@ -10,8 +10,6 @@ using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Util;
 
-#nullable enable
-
 namespace Vintagestory.GameContent
 {
     public class PieTopCrustType
@@ -20,10 +18,13 @@ namespace Vintagestory.GameContent
         public required string ShapeElement;
     }
 
-    // Definition: GetContents() must always return a ItemStack[] of array length 6
-    // [0] = crust
-    // [1-4] = filling
-    // [5] = topping (unused atm)
+    /// <summary>
+    /// GetContents() is an ItemStack[6]. Unused slots are represented as null.
+    ///
+    /// [0]: Base dough
+    /// [1-4]: Filling
+    /// [5]: Crust dough
+    /// </summary>
     public class BlockPie : BlockMeal, IBakeableCallback, IShelvable
     {
         /// <summary>
@@ -32,7 +33,7 @@ namespace Vintagestory.GameContent
         public string State => Variant["state"];
         protected override bool PlacedBlockEating => false;
 
-        public EnumShelvableLayout? GetShelvableType(ItemStack stack)
+        public static EnumShelvableLayout? GetShelvableType(ItemStack stack)
         {
             return stack.Attributes.GetAsInt("pieSize") switch
             {
@@ -41,7 +42,8 @@ namespace Vintagestory.GameContent
                 _ => EnumShelvableLayout.SingleCenter
             };
         }
-        public ModelTransform? GetOnShelfTransform(ItemStack stack)
+
+        public static ModelTransform? GetOnShelfTransform(ItemStack stack)
         {
             return GetShelvableType(stack) switch
             {
@@ -77,7 +79,8 @@ namespace Vintagestory.GameContent
                 {
                     foreach (CollectibleObject obj in api.World.Collectibles)
                     {
-                        EnumPiePartType? partType = InPieProperties.ReadFrom(obj)?.PartType;
+                        if (InPieProperties.ReadFrom(obj) is not InPieProperties pieProps || pieProps.FoodCategory == EnumFoodCategory.NoNutrition) continue;
+                        EnumPiePartType partType = pieProps.PartType;
 
                         if (obj is ItemDough || partType == EnumPiePartType.Crust)
                         {
@@ -95,6 +98,20 @@ namespace Vintagestory.GameContent
                             case EnumPiePartType.Crust:
                                 toppingStacks.Add(new ItemStack(obj, 2));
                                 break;
+                        }
+
+                        if (pieProps.PartType == EnumPiePartType.Filling || pieProps.PartType == EnumPiePartType.Topping)
+                        {
+                            int nonFoodCatCodes = pieProps.MixingCodes.Where(code => code != pieProps.FoodCategory.ToString().ToLowerInvariant()).ToArray().Length;
+                            if (nonFoodCatCodes == 0 && pieProps.FoodCategory == EnumFoodCategory.NoNutrition)
+                            {
+                                api.World.Logger.Error($"InPieProperties for filling {obj.Code} has no mixing codes and food category NoNutrition. It cannot be added to pies! See the documentation.");
+                            }
+
+                            if (!pieProps.AllowMixing && nonFoodCatCodes > 0)
+                            {
+                                api.World.Logger.Error($"InPieProperties for filling {obj.Code} has explicit mixingCodes, but allowMixing is disabled. Mixing codes will be ignored. Don't do this intentionally. Allow mixing or remove the mixing codes to suppress this error.");
+                            }
                         }
                     }
                 }
@@ -320,15 +337,16 @@ namespace Vintagestory.GameContent
         }
 
         /// <summary>
-        /// The food category of the ingredient when used in a pie.
-        /// 
-        /// See InPieProperties.ReadFrom()
+        /// The food category mixing code for the ingredient when used in a pie.
+        /// This is not the actual food category when consumed.
+        ///
+        /// See InPieProperties.FoodCategory documentation
         /// </summary>
         public static EnumFoodCategory IngredientFoodCategory(ItemStack? stack)
         {
             if (InPieProperties.ReadFrom(stack) is InPieProperties pieProps) return pieProps.FoodCategory;
 
-            return EnumFoodCategory.Unknown;
+            return EnumFoodCategory.NoNutrition;
         }
 
 
@@ -642,9 +660,9 @@ namespace Vintagestory.GameContent
                     ingredient.Resolve(api.World, "handbook meal recipes");
                     foreach (ItemStack? astack in ingredient.ValidStacks.Select(stack => stack.ResolvedItemstack))
                     {
-                        if (ingredient.GetMatchingStack(astack) is not { } vstack) continue;
+                        if (ingredient.GetMatchingStack(astack) is not CookingRecipeStack vstack) continue;
 
-                        if (astack?.Clone() is { } stack && BlockLiquidContainerBase.GetContainableProps(stack) is { } props)
+                        if (astack?.Clone() is ItemStack stack && BlockLiquidContainerBase.GetContainableProps(stack) is WaterTightContainableProps props)
                         {
                             stack.StackSize = vstack.StackSize * (int)(props.ItemsPerLitre * ingredient.PortionSizeLitres);
                             ingredientStacks.Add(stack);
@@ -662,9 +680,6 @@ namespace Vintagestory.GameContent
 
                 cachedValidStacksByIngredient = validStacksByIngredient;
             };
-
-            if (validStacksByIngredient == null) return new ItemStack?[6];
-
 
 
             void addIngredient(ref List<ItemStack?> pie, string code, ref Dictionary<CookingRecipeIngredient, List<ItemStack?>> valIngStacks, ref CookingRecipeIngredient? requestedIngredient)
@@ -797,15 +812,22 @@ namespace Vintagestory.GameContent
 
             if (GetContents(world, stack) is ItemStack[] contents && contents.Length > 1)
             {
-                if (InPieProperties.ReadFrom(contents[1])?.AllowMixing == false)
+                InPieProperties? pieProps = InPieProperties.ReadFrom(contents[1]);
+                if (pieProps?.AllowMixing == false)
                 {
                     type = "single-" + contents[1].Collectible.Code.ToShortString();
                 }
-                else type = "mixed-" + IngredientFoodCategory(contents[1]).ToString().ToLowerInvariant();
+                else
+                {
+                    type = "mixed-" + IngredientFoodCategory(contents[1]).ToString().ToLowerInvariant();
+                }
 
                 return "handbook-mealrecipe-" + type + "-pie";
             }
-            else return "craftinginfo-pie";
+            else
+            {
+                return "craftinginfo-pie";
+            }
         }
     }
 }

--- a/Block/BlockPie.cs
+++ b/Block/BlockPie.cs
@@ -395,7 +395,7 @@ namespace Vintagestory.GameContent
 
 
             TransitionableProperties[] propsm = pieStack.Collectible.GetTransitionableProperties(api.World, pieStack, null);
-            if (propsm != null && propsm.Length > 0)
+            if (propsm?.Length > 0)
             {
                 pieStack.Collectible.AppendPerishableInfoText(inSlot, dsc, api.World);
             }

--- a/Block/BlockPie.cs
+++ b/Block/BlockPie.cs
@@ -580,8 +580,8 @@ namespace Vintagestory.GameContent
                 [
                     new ()
                     {
-                        Code = "crust",
-                        TypeName = "piecrust",
+                        Code = "dough",
+                        TypeName = "bottomcrust",
                         MinQuantity = 1,
                         MaxQuantity = 1,
                         ValidStacks = [.. crusts.Select<ItemStack, CookingRecipeStack>(crust => new ()
@@ -608,8 +608,8 @@ namespace Vintagestory.GameContent
                     },
                     new ()
                     {
-                        Code = "topping",
-                        TypeName = "pietopping",
+                        Code = "crust",
+                        TypeName = "topcrust",
                         MinQuantity = 0,
                         MaxQuantity = 1,
                         ValidStacks = [.. toppings.Select<ItemStack, CookingRecipeStack>(topping => new ()
@@ -743,9 +743,9 @@ namespace Vintagestory.GameContent
                 }
 
                 randomPie = [];
-                addIngredient(ref randomPie, "crust", ref valIngStacks, ref requestedIngredient);
+                addIngredient(ref randomPie, "dough", ref valIngStacks, ref requestedIngredient);
                 addIngredient(ref randomPie, "filling", ref valIngStacks, ref requestedIngredient);
-                addIngredient(ref randomPie, "topping", ref valIngStacks, ref requestedIngredient);
+                addIngredient(ref randomPie, "crust", ref valIngStacks, ref requestedIngredient);
 
                 while (randomPie.Count < 6) randomPie.Add(null);
             }

--- a/Block/BlockPie.cs
+++ b/Block/BlockPie.cs
@@ -26,6 +26,9 @@ namespace Vintagestory.GameContent
     // [5] = topping (unused atm)
     public class BlockPie : BlockMeal, IBakeableCallback, IShelvable
     {
+        /// <summary>
+        /// The pie's cooking stage; "raw", "partbaked", "perfect", or "charred"
+        /// </summary>
         public string State => Variant["state"];
         protected override bool PlacedBlockEating => false;
 
@@ -65,22 +68,33 @@ namespace Vintagestory.GameContent
 
             interactions = ObjectCacheUtil.GetOrCreate(api, "pieInteractions-", () =>
             {
-                var knifeStacks = ObjectCacheUtil.GetToolStacks(api, EnumTool.Knife);
-                List<ItemStack> fillStacks = [];
+                ItemStack[] knifeStacks = ObjectCacheUtil.GetToolStacks(api, EnumTool.Knife);
                 List<ItemStack> doughStacks = [];
+                List<ItemStack> fillStacks = [];
+                List<ItemStack> toppingStacks = [];
 
                 if (fillStacks.Count == 0 && doughStacks.Count == 0)
                 {
-                    foreach (var obj in api.World.Collectibles)
+                    foreach (CollectibleObject obj in api.World.Collectibles)
                     {
-                        if (obj is ItemDough)
+                        EnumPiePartType? partType = InPieProperties.ReadFrom(obj)?.PartType;
+
+                        if (obj is ItemDough || partType == EnumPiePartType.Crust)
                         {
                             doughStacks.Add(new ItemStack(obj, 2));
                         }
 
-                        if (InPieProperties.ReadFrom(obj)?.PartType == EnumPiePartType.Filling)
+                        switch (partType)
                         {
-                            fillStacks.Add(new ItemStack(obj, 2));
+                            case EnumPiePartType.Filling:
+                                fillStacks.Add(new ItemStack(obj, 2));
+                                break;
+                            case EnumPiePartType.Topping:
+                                toppingStacks.Add(new ItemStack(obj, 2));
+                                break;
+                            case EnumPiePartType.Crust:
+                                toppingStacks.Add(new ItemStack(obj, 2));
+                                break;
                         }
                     }
                 }
@@ -106,12 +120,12 @@ namespace Vintagestory.GameContent
                         }
                     },
                     new() {
-                        ActionLangCode = "blockhelp-pie-addcrust",
+                        ActionLangCode = "blockhelp-pie-addcrustortopping",
                         MouseButton = EnumMouseButton.Right,
-                        Itemstacks = doughStacks.ToArray(),
+                        Itemstacks = toppingStacks.ToArray(),
                         GetMatchingStacks = (wi, bs, _) => {
                             if (GetBlockEntity<BlockEntityPie>(bs.Position) is not BlockEntityPie pie) return null;
-                            return pie.State == "raw" && pie.HasAllFilling && !pie.HasCrust ? wi.Itemstacks : null;
+                            return pie.State == "raw" && pie.HasAllFilling && pie.ToppingType == null ? wi.Itemstacks.Where(pie.CanAddIngredient).ToArray() : null;
                         }
                     },
                     new() {
@@ -120,7 +134,7 @@ namespace Vintagestory.GameContent
                         Itemstacks = knifeStacks,
                         GetMatchingStacks = (wi, bs, _) => {
                             if (GetBlockEntity<BlockEntityPie>(bs.Position) is not BlockEntityPie pie) return null;
-                            return pie.State == "raw" && pie.HasCrust ? wi.Itemstacks : null;
+                            return pie.State == "raw" && pie.ToppingType == EnumPiePartType.Crust ? wi.Itemstacks : null;
                         }
                     }
                 };
@@ -202,7 +216,7 @@ namespace Vintagestory.GameContent
 
         public override ItemStack OnPickBlock(IWorldAccessor world, BlockPos pos)
         {
-            if ((world.BlockAccessor.GetBlockEntity(pos) as BlockEntityPie)?.Inventory[0].Itemstack is { } pieStack) return pieStack.Clone();
+            if ((world.BlockAccessor.GetBlockEntity(pos) as BlockEntityPie)?.Inventory[0].Itemstack is ItemStack pieStack) return pieStack.Clone();
 
             return base.OnPickBlock(world, pos);
         }
@@ -270,29 +284,18 @@ namespace Vintagestory.GameContent
         public override string GetHeldItemName(ItemStack? itemStack)
         {
             ItemStack[] cStacks = GetContents(api.World, itemStack);
-            if (cStacks.Length <= 1) return Lang.Get("pie-empty");
-
-            ItemStack prevStack = cStacks[1];
-            EnumFoodCategory[] foodCats = cStacks.Select(IngredientFoodCategory).ToArray();
-            EnumFoodCategory prevFoodCat = foodCats[1];
-
-            if (prevStack == null) return Lang.Get("pie-empty");
+            if (cStacks.Length <= 1 || cStacks[1] == null) return Lang.Get("pie-empty");
 
             bool singleIngredient = true;
-            bool singleFoodCat = true;
-            IEnumerable<string> mixCodes = InPieProperties.ReadFrom(prevStack)?.MixingCodes ?? [];
+            IEnumerable<string> mixCodes = InPieProperties.ReadFrom(cStacks[1])!.MixingCodes ?? [];
             for (int i = 2; i < cStacks.Length - 1; i++)
             {
                 if (cStacks[i] == null) continue;
 
-                singleIngredient &= prevStack.Equals(api.World, cStacks[i], GlobalConstants.IgnoredStackAttributes);
-                singleFoodCat &= cStacks[i] == null || foodCats[i] == prevFoodCat;
-                mixCodes = InPieProperties.ReadFrom(cStacks[i])?.MixingCodes.Intersect(mixCodes) ?? [];
+                singleIngredient &= cStacks[i].Equals(api.World, cStacks[1], GlobalConstants.IgnoredStackAttributes);
+                mixCodes = InPieProperties.ReadFrom(cStacks[i])!.MixingCodes.Intersect(mixCodes) ?? [];
 
-                if (!singleIngredient && !singleFoodCat && !mixCodes.Any()) break;
-
-                prevStack = cStacks[i];
-                prevFoodCat = foodCats[i];
+                if (!singleIngredient && !mixCodes.Any()) break;
             }
 
             string state = Variant["state"];
@@ -302,48 +305,30 @@ namespace Vintagestory.GameContent
                 return Lang.Get("pie-single-rotten");
             }
 
-            if (singleIngredient)
-            {
-                return Lang.Get("pie-single-" + prevStack.Collectible.Code.ToShortString() + "-" + state);
-            }
+            string pieName = Lang.Get(singleIngredient
+                ? "pie-single-" + cStacks[1].Collectible.Code.ToShortString() + "-" + state
+                : "pie-mixed-" + mixCodes.First() + "-" + state);
 
-            if (!singleFoodCat && mixCodes.Any())
+            if (cStacks[5] != null && InPieProperties.ReadFrom(cStacks[5])!.PartType != EnumPiePartType.Crust)
             {
-                return Lang.Get("pie-mixed-" + mixCodes.First() + "-" + state);
+                return Lang.Get("meal-topping-ingredient-format", cStacks[5].Collectible.GetHeldItemName(cStacks[5]), pieName.ToLowerInvariant());
             }
-
-            return Lang.Get("pie-mixed-" + IngredientFoodCategory(cStacks[1]).ToString().ToLowerInvariant() + "-" + state);
+            else
+            {
+                return pieName;
+            }
         }
 
         /// <summary>
         /// The food category of the ingredient when used in a pie.
-        ///
-        /// Checks in order, stopping once a value is found:
-        ///   1. If stack is null, default to vegetable
-        ///   2. InPieProperties.FoodCategory
-        ///   3. If stack has ContainableProps:
-        ///     3a. NutritionPropsPerLitreWhenInMeal.FoodCategory
-        ///     3b. NutritionPropsPerLitre.FoodCategory
-        ///   4. If stack has NutritionProps:
-        ///     4a. NutritionPropsWhenInMeal.FoodCategory
-        ///     4b. NutritionProps.FoodCategory
-        ///   5. Default to vegetable
+        /// 
+        /// See InPieProperties.ReadFrom()
         /// </summary>
         public static EnumFoodCategory IngredientFoodCategory(ItemStack? stack)
         {
-            if (stack == null) return EnumFoodCategory.Vegetable;
-            EnumFoodCategory? category = InPieProperties.ReadFrom(stack)?.FoodCategory;
+            if (InPieProperties.ReadFrom(stack) is InPieProperties pieProps) return pieProps.FoodCategory;
 
-            if (category == null && BlockLiquidContainerBase.GetContainableProps(stack) is WaterTightContainableProps liquidProps)
-            {
-                category ??= liquidProps.NutritionPropsPerLitreWhenInMeal?.FoodCategory;
-                category ??= liquidProps.NutritionPropsPerLitre?.FoodCategory;
-            }
-
-            category ??= stack.ItemAttributes?["nutritionPropsWhenInMeal"]?.AsObject<FoodNutritionProperties>()?.FoodCategory;
-            category ??= stack.Collectible.GetNutritionProperties(null, stack, null)?.FoodCategory;
-
-            return category ?? EnumFoodCategory.Vegetable;
+            return EnumFoodCategory.Unknown;
         }
 
 
@@ -373,7 +358,7 @@ namespace Vintagestory.GameContent
 
             ItemStack[] stacks = GetContents(api.World, pieStack);
 
-            var forEntity = (world as IClientWorldAccessor)?.Player?.Entity;
+            EntityPlayer? forEntity = (world as IClientWorldAccessor)?.Player?.Entity;
 
 
             float[] nmul = GetNutritionHealthMul(null, inSlot, forEntity);
@@ -406,6 +391,7 @@ namespace Vintagestory.GameContent
             return str;
         }
 
+        // Skip over the meal transitioning code because only the pie itself spoils, not its contents.
         public override TransitionState[]? UpdateAndGetTransitionStates(IWorldAccessor world, ItemSlot inslot)
         {
             return UpdateAndGetTransitionStatesNative(world, inslot);
@@ -441,6 +427,13 @@ namespace Vintagestory.GameContent
             //base.OnBlockInteractStop(secondsUsed, world, byPlayer, blockSel);
         }
 
+        /// <summary>
+        /// Take a slice from the pie in the itemstack and set pieSize and quantityServings.
+        /// 
+        /// Once sliced, a pie is no longer bakeable.
+        /// </summary>
+        /// <param name="stack">The pie to take a slice from.</param>
+        /// <returns>The new slice as an ItemStack.</returns>
         public static ItemStack? TakeSlice(ref ItemStack? stack)
         {
             if (stack?.Clone() is not ItemStack outStack) return null;
@@ -487,12 +480,12 @@ namespace Vintagestory.GameContent
 
             if (outputSlot.Itemstack == null) return;
 
-            foreach (var slot in allInputslots)
+            foreach (ItemSlot slot in allInputslots)
             {
                 if (slot.Itemstack?.Collectible is not BlockPie) continue;
 
-                var pieStack = slot.Itemstack.Clone();
-                outputSlot.Itemstack = TakeSlice(ref pieStack);
+                ItemStack pieStack = slot.Itemstack.Clone();
+                outputSlot.Itemstack = TakeSlice(ref pieStack!);
             }
         }
 
@@ -530,52 +523,55 @@ namespace Vintagestory.GameContent
             WorldInteraction[] baseinteractions = [ .. base.GetPlacedBlockInteractionHelp(world, selection, forPlayer)
                 .Where(bi => bi.ActionLangCode != "blockhelp-meal-eat" && bi.ActionLangCode != "blockhelp-behavior-rightclickpickup")];
 
-            var allinteractions = interactions.Append(baseinteractions);
+            WorldInteraction[] allinteractions = interactions.Append(baseinteractions);
             return allinteractions;
         }
 
         public static List<CookingRecipe> GetHandbookRecipes(ICoreAPI api, ItemStack[] allStacks)
         {
-            List<ItemStack> doughs = [];
-            Dictionary<EnumFoodCategory, List<ItemStack>> categoryFillings = [];
-            Dictionary<string, List<ItemStack>> mixedFillings = [];
             List<ItemStack> crusts = [];
             List<ItemStack> noMixFillings = [];
+            Dictionary<string, List<ItemStack>> mixedFillings = [];
+            List<ItemStack> toppings = [];
 
-            foreach (var stack in allStacks)
+            foreach (ItemStack stack in allStacks)
             {
-                var pieProps = InPieProperties.ReadFrom(stack);
+                if (InPieProperties.ReadFrom(stack) is not InPieProperties pieProps) continue;
 
-                if (pieProps?.PartType == EnumPiePartType.Crust) doughs.Add(stack);
-                if (pieProps is { PartType: EnumPiePartType.Filling, AllowMixing: true })
+                switch (pieProps.PartType)
                 {
-                    foreach (var code in pieProps.MixingCodes)
-                    {
-                        if (mixedFillings.TryGetValue(code, out var value)) value.Add(stack);
-                        else mixedFillings.Add(code, [stack]);
-                    }
-
-                    var cat = IngredientFoodCategory(stack);
-                    if (cat is not EnumFoodCategory.NoNutrition and not EnumFoodCategory.Unknown)
-                    {
-                        if (categoryFillings.TryGetValue(cat, out var value)) value.Add(stack);
-                        else categoryFillings.Add(cat, [stack]);
-                    }
+                    case EnumPiePartType.Crust:
+                        crusts.Add(stack);
+                        toppings.Add(stack);
+                        break;
+                    case EnumPiePartType.Filling:
+                        if (pieProps.AllowMixing)
+                        {
+                            foreach (string mixCode in pieProps.MixingCodes)
+                            {
+                                if (mixedFillings.TryGetValue(mixCode, out List<ItemStack>? value)) value.Add(stack);
+                                else mixedFillings.Add(mixCode, [stack]);
+                            }
+                        }
+                        else
+                        {
+                            noMixFillings.Add(stack);
+                        }
+                        break;
+                    case EnumPiePartType.Topping:
+                        toppings.Add(stack);
+                        break;
                 }
-                if (pieProps is { PartType: EnumPiePartType.Crust, AllowMixing: true }) crusts.Add(stack);
-
-                if (pieProps is { AllowMixing: false, MixingCodes.Length: 0 }) noMixFillings.Add(stack);
             }
 
             return
             [
-                .. categoryFillings.Select(entry => CreateRecipe(api.World, "mixed-" + entry.Key.ToString().ToLowerInvariant(), doughs, [.. entry.Value], crusts)),
-                .. mixedFillings.Select(entry => CreateRecipe(api.World, "mixed-" + entry.Key.ToLowerInvariant(), doughs, [.. entry.Value], crusts)),
-                .. noMixFillings.Select(stack => CreateRecipe(api.World, "single-" + stack.Collectible.Code.ToShortString(), doughs, [stack], crusts))
+                .. mixedFillings.Select(entry => CreateRecipe(api.World, "mixed-" + entry.Key.ToLowerInvariant(), crusts, [.. entry.Value], toppings)),
+                .. noMixFillings.Select(stack => CreateRecipe(api.World, "single-" + stack.Collectible.Code.ToShortString(), crusts, [stack], toppings))
             ];
         }
 
-        private static CookingRecipe CreateRecipe(IWorldAccessor world, string code, List<ItemStack> doughs, List<ItemStack> fillings, List<ItemStack> crusts, bool mixedRecipe = false)
+        private static CookingRecipe CreateRecipe(IWorldAccessor world, string code, List<ItemStack> crusts, List<ItemStack> fillings, List<ItemStack> toppings, bool mixedRecipe = false)
         {
             return new()
             {
@@ -584,16 +580,16 @@ namespace Vintagestory.GameContent
                 [
                     new ()
                     {
-                        Code = "dough",
-                        TypeName = "bottomcrust",
+                        Code = "crust",
+                        TypeName = "piecrust",
                         MinQuantity = 1,
                         MaxQuantity = 1,
-                        ValidStacks = [.. doughs.Select<ItemStack, CookingRecipeStack>(dough => new ()
+                        ValidStacks = [.. crusts.Select<ItemStack, CookingRecipeStack>(crust => new ()
                         {
-                            Code = dough.Collectible.Code,
-                            Type = dough.Collectible.ItemClass,
+                            Code = crust.Collectible.Code,
+                            Type = crust.Collectible.ItemClass,
                             Quantity = 2,
-                            ResolvedItemstack = dough.Clone()
+                            ResolvedItemstack = crust.Clone()
                         })]
                     },
                     new ()
@@ -612,16 +608,16 @@ namespace Vintagestory.GameContent
                     },
                     new ()
                     {
-                        Code = "crust",
-                        TypeName = "topcrust",
+                        Code = "topping",
+                        TypeName = "pietopping",
                         MinQuantity = 0,
                         MaxQuantity = 1,
-                        ValidStacks = [.. crusts.Select<ItemStack, CookingRecipeStack>(crust => new ()
+                        ValidStacks = [.. toppings.Select<ItemStack, CookingRecipeStack>(topping => new ()
                         {
-                            Code = crust.Collectible.Code,
-                            Type = crust.Collectible.ItemClass,
+                            Code = topping.Collectible.Code,
+                            Type = topping.Collectible.ItemClass,
                             Quantity = 2,
-                            ResolvedItemstack = crust.Clone()
+                            ResolvedItemstack = topping.Clone()
                         })]
                     }
                 ],
@@ -633,13 +629,13 @@ namespace Vintagestory.GameContent
         {
             if (recipe.Ingredients == null) return new ItemStack?[6];
 
-            var validStacksByIngredient = cachedValidStacksByIngredient;
+            Dictionary<CookingRecipeIngredient, HashSet<ItemStack?>>? validStacksByIngredient = cachedValidStacksByIngredient;
 
             if (validStacksByIngredient == null)
             {
                 validStacksByIngredient = [];
 
-                foreach (var ingredient in recipe.Ingredients)
+                foreach (CookingRecipeIngredient? ingredient in recipe.Ingredients)
                 {
                     HashSet<ItemStack?> ingredientStacks = [];
 
@@ -653,7 +649,10 @@ namespace Vintagestory.GameContent
                             stack.StackSize = vstack.StackSize * (int)(props.ItemsPerLitre * ingredient.PortionSizeLitres);
                             ingredientStacks.Add(stack);
                         }
-                        else ingredientStacks.Add(null);
+                        else
+                        {
+                            ingredientStacks.Add(null);
+                        }
                     }
 
                     if (ingredient.MinQuantity <= 0) ingredientStacks.Add(null);
@@ -672,23 +671,11 @@ namespace Vintagestory.GameContent
             {
                 (CookingRecipeIngredient ingredient, List<ItemStack?> validStacks) = valIngStacks.FirstOrDefault(entry => entry.Key.Code == code);
 
-                // We want to fill out all the possible food categories if possible so that
-                // the correct pie type will be displayed. For example, if we're making a
-                // random pot pie, but we end up only adding vegetables, it will show up
-                // as a vegetable pie, which is confusing.
-                HashSet<EnumFoodCategory> allFoodCategories = [];
-                HashSet<EnumFoodCategory> includedFoodCategories = [];
-
                 // Try to fulfill the ingredient request
                 if (ingredient.Code == requestedIngredient?.Code)
                 {
-                    if (validStacks.First(stack => stack?.Collectible.Code == ingredientStack?.Collectible.Code) is { } stack)
+                    if (validStacks.First(stack => stack?.Collectible.Code == ingredientStack?.Collectible.Code) is ItemStack stack)
                     {
-                        if (IngredientFoodCategory(stack) is EnumFoodCategory cat)
-                        {
-                            includedFoodCategories.Add(cat);
-                        }
-
                         pie.Add(stack.Clone());
 
                         ingredient.MinQuantity--;
@@ -698,84 +685,39 @@ namespace Vintagestory.GameContent
                     requestedIngredient = null;
                 }
 
-                // Get all the available categories
-                if (ingredient.Code == "filling")
+                // Only fillings need the code below here for filtering, so we skip the
+                // list copying if possible.
+                if (code != "filling")
                 {
-                    foreach (ItemStack? stack in validStacks)
-                    {
-                        if (IngredientFoodCategory(stack) is EnumFoodCategory cat && cat != EnumFoodCategory.NoNutrition)
-                        {
-                            allFoodCategories.Add(cat);
-                        }
-                    }
+                    pie.Add(validStacks[api.World.Rand.Next(validStacks.Count)]?.Clone());
+                    return;
                 }
 
-                // List that includes only food categories that are not already present
-                List<ItemStack?>? filteredValidStacks = allFoodCategories.Count > 1 ? new(validStacks) : [];
+                // When we add an ingredient, we filter out all the other ingredients
+                // that have any of the same codes that aren't the recipe code.
+                // This ensures we get the widest selection possible
+                // in order to minimize the chance of accidentally getting a pie
+                // that is considered a different category than requested.
+                //
+                // We try to include as many codes as possible to avoid accidentally
+                // getting a more specific type of pie, e.g. we don't want to get all
+                // vegetables when we're trying to generate a pot pie.
 
-
-
-                // For each food category, try to filter out non-matching mixing codes.
-                // If at least one ingredient is left, apply it to the actual ingredient
-                // list. Helps prevent incorrect mixing codes when multiple codes have
-                // the same food categories.
-                List<EnumFoodCategory> mixCodeFilterable = [];
-
-                // [ "mixed", "type-trailing" ]
-                string[] pieMixCode = recipe?.Code?.Split("-", 2) ?? ["single", ""];
-
-                if (pieMixCode[0] == "mixed")
-                {
-                    foreach (EnumFoodCategory cat in allFoodCategories)
-                    {
-                        int noOtherMixingCodesInCategory = filteredValidStacks
-                            .Where(stack =>
-                            {
-                                if (InPieProperties.ReadFrom(stack) is not { } props) return true;
-                                return props.FoodCategory == cat && props.MixingCodes.Except([pieMixCode[1]]).Count() == 0;
-                            })
-                            .Count();
-
-                        if (noOtherMixingCodesInCategory > 0)
-                        {
-                            // We can filter out non-matching mixing codes because we have at least one left for this category.
-                            filteredValidStacks = filteredValidStacks.Where(stack =>
-                            {
-                                if (InPieProperties.ReadFrom(stack) is not { } props) return true;
-                                return props.FoodCategory != cat || props.MixingCodes.Except([pieMixCode[1]]).Count() == 0;
-                            }).ToList();
-                        }
-                    }
-                }
-
-
+                List<ItemStack?> filteredValidStacks = validStacks;
+                string recipeCode = recipe.Code?.Split("-").ElementAtOrDefault(1) ?? "";
                 while (ingredient.MinQuantity > 0)
                 {
-                    // Use the filtered list to fill out the other desired categories, if any remain.
-                    if (ingredient.Code == "filling" && (filteredValidStacks?.Count ?? 0) > 0)
+                    if (filteredValidStacks.Count > 0)
                     {
-                        ItemStack? newIngredient = filteredValidStacks![api.World.Rand.Next(filteredValidStacks!.Count)]?.Clone();
-                        if (IngredientFoodCategory(newIngredient) is EnumFoodCategory newCategory)
-                        {
-                            includedFoodCategories.Add(newCategory);
-
-                            bool filterStackIfCategoryIncluded(ItemStack? stack)
-                            {
-                                if (IngredientFoodCategory(stack) is EnumFoodCategory category)
-                                {
-                                    return includedFoodCategories.Contains(category);
-                                }
-                                else { return false; }
-                            }
-
-                            filteredValidStacks!.RemoveAll(filterStackIfCategoryIncluded);
-                        }
-
-                        pie.Add(newIngredient);
+                        ItemStack? stack = filteredValidStacks[api.World.Rand.Next(filteredValidStacks.Count)]?.Clone();
+                        // Get the list of codes for this ingredient that can be filtered out
+                        string[] ingredientCodes = InPieProperties.ReadFrom(stack)!.MixingCodes.Where(code => code != recipeCode)?.ToArray() ?? [];
+                        // Remove all the other ingredients that share any codes
+                        filteredValidStacks = filteredValidStacks.Where(stack => InPieProperties.ReadFrom(stack)!.MixingCodes.Intersect(ingredientCodes).Count() == 0).ToList();
+                        pie.Add(stack);
                     }
                     else
                     {
-                        // Otherwise, just pull any ingredient.
                         pie.Add(validStacks[api.World.Rand.Next(validStacks.Count)]?.Clone());
                     }
 
@@ -789,7 +731,7 @@ namespace Vintagestory.GameContent
             List<ItemStack?> randomPie = [];
             while (!recipe.Matches([.. randomPie]))
             {
-                var valIngStacks = new Dictionary<CookingRecipeIngredient, List<ItemStack?>>();
+                Dictionary<CookingRecipeIngredient, List<ItemStack?>> valIngStacks = [];
                 foreach (var entry in validStacksByIngredient) valIngStacks.Add(entry.Key.Clone(), [.. entry.Value]);
                 valIngStacks = valIngStacks.OrderBy(x => api.World.Rand.Next()).ToDictionary(item => item.Key, item => item.Value);
 
@@ -801,13 +743,12 @@ namespace Vintagestory.GameContent
                 }
 
                 randomPie = [];
-                addIngredient(ref randomPie, "dough", ref valIngStacks, ref requestedIngredient);
-                addIngredient(ref randomPie, "filling", ref valIngStacks, ref requestedIngredient);
                 addIngredient(ref randomPie, "crust", ref valIngStacks, ref requestedIngredient);
+                addIngredient(ref randomPie, "filling", ref valIngStacks, ref requestedIngredient);
+                addIngredient(ref randomPie, "topping", ref valIngStacks, ref requestedIngredient);
 
                 while (randomPie.Count < 6) randomPie.Add(null);
             }
-
             return [.. randomPie];
         }
 

--- a/Block/BlockPie.cs
+++ b/Block/BlockPie.cs
@@ -91,25 +91,37 @@ namespace Vintagestory.GameContent
                         ActionLangCode = "blockhelp-pie-cut",
                         MouseButton = EnumMouseButton.Right,
                         Itemstacks = knifeStacks,
-                        GetMatchingStacks = (wi, bs, _) => GetBlockEntity<BlockEntityPie>(bs.Position) is { State: not null and not "raw", SlicesLeft: > 1 } ? wi.Itemstacks : null
+                        GetMatchingStacks = (wi, bs, _) => {
+                            if (GetBlockEntity<BlockEntityPie>(bs.Position) is not BlockEntityPie pie) return null;
+                            return pie.State != "raw" && pie.SlicesLeft > 1 ? wi.Itemstacks : null;
+                        }
                     },
                     new() {
                         ActionLangCode = "blockhelp-pie-addfilling",
                         MouseButton = EnumMouseButton.Right,
                         Itemstacks = fillStacks.ToArray(),
-                        GetMatchingStacks = (wi, bs, _) => GetBlockEntity<BlockEntityPie>(bs.Position) is { State: "raw", HasAllFilling: false } ? wi.Itemstacks.Where(stack => GetBlockEntity<BlockEntityPie>(bs.Position).CanAddIngredient(stack)).ToArray() : null
+                        GetMatchingStacks = (wi, bs, _) => {
+                            if (GetBlockEntity<BlockEntityPie>(bs.Position) is not BlockEntityPie pie) return null;
+                            return pie.State == "raw" && !pie.HasAllFilling ? wi.Itemstacks.Where(pie.CanAddIngredient).ToArray() : null;
+                        }
                     },
                     new() {
                         ActionLangCode = "blockhelp-pie-addcrust",
                         MouseButton = EnumMouseButton.Right,
                         Itemstacks = doughStacks.ToArray(),
-                        GetMatchingStacks = (wi, bs, _) => GetBlockEntity<BlockEntityPie>(bs.Position) is { State: "raw", HasAllFilling: true, HasCrust: false } ? wi.Itemstacks : null
+                        GetMatchingStacks = (wi, bs, _) => {
+                            if (GetBlockEntity<BlockEntityPie>(bs.Position) is not BlockEntityPie pie) return null;
+                            return pie.State == "raw" && pie.HasAllFilling && !pie.HasCrust ? wi.Itemstacks : null;
+                        }
                     },
                     new() {
                         ActionLangCode = "blockhelp-pie-changecruststyle",
                         MouseButton = EnumMouseButton.Right,
                         Itemstacks = knifeStacks,
-                        GetMatchingStacks = (wi, bs, _) => GetBlockEntity<BlockEntityPie>(bs.Position) is { State: "raw", HasCrust: true } ? wi.Itemstacks : null
+                        GetMatchingStacks = (wi, bs, _) => {
+                            if (GetBlockEntity<BlockEntityPie>(bs.Position) is not BlockEntityPie pie) return null;
+                            return pie.State == "raw" && pie.HasCrust ? wi.Itemstacks : null;
+                        }
                     }
                 };
             });
@@ -260,25 +272,27 @@ namespace Vintagestory.GameContent
             ItemStack[] cStacks = GetContents(api.World, itemStack);
             if (cStacks.Length <= 1) return Lang.Get("pie-empty");
 
-            ItemStack cstack = cStacks[1];
-            var foodCats = cStacks.Select(FillingFoodCategory).ToArray();
-            EnumFoodCategory foodCat = foodCats[1];
+            ItemStack prevStack = cStacks[1];
+            EnumFoodCategory[] foodCats = cStacks.Select(FillingFoodCategory).ToArray();
+            EnumFoodCategory prevFoodCat = foodCats[1];
 
-            if (cstack == null) return Lang.Get("pie-empty");
+            if (prevStack == null) return Lang.Get("pie-empty");
 
             bool singleIngredient = true;
             bool singleFoodCat = true;
-            IEnumerable<string> mixCodes = InPieProperties.ReadFrom(cstack)?.MixingCodes ?? [];
-            for (int i = 2; (singleIngredient || singleFoodCat || mixCodes.Any()) && i < cStacks.Length - 1; i++)
+            IEnumerable<string> mixCodes = InPieProperties.ReadFrom(prevStack)?.MixingCodes ?? [];
+            for (int i = 2; i < cStacks.Length - 1; i++)
             {
                 if (cStacks[i] == null) continue;
 
-                singleIngredient &= cstack.Equals(api.World, cStacks[i], GlobalConstants.IgnoredStackAttributes);
-                singleFoodCat &= cStacks[i] == null || foodCats[i] == foodCat;
-                mixCodes = InPieProperties.ReadFrom(cstack)?.MixingCodes.Intersect(mixCodes) ?? [];
+                singleIngredient &= prevStack.Equals(api.World, cStacks[i], GlobalConstants.IgnoredStackAttributes);
+                singleFoodCat &= cStacks[i] == null || foodCats[i] == prevFoodCat;
+                mixCodes = InPieProperties.ReadFrom(cStacks[i])?.MixingCodes.Intersect(mixCodes) ?? [];
 
-                cstack = cStacks[i];
-                foodCat = foodCats[i];
+                if (!singleIngredient && !singleFoodCat && !mixCodes.Any()) break;
+
+                prevStack = cStacks[i];
+                prevFoodCat = foodCats[i];
             }
 
             string state = Variant["state"];
@@ -290,7 +304,7 @@ namespace Vintagestory.GameContent
 
             if (singleIngredient)
             {
-                return Lang.Get("pie-single-" + cstack.Collectible.Code.ToShortString() + "-" + state);
+                return Lang.Get("pie-single-" + prevStack.Collectible.Code.ToShortString() + "-" + state);
             }
 
             if (!singleFoodCat && mixCodes.Any())
@@ -357,10 +371,11 @@ namespace Vintagestory.GameContent
 
         public override string GetPlacedBlockInfo(IWorldAccessor world, BlockPos pos, IPlayer forPlayer)
         {
-            if ((world.BlockAccessor.GetBlockEntity(pos) as BlockEntityPie)?.Inventory is not { } bepInv || bepInv.Count < 1 || bepInv[0].Itemstack is not { } pieStack) return "";
+            if ((world.BlockAccessor.GetBlockEntity(pos) as BlockEntityPie)?.Inventory is not InventoryBase bepInv) return "";
+            if (bepInv.Count < 1 || bepInv[0].Itemstack is not ItemStack pieStack) return "";
 
             ItemStack[] stacks = GetContents(api.World, pieStack);
-            StringBuilder sb = new StringBuilder();
+            StringBuilder sb = new();
 
             TransitionableProperties[]? propsm = pieStack.Collectible.GetTransitionableProperties(api.World, pieStack, null);
             if (propsm?.Length > 0)
@@ -397,7 +412,7 @@ namespace Vintagestory.GameContent
             if (slot != null)
             {
                 TransitionState? state = slot.Itemstack?.Collectible.UpdateAndGetTransitionState(api.World, slot, EnumTransitionType.Perish);
-                float spoilState = state != null ? state.TransitionLevel : 0;
+                float spoilState = state?.TransitionLevel ?? 0;
                 satLossMul = GlobalConstants.FoodSpoilageSatLossMul(spoilState, slot.Itemstack, forEntity);
             }
 
@@ -417,7 +432,7 @@ namespace Vintagestory.GameContent
 
         public static ItemStack? TakeSlice(ref ItemStack? stack)
         {
-            if (stack?.Clone() is not { } outStack) return null;
+            if (stack?.Clone() is not ItemStack outStack) return null;
 
             int size = stack.Attributes.GetAsInt("pieSize");
             float servings = stack.Attributes.GetFloat("quantityServings");

--- a/Block/BlockPie.cs
+++ b/Block/BlockPie.cs
@@ -3,31 +3,47 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
+using Vintagestory.API;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Config;
-using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Util;
 
 namespace Vintagestory.GameContent
 {
+    /// <summary>
+    /// A definition for a top crust type, including its code and shape element.
+    /// </summary>
+    /// <example language="json">
+    /// {
+    ///     "code": "full",
+    ///     "shapeElement": "origin/base/top crust full/*"
+    /// }
+    /// </example>
+    [DocumentAsJson]
     public class PieTopCrustType
     {
         public required string Code;
         public required string ShapeElement;
     }
 
-    // Definition: GetContents() must always return a ItemStack[] of array length 6
-    // [0] = crust
-    // [1-4] = filling
-    // [5] = topping (unused atm)
+    /// <summary>
+    /// GetContents() is an ItemStack[6]. Unused slots are represented as null.
+    ///
+    /// [0]: Base dough
+    /// [1-4]: Filling
+    /// [5]: Crust dough or topping
+    /// </summary>
     public class BlockPie : BlockMeal, IBakeableCallback, IShelvable
     {
+        /// <summary>
+        /// The pie's cooking stage; "raw", "partbaked", "perfect", or "charred"
+        /// </summary>
         public string State => Variant["state"];
         protected override bool PlacedBlockEating => false;
 
-        public EnumShelvableLayout? GetShelvableType(ItemStack stack)
+        public static EnumShelvableLayout? GetShelvableType(ItemStack stack)
         {
             return stack.Attributes.GetAsInt("pieSize") switch
             {
@@ -36,7 +52,8 @@ namespace Vintagestory.GameContent
                 _ => EnumShelvableLayout.SingleCenter
             };
         }
-        public ModelTransform? GetOnShelfTransform(ItemStack stack)
+
+        public static ModelTransform? GetOnShelfTransform(ItemStack stack)
         {
             return GetShelvableType(stack) switch
             {
@@ -52,6 +69,26 @@ namespace Vintagestory.GameContent
 
         public static PieTopCrustType[] TopCrustTypes = null!;
 
+        protected static HashSet<string> reportedMissingPieProps = [];
+
+        /// <summary>
+        /// Report that an object in a pie is missing its InPieProperties.
+        /// Use this to prevent repeated error spam.
+        /// </summary>
+        /// <param name="logger">The logger to use.</param>
+        /// <param name="code">The collectible code.</param>
+        /// <returns>true if the element is added to the HashSet object; false if the element is already present.</returns>
+        public static bool ReportMissingPieProps(ILogger logger, string code)
+        {
+            if (!reportedMissingPieProps.Contains(code))
+            {
+                logger.Error($"{code} is already in a pie, but it no longer has inPieProperties. It's still edible, but some things will break.");
+            }
+
+            return reportedMissingPieProps.Add(code);
+        }
+
+
         [MemberNotNull(nameof(ms), nameof(interactions))]
         public override void OnLoaded(ICoreAPI api)
         {
@@ -63,22 +100,53 @@ namespace Vintagestory.GameContent
 
             interactions = ObjectCacheUtil.GetOrCreate(api, "pieInteractions-", () =>
             {
-                var knifeStacks = ObjectCacheUtil.GetToolStacks(api, EnumTool.Knife);
-                List<ItemStack> fillStacks = [];
+                ItemStack[] knifeStacks = ObjectCacheUtil.GetToolStacks(api, EnumTool.Knife);
                 List<ItemStack> doughStacks = [];
+                List<ItemStack> fillStacks = [];
+                List<ItemStack> toppingStacks = [];
 
                 if (fillStacks.Count == 0 && doughStacks.Count == 0)
                 {
-                    foreach (var obj in api.World.Collectibles)
+                    foreach (CollectibleObject obj in api.World.Collectibles)
                     {
-                        if (obj is ItemDough)
+                        if (InPieProperties.ReadFrom(obj, out string? piePropsErr) is not InPieProperties pieProps)
                         {
-                            doughStacks.Add(new ItemStack(obj, 2));
+                            if (piePropsErr != null) api.World.Logger.Error(piePropsErr);
+                            continue;
                         }
 
-                        if (obj.Attributes?["inPieProperties"].AsObject<InPieProperties?>(null, obj.Code.Domain)?.PartType == EnumPiePartType.Filling)
+                        EnumPiePartType partType = pieProps.PartType;
+
+                        if (obj is ItemDough || partType == EnumPiePartType.Crust)
                         {
-                            fillStacks.Add(new ItemStack(obj, 2));
+                            doughStacks.Add(new ItemStack(obj, pieProps.ItemsPerPortion()));
+                        }
+
+                        switch (partType)
+                        {
+                            case EnumPiePartType.Filling:
+                                fillStacks.Add(new ItemStack(obj, pieProps.ItemsPerPortion()));
+                                break;
+                            case EnumPiePartType.Topping:
+                                toppingStacks.Add(new ItemStack(obj, pieProps.ItemsPerPortion()));
+                                break;
+                            case EnumPiePartType.Crust:
+                                toppingStacks.Add(new ItemStack(obj, pieProps.ItemsPerPortion()));
+                                break;
+                        }
+
+                        if (pieProps.PartType == EnumPiePartType.Filling || pieProps.PartType == EnumPiePartType.Topping)
+                        {
+                            int nonFoodCatCodes = pieProps.MixingCodes.Where(code => code != pieProps.FoodCategory.ToString().ToLowerInvariant()).ToArray().Length;
+                            if (nonFoodCatCodes == 0 && pieProps.FoodCategory == EnumFoodCategory.NoNutrition)
+                            {
+                                api.World.Logger.Error($"InPieProperties for filling {obj.Code} has no mixing codes and food category NoNutrition. It cannot be added to pies! See the documentation.");
+                            }
+
+                            if (!pieProps.AllowMixing && nonFoodCatCodes > 0)
+                            {
+                                api.World.Logger.Error($"InPieProperties for filling {obj.Code} has explicit mixingCodes, but allowMixing is disabled. Mixing codes will be ignored. Don't do this intentionally. Allow mixing or remove the mixing codes to suppress this error.");
+                            }
                         }
                     }
                 }
@@ -89,25 +157,37 @@ namespace Vintagestory.GameContent
                         ActionLangCode = "blockhelp-pie-cut",
                         MouseButton = EnumMouseButton.Right,
                         Itemstacks = knifeStacks,
-                        GetMatchingStacks = (wi, bs, _) => GetBlockEntity<BlockEntityPie>(bs.Position) is { State: not null and not "raw", SlicesLeft: > 1 } ? wi.Itemstacks : null
+                        GetMatchingStacks = (wi, bs, _) => {
+                            if (GetBlockEntity<BlockEntityPie>(bs.Position) is not BlockEntityPie pie) return null;
+                            return pie.State != "raw" && pie.SlicesLeft > 1 ? wi.Itemstacks : null;
+                        }
                     },
                     new() {
                         ActionLangCode = "blockhelp-pie-addfilling",
                         MouseButton = EnumMouseButton.Right,
                         Itemstacks = fillStacks.ToArray(),
-                        GetMatchingStacks = (wi, bs, _) => GetBlockEntity<BlockEntityPie>(bs.Position) is { State: "raw", HasAllFilling: false } ? wi.Itemstacks : null
+                        GetMatchingStacks = (wi, bs, _) => {
+                            if (GetBlockEntity<BlockEntityPie>(bs.Position) is not BlockEntityPie pie) return null;
+                            return pie.State == "raw" && !pie.HasAllFilling ? wi.Itemstacks.Where(pie.CanAddIngredient).ToArray() : null;
+                        }
                     },
                     new() {
-                        ActionLangCode = "blockhelp-pie-addcrust",
+                        ActionLangCode = "blockhelp-pie-addcrustortopping",
                         MouseButton = EnumMouseButton.Right,
-                        Itemstacks = doughStacks.ToArray(),
-                        GetMatchingStacks = (wi, bs, _) => GetBlockEntity<BlockEntityPie>(bs.Position) is { State: "raw", HasAllFilling: true, HasCrust: false } ? wi.Itemstacks : null
+                        Itemstacks = toppingStacks.ToArray(),
+                        GetMatchingStacks = (wi, bs, _) => {
+                            if (GetBlockEntity<BlockEntityPie>(bs.Position) is not BlockEntityPie pie) return null;
+                            return pie.State == "raw" && pie.HasAllFilling && pie.ToppingType == null ? wi.Itemstacks.Where(pie.CanAddIngredient).ToArray() : null;
+                        }
                     },
                     new() {
                         ActionLangCode = "blockhelp-pie-changecruststyle",
                         MouseButton = EnumMouseButton.Right,
                         Itemstacks = knifeStacks,
-                        GetMatchingStacks = (wi, bs, _) => GetBlockEntity<BlockEntityPie>(bs.Position) is { State: "raw", HasCrust: true } ? wi.Itemstacks : null
+                        GetMatchingStacks = (wi, bs, _) => {
+                            if (GetBlockEntity<BlockEntityPie>(bs.Position) is not BlockEntityPie pie) return null;
+                            return pie.State == "raw" && pie.ToppingType == EnumPiePartType.Crust ? wi.Itemstacks : null;
+                        }
                     }
                 };
             });
@@ -143,8 +223,6 @@ namespace Vintagestory.GameContent
         {
             return slot.Itemstack?.Attributes?.GetAsInt("pieSize") == 1 && State != "raw";
         }
-
-
 
 
         ModelTransform oneSliceTranformGui = new ModelTransform()
@@ -190,7 +268,7 @@ namespace Vintagestory.GameContent
 
         public override ItemStack OnPickBlock(IWorldAccessor world, BlockPos pos)
         {
-            if ((world.BlockAccessor.GetBlockEntity(pos) as BlockEntityPie)?.Inventory[0].Itemstack is { } pieStack) return pieStack.Clone();
+            if ((world.BlockAccessor.GetBlockEntity(pos) as BlockEntityPie)?.Inventory[0].Itemstack is ItemStack pieStack) return pieStack.Clone();
 
             return base.OnPickBlock(world, pos);
         }
@@ -234,8 +312,9 @@ namespace Vintagestory.GameContent
             IPlayer? byPlayer = (byEntity as EntityPlayer)?.Player;
             ItemSlot? hotbarSlot = byPlayer?.InventoryManager.ActiveHotbarSlot;
 
-            var pieprops = hotbarSlot?.Itemstack?.ItemAttributes["inPieProperties"]?.AsObject<InPieProperties>();
-            if (pieprops?.PartType != EnumPiePartType.Crust) return;
+            if (InPieProperties.ReadFrom(hotbarSlot?.Itemstack) is not InPieProperties pieProps
+                || pieProps?.PartType != EnumPiePartType.Crust
+                || pieProps.IsLiquid) return;
 
             BlockPos abovePos = blockSel.Position.UpCopy();
 
@@ -258,68 +337,64 @@ namespace Vintagestory.GameContent
 
         public override string GetHeldItemName(ItemStack? itemStack)
         {
-            ItemStack[] cStacks = GetContents(api.World, itemStack);
-            if (cStacks.Length <= 1) return Lang.Get("pie-empty");
+            ItemStack?[] cStacks = GetContents(api.World, itemStack);
+            if (cStacks.Length <= 1 || cStacks[1] == null) return Lang.Get("pie-empty");
 
-            ItemStack cstack = cStacks[1];
-            var foodCats = cStacks.Select(FillingFoodCategory).ToArray();
-            EnumFoodCategory foodCat = foodCats[1];
+            // Use null-forgiving in this method in case the pie is malformed,
+            // e.g. an ingredient lost its pie props. Report it because its
+            // a content error.
+            for (int i = 0; i < 6; i++)
+            {
+                if (cStacks[i] != null && InPieProperties.ReadFrom(cStacks[i]) == null)
+                {
+                    ReportMissingPieProps(api.Logger, cStacks[i]!.Collectible.Code);
+                }
+            }
 
-            if (cstack == null) return Lang.Get("pie-empty");
-
-            bool equal = true;
-            bool foodCatEquals = true;
-            IEnumerable<string> mixCodes = cstack.ItemAttributes["inPieProperties"].AsObject<InPieProperties>()?.MixingCodes ?? [];
-            for (int i = 2; (equal || foodCatEquals || mixCodes.Any()) && i < cStacks.Length - 1; i++)
+            bool singleIngredient = true;
+            IEnumerable<string> mixCodes = InPieProperties.ReadFrom(cStacks[1])?.MixingCodes ?? [];
+            for (int i = 2; i < cStacks.Length - 1; i++)
             {
                 if (cStacks[i] == null) continue;
 
-                equal &= cstack.Equals(api.World, cStacks[i], GlobalConstants.IgnoredStackAttributes);
-                foodCatEquals &= cStacks[i] == null || foodCats[i] == foodCat;
-                mixCodes = cstack.ItemAttributes["inPieProperties"].AsObject<InPieProperties>()?.MixingCodes.Intersect(mixCodes) ?? [];
+                singleIngredient &= cStacks[i]?.Equals(api.World, cStacks[1], GlobalConstants.IgnoredStackAttributes) ?? true;
+                mixCodes = InPieProperties.ReadFrom(cStacks[i])?.MixingCodes.Intersect(mixCodes) ?? [];
 
-                cstack = cStacks[i];
-                foodCat = foodCats[i];
+                if (!singleIngredient && !mixCodes.Any()) break;
             }
 
             string state = Variant["state"];
 
-            if (MealMeshCache.ContentsRotten(cStacks))
+            string mixCode = mixCodes.FirstOrDefault() ?? "missing";
+
+            if (!singleIngredient && mixCode == "missing")
             {
-                return Lang.Get("pie-single-rotten");
+                api.Logger.Error($"Pie does not have any valid mixing codes! They were likely removed from one of the ingredients: [\n    {string.Join("\n    ", (object?[])cStacks)}\n]");
             }
 
-            if (equal)
+            string pieName = Lang.Get(singleIngredient
+                ? "pie-single-" + cStacks[1]!.Collectible.Code.ToShortString() + "-" + state
+                : "pie-mixed-" + mixCode + "-" + state);
+
+            if (cStacks[5] != null && InPieProperties.ReadFrom(cStacks[5])?.PartType != EnumPiePartType.Crust)
             {
-                return Lang.Get("pie-single-" + cstack.Collectible.Code.ToShortString() + "-" + state);
+                pieName = Lang.Get("meal-topping-ingredient-format", cStacks[5]?.Collectible.GetHeldItemName(cStacks[5]), pieName.ToLowerInvariant());
             }
 
-            if (!foodCatEquals && mixCodes.Any())
-            {
-                return Lang.Get("pie-mixed-" + mixCodes.First() + "-" +state);
-            }
-
-            return Lang.Get("pie-mixed-" + FillingFoodCategory(cStacks[1]).ToString().ToLowerInvariant() + "-" + state);
+            return pieName;
         }
 
-        public static EnumFoodCategory FillingFoodCategory(ItemStack? stack)
+        /// <summary>
+        /// The food category mixing code for the ingredient when used in a pie.
+        /// This is not the actual food category when consumed.
+        ///
+        /// See InPieProperties.FoodCategory documentation
+        /// </summary>
+        public static EnumFoodCategory IngredientFoodCategory(ItemStack? stack)
         {
-            if (stack == null) return EnumFoodCategory.Vegetable;
-            EnumFoodCategory? category = stack.ItemAttributes["inPieProperties"].AsObject<InPieProperties>()?.FoodCategory;
+            if (InPieProperties.ReadFrom(stack) is InPieProperties pieProps) return pieProps.FoodCategory;
 
-            if (category == null)
-            {
-                var liquidProps = BlockLiquidContainerBase.GetContainableProps(stack);
-                if (liquidProps != null)
-                {
-                    category = liquidProps.NutritionPropsPerLitreWhenInMeal?.FoodCategory
-                            ?? liquidProps.NutritionPropsPerLitre?.FoodCategory;
-                }
-            }
-            category ??= stack.ItemAttributes?["nutritionPropsWhenInMeal"]?.AsObject<FoodNutritionProperties>()?.FoodCategory
-                      ?? stack.Collectible.GetNutritionProperties(null, stack, null)?.FoodCategory;
-
-            return category ?? EnumFoodCategory.Vegetable;
+            return EnumFoodCategory.NoNutrition;
         }
 
 
@@ -329,7 +404,7 @@ namespace Vintagestory.GameContent
 
             int pieSize = pieStack.Attributes.GetAsInt("pieSize");
             float servingsLeft = GetQuantityServings(world, pieStack);
-            if (!pieStack.Attributes.HasAttribute("quantityServings")) servingsLeft = 1;
+            if (pieStack.Attributes?.HasAttribute("quantityServings") == false) servingsLeft = pieStack.Attributes.GetAsInt("pieSize") / 4f;
 
             if (pieSize == 1)
             {
@@ -342,14 +417,14 @@ namespace Vintagestory.GameContent
 
 
             TransitionableProperties[] propsm = pieStack.Collectible.GetTransitionableProperties(api.World, pieStack, null);
-            if (propsm != null && propsm.Length > 0)
+            if (propsm?.Length > 0)
             {
                 pieStack.Collectible.AppendPerishableInfoText(inSlot, dsc, api.World);
             }
 
             ItemStack[] stacks = GetContents(api.World, pieStack);
 
-            var forEntity = (world as IClientWorldAccessor)?.Player?.Entity;
+            EntityPlayer? forEntity = (world as IClientWorldAccessor)?.Player?.Entity;
 
 
             float[] nmul = GetNutritionHealthMul(null, inSlot, forEntity);
@@ -358,13 +433,14 @@ namespace Vintagestory.GameContent
 
         public override string GetPlacedBlockInfo(IWorldAccessor world, BlockPos pos, IPlayer forPlayer)
         {
-            if ((world.BlockAccessor.GetBlockEntity(pos) as BlockEntityPie)?.Inventory is not { } bepInv || bepInv.Count < 1 || bepInv[0].Itemstack is not { } pieStack) return "";
+            if ((world.BlockAccessor.GetBlockEntity(pos) as BlockEntityPie)?.Inventory is not InventoryBase bepInv) return "";
+            if (bepInv.Count < 1 || bepInv[0].Itemstack is not ItemStack pieStack) return "";
 
             ItemStack[] stacks = GetContents(api.World, pieStack);
-            StringBuilder sb = new StringBuilder();
+            StringBuilder sb = new();
 
-            TransitionableProperties[] propsm = pieStack.Collectible.GetTransitionableProperties(api.World, pieStack, null);
-            if (propsm != null && propsm.Length > 0)
+            TransitionableProperties[]? propsm = pieStack.Collectible.GetTransitionableProperties(api.World, pieStack, null);
+            if (propsm?.Length > 0)
             {
                 pieStack.Collectible.AppendPerishableInfoText(bepInv[0], sb, api.World);
             }
@@ -381,62 +457,11 @@ namespace Vintagestory.GameContent
             return str;
         }
 
-        public override TransitionState? UpdateAndGetTransitionState(IWorldAccessor world, ItemSlot inslot, EnumTransitionType type)
-        {
-            ItemStack[] cstacks = GetContents(world, inslot.Itemstack);
-            UnspoilContents(world, cstacks);
-            SetContents(inslot.Itemstack, cstacks);
-
-            return base.UpdateAndGetTransitionState(world, inslot, type);
-        }
-
+        // Skip over the meal transitioning code because only the pie itself spoils, not its contents.
         public override TransitionState[]? UpdateAndGetTransitionStates(IWorldAccessor world, ItemSlot inslot)
         {
-            ItemStack[] cstacks = GetContents(world, inslot.Itemstack);
-            UnspoilContents(world, cstacks);
-            SetContents(inslot.Itemstack, cstacks);
-
-
-            return base.UpdateAndGetTransitionStatesNative(world, inslot);
+            return UpdateAndGetTransitionStatesNative(world, inslot);
         }
-
-
-        public override string GetContentNutritionFacts(IWorldAccessor world, ItemSlot inSlotorFirstSlot, ItemStack[] contentStacks, EntityAgent? forEntity, bool mulWithStacksize = false, float nutritionMul = 1, float healthMul = 1)
-        {
-            UnspoilContents(world, contentStacks);
-
-            return base.GetContentNutritionFacts(world, inSlotorFirstSlot, contentStacks, forEntity, mulWithStacksize, nutritionMul, healthMul);
-        }
-
-
-        protected void UnspoilContents(IWorldAccessor world, ItemStack[] cstacks)
-        {
-            // Dont spoil the pie contents, the pie itself has a spoilage timer. Semi hacky fix reset their spoil timers each update
-
-            for (int i = 0; i < cstacks.Length; i++)
-            {
-                ItemStack cstack = cstacks[i];
-                if (cstack == null) continue;
-
-                if (!(cstack.Attributes["transitionstate"] is ITreeAttribute))
-                {
-                    cstack.Attributes["transitionstate"] = new TreeAttribute();
-                }
-                ITreeAttribute attr = (ITreeAttribute)cstack.Attributes["transitionstate"];
-
-                if (attr.HasAttribute("createdTotalHours"))
-                {
-                    attr.SetDouble("createdTotalHours", world.Calendar.TotalHours);
-                    attr.SetDouble("lastUpdatedTotalHours", world.Calendar.TotalHours);
-                    var transitionedHours = (attr["transitionedHours"] as FloatArrayAttribute)?.value;
-                    for (int j = 0; transitionedHours != null && j < transitionedHours.Length; j++)
-                    {
-                        transitionedHours[j] = 0;
-                    }
-                }
-            }
-        }
-
 
         public override float[] GetNutritionHealthMul(BlockPos? pos, ItemSlot? slot, EntityAgent? forEntity)
         {
@@ -450,7 +475,7 @@ namespace Vintagestory.GameContent
             if (slot != null)
             {
                 TransitionState? state = slot.Itemstack?.Collectible.UpdateAndGetTransitionState(api.World, slot, EnumTransitionType.Perish);
-                float spoilState = state != null ? state.TransitionLevel : 0;
+                float spoilState = state?.TransitionLevel ?? 0;
                 satLossMul = GlobalConstants.FoodSpoilageSatLossMul(spoilState, slot.Itemstack, forEntity);
             }
 
@@ -468,9 +493,16 @@ namespace Vintagestory.GameContent
             //base.OnBlockInteractStop(secondsUsed, world, byPlayer, blockSel);
         }
 
+        /// <summary>
+        /// Take a slice from the pie in the itemstack and set pieSize and quantityServings.
+        /// 
+        /// Once sliced, a pie is no longer bakeable.
+        /// </summary>
+        /// <param name="stack">The pie to take a slice from.</param>
+        /// <returns>The new slice as an ItemStack.</returns>
         public static ItemStack? TakeSlice(ref ItemStack? stack)
         {
-            if (stack?.Clone() is not { } outStack) return null;
+            if (stack?.Clone() is not ItemStack outStack) return null;
 
             int size = stack.Attributes.GetAsInt("pieSize");
             float servings = stack.Attributes.GetFloat("quantityServings");
@@ -514,12 +546,12 @@ namespace Vintagestory.GameContent
 
             if (outputSlot.Itemstack == null) return;
 
-            foreach (var slot in allInputslots)
+            foreach (ItemSlot slot in allInputslots)
             {
                 if (slot.Itemstack?.Collectible is not BlockPie) continue;
 
-                var pieStack = slot.Itemstack.Clone();
-                outputSlot.Itemstack = TakeSlice(ref pieStack);
+                ItemStack pieStack = slot.Itemstack.Clone();
+                outputSlot.Itemstack = TakeSlice(ref pieStack!);
             }
         }
 
@@ -531,7 +563,7 @@ namespace Vintagestory.GameContent
                 return;
             }
 
-            var pieStack = stackInSlot.Itemstack.Clone();
+            ItemStack? pieStack = stackInSlot.Itemstack?.Clone();
             TakeSlice(ref pieStack);
             if (pieStack?.Attributes.GetAsInt("pieSize") == 1)
             {
@@ -563,47 +595,108 @@ namespace Vintagestory.GameContent
 
         public static List<CookingRecipe> GetHandbookRecipes(ICoreAPI api, ItemStack[] allStacks)
         {
-            List<ItemStack> doughs = [];
-            Dictionary<EnumFoodCategory, List<ItemStack>> categoryFillings = [];
-            Dictionary<string, List<ItemStack>> mixedFillings = [];
             List<ItemStack> crusts = [];
             List<ItemStack> noMixFillings = [];
+            Dictionary<string, List<ItemStack>> mixedFillings = [];
+            Dictionary<string, List<ItemStack>> toppingsByCode = [];
 
-            foreach (var stack in allStacks)
+            foreach (ItemStack s in allStacks)
             {
-                var pieProps = stack.ItemAttributes?["inPieProperties"]?.AsObject<InPieProperties>();
+                if (InPieProperties.ReadFrom(s) is not InPieProperties pieProps) continue;
+                ItemStack stack = s.Clone();
 
-                if (pieProps?.PartType == EnumPiePartType.Crust) doughs.Add(stack);
-                if (pieProps is { PartType: EnumPiePartType.Filling, AllowMixing: true })
+                stack.StackSize = pieProps.ItemsPerPortion();
+
+                switch (pieProps.PartType)
                 {
-                    foreach (var code in pieProps.MixingCodes)
-                    {
-                        if (mixedFillings.TryGetValue(code, out var value)) value.Add(stack);
-                        else mixedFillings.Add(code, [stack]);
-                    }
+                    case EnumPiePartType.Crust:
+                        crusts.Add(stack);
 
-                    var cat = FillingFoodCategory(stack);
-                    if (cat is not EnumFoodCategory.NoNutrition and not EnumFoodCategory.Unknown)
-                    {
-                        if (categoryFillings.TryGetValue(cat, out var value)) value.Add(stack);
-                        else categoryFillings.Add(cat, [stack]);
-                    }
+                        break;
+                    case EnumPiePartType.Filling:
+                        if (pieProps.AllowMixing)
+                        {
+                            foreach (string mixCode in pieProps.MixingCodes)
+                            {
+                                if (mixedFillings.TryGetValue(mixCode, out List<ItemStack>? value)) value.Add(stack);
+                                else mixedFillings.Add(mixCode, [stack]);
+                            }
+                        }
+                        else
+                        {
+                            noMixFillings.Add(stack);
+                        }
+                        break;
+                    case EnumPiePartType.Topping:
+                        foreach (string mixCode in pieProps.MixingCodes)
+                        {
+                            if (toppingsByCode.TryGetValue(mixCode, out List<ItemStack>? value)) value.Add(stack);
+                            else toppingsByCode.Add(mixCode, [stack]);
+                        }
+                        break;
                 }
-                if (pieProps is { PartType: EnumPiePartType.Crust, AllowMixing: true }) crusts.Add(stack);
-
-                if (pieProps is { AllowMixing: false, MixingCodes.Length: 0 }) noMixFillings.Add(stack);
             }
 
             return
             [
-                .. categoryFillings.Select(entry => CreateRecipe(api.World, "mixed-" + entry.Key.ToString().ToLowerInvariant(), doughs, [.. entry.Value], crusts)),
-                .. mixedFillings.Select(entry => CreateRecipe(api.World, "mixed-" + entry.Key.ToLowerInvariant(), doughs, [.. entry.Value], crusts)),
-                .. noMixFillings.Select(stack => CreateRecipe(api.World, "single-" + stack.Collectible.Code.ToShortString(), doughs, [stack], crusts))
+                .. mixedFillings.Select(entry =>
+                    {
+                        List<ItemStack> toppings = toppingsByCode
+                            .Where(topping => topping.Key == entry.Key)
+                            .SelectMany(topping => topping.Value)
+                            .ToList();
+
+                        // Crusts apply to all mixing codes, so always add them
+                        toppings.AddRange(crusts);
+
+                        return CreateRecipe(
+                            api.World,
+                            "mixed-" + entry.Key.ToLowerInvariant(),
+                            crusts,
+                            [.. entry.Value],
+                            toppings);
+                    }
+                ),
+                .. noMixFillings.Select(stack =>
+                {
+                    List<ItemStack> toppings = toppingsByCode
+                        .Where(topping => InPieProperties.ReadFrom(stack)!.MixingCodes.Contains(topping.Key))
+                        .SelectMany(topping => topping.Value)
+                        .ToList();
+
+                    // Crusts apply to all mixing codes, so always add them
+                    toppings.AddRange(crusts);
+
+                    return CreateRecipe(
+                        api.World,
+                        "single-" + stack.Collectible.Code.ToShortString(),
+                        crusts,
+                        [stack],
+                        toppings
+                    );
+                })
             ];
         }
 
-        private static CookingRecipe CreateRecipe(IWorldAccessor world, string code, List<ItemStack> doughs, List<ItemStack> fillings, List<ItemStack> crusts, bool mixedRecipe = false)
+        private static CookingRecipe CreateRecipe(IWorldAccessor world, string code, List<ItemStack> crusts, List<ItemStack> fillings, List<ItemStack> toppings, bool mixedRecipe = false)
         {
+            // See SurvivalHandbook.CreateCachedMealRecipeStacks
+            static CookingRecipeStack getCookingStack(ItemStack stack)
+            {
+                InPieProperties pieProps = InPieProperties.ReadFrom(stack)!;
+                float itemsPerLitre = pieProps.ItemsPerLitre;
+                float portionSizeLitres = pieProps.PortionSizeLitres;
+
+                return new()
+                {
+                    Code = stack.Collectible.Code,
+                    Type = stack.Collectible.ItemClass,
+                    StackSize = (int)Math.Ceiling(stack.StackSize * itemsPerLitre * portionSizeLitres),
+                    ResolvedItemStack = stack.Clone()
+                };
+            }
+
+
             return new()
             {
                 Code = code,
@@ -615,13 +708,8 @@ namespace Vintagestory.GameContent
                         TypeName = "bottomcrust",
                         MinQuantity = 1,
                         MaxQuantity = 1,
-                        ValidStacks = [.. doughs.Select<ItemStack, CookingRecipeStack>(dough => new ()
-                        {
-                            Code = dough.Collectible.Code,
-                            Type = dough.Collectible.ItemClass,
-                            Quantity = 2,
-                            ResolvedItemstack = dough.Clone()
-                        })]
+                        PortionSizeLitres = 0.01f,
+                        ValidStacks = [.. crusts.Select(getCookingStack)]
                     },
                     new ()
                     {
@@ -629,13 +717,8 @@ namespace Vintagestory.GameContent
                         TypeName = "piefilling",
                         MinQuantity = 4,
                         MaxQuantity = 4,
-                        ValidStacks = [.. fillings.Select<ItemStack, CookingRecipeStack>(filling => new ()
-                        {
-                            Code = filling.Collectible.Code,
-                            Type = filling.Collectible.ItemClass,
-                            Quantity = 2,
-                            ResolvedItemstack = filling.Clone()
-                        })]
+                        PortionSizeLitres = 0.01f,
+                        ValidStacks = [.. fillings.Select(getCookingStack)]
                     },
                     new ()
                     {
@@ -643,47 +726,43 @@ namespace Vintagestory.GameContent
                         TypeName = "topcrust",
                         MinQuantity = 0,
                         MaxQuantity = 1,
-                        ValidStacks = [.. crusts.Select<ItemStack, CookingRecipeStack>(crust => new ()
-                        {
-                            Code = crust.Collectible.Code,
-                            Type = crust.Collectible.ItemClass,
-                            Quantity = 2,
-                            ResolvedItemstack = crust.Clone()
-                        })]
+                        PortionSizeLitres = 0.01f,
+                        ValidStacks = [.. toppings.Select(getCookingStack)]
                     }
                 ],
                 PerishableProps = new()
             };
         }
 
+        // NOTE: This method can return an array of 6 nulls if there is a coding error, so check it before using SetContents to avoid accidentally removing contents entirely.
         public static ItemStack?[] GenerateRandomPie(ICoreAPI api, ref Dictionary<CookingRecipeIngredient, HashSet<ItemStack?>>? cachedValidStacksByIngredient, CookingRecipe recipe, ItemStack? ingredientStack = null)
         {
             if (recipe.Ingredients == null) return new ItemStack?[6];
 
-            var validStacksByIngredient = cachedValidStacksByIngredient;
+            Dictionary<CookingRecipeIngredient, HashSet<ItemStack?>>? validStacksByIngredient = cachedValidStacksByIngredient;
 
             if (validStacksByIngredient == null)
             {
                 validStacksByIngredient = [];
 
-                foreach (var ingredient in recipe.Ingredients)
+                foreach (CookingRecipeIngredient? ingredient in recipe.Ingredients)
                 {
                     HashSet<ItemStack?> ingredientStacks = [];
 
                     ingredient.Resolve(api.World, "handbook meal recipes");
-                    foreach (var astack in ingredient.ValidStacks.Select(stack => stack.ResolvedItemstack))
+                    foreach (ItemStack? stack in ingredient.ValidStacks.Select(stack => stack.ResolvedItemstack))
                     {
-                        if (ingredient.GetMatchingStack(astack) is not { } vstack) continue;
+                        if (ingredient.GetMatchingStack(stack) is not CookingRecipeStack recipeStack) continue;
 
-                        ItemStack stack = astack.Clone();
-                        stack.StackSize = vstack.StackSize;
-
-                        if (BlockLiquidContainerBase.GetContainableProps(stack) is { } props)
+                        if (stack != null && BlockLiquidContainerBase.GetContainableProps(stack) is WaterTightContainableProps props)
                         {
-                            stack.StackSize *= (int)(props.ItemsPerLitre * ingredient.PortionSizeLitres);
+                            stack.StackSize = recipeStack.StackSize * (int)(props.ItemsPerLitre * ingredient.PortionSizeLitres);
+                            ingredientStacks.Add(stack);
                         }
-
-                        ingredientStacks.Add(stack);
+                        else
+                        {
+                            ingredientStacks.Add(null);
+                        }
                     }
 
                     if (ingredient.MinQuantity <= 0) ingredientStacks.Add(null);
@@ -692,106 +771,97 @@ namespace Vintagestory.GameContent
                 }
 
                 cachedValidStacksByIngredient = validStacksByIngredient;
-            };
-
-            if (validStacksByIngredient == null) return new ItemStack?[6];
-
-            List<ItemStack?> randomMeal = [];
-
-            while (!recipe.Matches(randomMeal.ToArray()))
-            {
-                var valIngStacks = new Dictionary<CookingRecipeIngredient, List<ItemStack?>>();
-                foreach (var entry in validStacksByIngredient) valIngStacks.Add(entry.Key.Clone(), entry.Value.ToList());
-                valIngStacks = valIngStacks.OrderBy(x => api.World.Rand.Next()).ToDictionary(item => item.Key, item => item.Value);
-
-                CookingRecipeIngredient? requestedIngredient = null;
-                if (ingredientStack != null)
-                {
-                    var validIngredients = recipe.Ingredients.Where(ingredient => ingredient.Matches(ingredientStack)).ToList();
-                    requestedIngredient = validIngredients[api.World.Rand.Next(validIngredients.Count)].Clone();
-                }
-
-                randomMeal = [];
-
-                var ingredient = valIngStacks.FirstOrDefault(entry => entry.Key.Code == "dough").Key;
-                var validStacks = valIngStacks.FirstOrDefault(entry => entry.Key.Code == "dough").Value;
-
-                if (ingredient.Code == requestedIngredient?.Code)
-                {
-                    if (validStacks.First(stack => stack?.Collectible.Code == ingredientStack?.Collectible.Code) is { } stack)
-                    {
-                        randomMeal.Add(stack.Clone());
-
-                        ingredient.MinQuantity--;
-                        ingredient.MaxQuantity--;
-                    }
-                    requestedIngredient = null;
-                }
-
-                while (ingredient.MinQuantity > 0)
-                {
-                    randomMeal.Add(validStacks[api.World.Rand.Next(validStacks.Count)]?.Clone());
-
-                    ingredient.MinQuantity--;
-                    ingredient.MaxQuantity--;
-                }
-
-                ingredient = valIngStacks.FirstOrDefault(entry => entry.Key.Code == "filling").Key;
-                validStacks = valIngStacks.FirstOrDefault(entry => entry.Key.Code == "filling").Value;
-
-                if (ingredient.Code == requestedIngredient?.Code)
-                {
-                    if (validStacks.First(stack => stack?.Collectible.Code == ingredientStack?.Collectible.Code) is { } stack)
-                    {
-                        randomMeal.Add(stack.Clone());
-
-                        ingredient.MinQuantity--;
-                        ingredient.MaxQuantity--;
-                    }
-                    requestedIngredient = null;
-                }
-
-                while (ingredient.MinQuantity > 0)
-                {
-                    randomMeal.Add(validStacks[api.World.Rand.Next(validStacks.Count)]?.Clone());
-
-                    ingredient.MinQuantity--;
-                    ingredient.MaxQuantity--;
-                }
-
-                ingredient = valIngStacks.FirstOrDefault(entry => entry.Key.Code == "crust").Key;
-                validStacks = valIngStacks.FirstOrDefault(entry => entry.Key.Code == "crust").Value;
-
-                if (requestedIngredient != null)
-                {
-                    if (ingredient.Code == requestedIngredient?.Code)
-                    {
-                        if (validStacks.First(stack => stack?.Collectible.Code == ingredientStack?.Collectible.Code) is { } stack)
-                        {
-                            randomMeal.Add(stack.Clone());
-                            ingredient.MaxQuantity--;
-
-                            requestedIngredient = null;
-                        }
-                    }
-                }
-                else if (ingredient.MaxQuantity > 0)
-                {
-                    var stack = validStacks[api.World.Rand.Next(validStacks.Count)];
-
-                    if (stack != null)
-                    {
-                        randomMeal.Add(stack.Clone());
-                        ingredient.MaxQuantity--;
-                    }
-                }
-
-                while (randomMeal.Count < 6) randomMeal.Add(null);
             }
 
-            return randomMeal.ToArray();
+
+            void addIngredient(ref List<ItemStack?> pie, string code, ref Dictionary<CookingRecipeIngredient, List<ItemStack?>> valIngStacks, ref CookingRecipeIngredient? requestedIngredient)
+            {
+                (CookingRecipeIngredient ingredient, List<ItemStack?> validStacks) = valIngStacks.FirstOrDefault(entry => entry.Key.Code == code);
+
+                // Try to fulfill the ingredient request
+                if (ingredient.Code == requestedIngredient?.Code)
+                {
+                    if (validStacks.First(stack => stack?.Collectible.Code == ingredientStack?.Collectible.Code) is ItemStack stack)
+                    {
+                        pie.Add(stack.Clone());
+
+                        ingredient.MinQuantity--;
+                        ingredient.MaxQuantity--;
+                    }
+
+                    requestedIngredient = null;
+
+                    // Without this, we could add a requested dough/topping and
+                    // then another, which breaks the pie.
+                    if (ingredient.MaxQuantity <= 0) return;
+                }
+
+                // Only fillings need the code below here for filtering, so we skip the
+                // list copying for crusts and toppings.
+                if (code != "filling")
+                {
+                    pie.Add(validStacks.ElementAtOrDefault(api.World.Rand.Next(validStacks.Count))?.Clone());
+                    return;
+                }
+
+                List<ItemStack?> filteredValidStacks = validStacks;
+                string recipeCode = recipe.Code?.Split("-").ElementAtOrDefault(1) ?? "";
+                while (ingredient.MinQuantity > 0)
+                {
+                    if (filteredValidStacks.Count > 0)
+                    {
+                        ItemStack? stack = filteredValidStacks[api.World.Rand.Next(filteredValidStacks.Count)]?.Clone();
+                        // Get the list of codes for this ingredient that can be filtered out
+                        string[] ingredientCodes = InPieProperties.ReadFrom(stack)!.MixingCodes.Where(code => code != recipeCode)?.ToArray() ?? [];
+                        // Remove all the other ingredients that share any codes
+                        filteredValidStacks = filteredValidStacks.Where(stack => InPieProperties.ReadFrom(stack)!.MixingCodes.Intersect(ingredientCodes).Count() == 0).ToList();
+                        pie.Add(stack);
+                    }
+                    else
+                    {
+                        pie.Add(validStacks[api.World.Rand.Next(validStacks.Count)]?.Clone());
+                    }
+
+                    ingredient.MinQuantity--;
+                    ingredient.MaxQuantity--;
+                }
+            }
+
+            Dictionary<CookingRecipeIngredient, List<ItemStack?>> valIngStacks = [];
+            foreach (var entry in validStacksByIngredient) valIngStacks.Add(entry.Key.Clone(), [.. entry.Value]);
+            valIngStacks = valIngStacks.OrderBy(x => api.World.Rand.Next()).ToDictionary(item => item.Key, item => item.Value);
+            CookingRecipeIngredient? requestedIngredient = null;
+            if (ingredientStack != null)
+            {
+                List<CookingRecipeIngredient> validIngredients = [.. recipe.Ingredients.Where(ingredient => ingredient.Matches(ingredientStack))];
+                requestedIngredient = validIngredients[api.World.Rand.Next(validIngredients.Count)].Clone();
+            }
+
+            List<ItemStack?> randomPie = [];
+            addIngredient(ref randomPie, "dough", ref valIngStacks, ref requestedIngredient);
+            addIngredient(ref randomPie, "filling", ref valIngStacks, ref requestedIngredient);
+            addIngredient(ref randomPie, "crust", ref valIngStacks, ref requestedIngredient);
+
+            if (randomPie.Count != 6)
+            {
+                api.Logger.Error($"Random pie [ {string.Join(", ", randomPie)} ] has a length that is not 6. Making it completely empty to prevent worse issues. This is a coding error, so please report it.");
+                return [null, null, null, null, null, null];
+            }
+
+            if (!recipe.Matches([.. randomPie]))
+            {
+                api.Logger.Error($"Random pie [ {string.Join(", ", randomPie)} ] is invalid or does not match recipe {recipe.Code}. Making it completely empty to prevent worse issues. This is a coding error, so please report it.");
+                return [null, null, null, null, null, null];
+            }
+
+            return [.. randomPie];
         }
 
+        /// <summary>
+        /// Cycle the crust type to the next index. Don't use with toppings - they should always be full.
+        /// </summary>
+        /// <param name="pieStack"></param>
+        /// <returns></returns>
         [return: NotNullIfNotNull(nameof(pieStack))]
         public static ItemStack? CycleTopCrustType(ItemStack? pieStack)
         {
@@ -833,19 +903,37 @@ namespace Vintagestory.GameContent
 
         public override string HandbookPageCodeForStack(IWorldAccessor world, ItemStack stack)
         {
-            string? type = null;
+            ItemStack[] cStacks = GetContents(api.World, stack);
+            if (cStacks.Length <= 1 || cStacks[1] == null) return "craftinginfo-pie";
 
-            if (GetContents(world, stack) is ItemStack[] contents && contents.Length > 1)
+            // Use null-forgiving in this method in case the pie is malformed,
+            // e.g. an ingredient lost its pie props. Report it because its
+            // a content error.
+            for (int i = 0; i < 6; i++)
             {
-                if (contents[1]?.ItemAttributes?["inPieProperties"]?.AsObject<InPieProperties>()?.AllowMixing == false)
+                if (cStacks[i] != null && InPieProperties.ReadFrom(cStacks[i]) == null)
                 {
-                    type = "single-" + contents[1].Collectible.Code.ToShortString();
+                    ReportMissingPieProps(api.Logger, cStacks[i].Collectible.Code);
                 }
-                else type = "mixed-" + FillingFoodCategory(contents[1]).ToString().ToLowerInvariant();
-
-                return "handbook-mealrecipe-" + type + "-pie";
             }
-            else return "craftinginfo-pie";
+
+            bool singleIngredient = true;
+            IEnumerable<string> mixCodes = InPieProperties.ReadFrom(cStacks[1])?.MixingCodes ?? [];
+            for (int i = 2; i < cStacks.Length - 1; i++)
+            {
+                if (cStacks[i] == null) continue;
+
+                singleIngredient &= cStacks[i].Equals(api.World, cStacks[1], GlobalConstants.IgnoredStackAttributes);
+                mixCodes = InPieProperties.ReadFrom(cStacks[i])?.MixingCodes.Intersect(mixCodes) ?? [];
+
+                if (!singleIngredient && !mixCodes.Any()) break;
+            }
+
+            string pieType = singleIngredient
+                ? "single-" + cStacks[1].Collectible.Code.ToShortString()
+                : "mixed-" + mixCodes.FirstOrDefault("unknown").ToLowerInvariant();
+
+            return $"handbook-mealrecipe-{pieType}-pie";
         }
     }
 }

--- a/BlockBehavior/BlockBehaviorPieFormingSurface.cs
+++ b/BlockBehavior/BlockBehaviorPieFormingSurface.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Vintagestory.API.Client;
+using Vintagestory.API.Common;
+using Vintagestory.API.MathTools;
+using Vintagestory.API.Util;
+
+namespace Vintagestory.GameContent
+{
+    public class PieFormingSurfaceBackwardsCompatSystem : ModSystem
+    {
+        public override void AssetsFinalize(ICoreAPI api)
+        {
+            foreach (Block block in api.World.Blocks)
+            {
+                // Allow the legacy attribute to apply this behavior
+                if (block.Attributes?.IsTrue("pieFormingSurface") == true && !block.BlockBehaviors.Contains(bh => bh is BlockBehaviorPieFormingSurface))
+                {
+                    block.BlockBehaviors.Append(new BlockBehaviorPieFormingSurface(block));
+                    block.CollectibleBehaviors.Append(new BlockBehaviorPieFormingSurface(block));
+                }
+            }
+
+            base.AssetsFinalize(api);
+        }
+    }
+
+    /// <summary>
+    /// Specifies that this block works as a pie forming surface. Does not have any properties.
+    /// </summary>
+    /// <example><code lang="json">
+    ///"behaviors": [
+	///	{ "name": "PieFormingSurface" }
+	///]
+    /// </code></example>
+    public class BlockBehaviorPieFormingSurface(Block block) : BlockBehavior(block)
+    {
+        static WorldInteraction[] interactions = null!;
+
+        ICoreAPI api = null!;
+
+        public override void OnLoaded(ICoreAPI api)
+        {
+            base.OnLoaded(api);
+
+            this.api = api;
+
+            block.InteractionHelpYOffset += 0.25f;
+
+            if (api.Side != EnumAppSide.Client || interactions != null) return;
+
+            List<ItemStack> doughStacks = [];
+
+            foreach (CollectibleObject obj in api.World.Collectibles)
+            {
+                if (InPieProperties.ReadFrom(obj) is not InPieProperties pieProps) continue;
+
+                if (pieProps.PartType == EnumPiePartType.Crust)
+                {
+                    doughStacks.Add(new ItemStack(obj, pieProps.PortionSize));
+                }
+            }
+
+            interactions = [
+                new()
+                {
+                    ActionLangCode = "heldhelp-makepie",
+                    Itemstacks = [.. doughStacks],
+                    HotKeyCode = "shift",
+                    MouseButton = EnumMouseButton.Right,
+                }
+            ];
+        }
+
+        public override WorldInteraction[] GetPlacedBlockInteractionHelp(IWorldAccessor world, BlockSelection selection, IPlayer forPlayer, ref EnumHandling handling)
+        {
+            WorldInteraction[] wi = base.GetPlacedBlockInteractionHelp(world, selection, forPlayer, ref handling);
+
+            BlockPos abovePos = selection.Position.UpCopy();
+
+            Block placeBlock = world.BlockAccessor.GetBlock(abovePos);
+            if (placeBlock.Replaceable >= 6000)
+            {
+                return wi.Append(interactions);
+            }
+
+            return wi;
+        }
+
+        public override bool OnBlockInteractStart(IWorldAccessor world, IPlayer byPlayer, BlockSelection blockSel, ref EnumHandling handling)
+        {
+            if (blockSel != null && byPlayer.Entity.Controls.ShiftKey)
+            {
+                if (StackCanPlacePie(byPlayer.InventoryManager.ActiveHotbarSlot.Itemstack))
+                {
+                    (api.World.GetBlock(new AssetLocation("pie-raw")) as BlockPie)?.TryPlacePie(byPlayer.Entity, blockSel);
+                    handling = EnumHandling.PreventDefault;
+                    return true;
+                }
+
+                return false;
+            }
+
+            return base.OnBlockInteractStart(world, byPlayer, blockSel, ref handling);
+        }
+
+        public static bool StackCanPlacePie(ItemStack? stack)
+        {
+            if (stack == null)
+            {
+                return false;
+            }
+
+            if (stack.Collectible.GetCollectibleInterface<ILiquidSource>() != null)
+            {
+                return false;
+            }
+
+            if (InPieProperties.ReadFrom(stack) is not InPieProperties pieProps)
+            {
+                return false;
+            }
+
+            float totalPortions = stack.StackSize / pieProps.ItemsPerPortion();
+            if (totalPortions < 1)
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/BlockEntity/BEPie.cs
+++ b/BlockEntity/BEPie.cs
@@ -177,6 +177,7 @@ namespace Vintagestory.GameContent
                 {
                     if (Api.Side == EnumAppSide.Server && TakeSlice() is { } slicestack)
                     {
+                        hotbarSlot.Itemstack.Collectible.DamageItem(byPlayer.Entity.World, byPlayer.Entity, hotbarSlot);
                         if (!byPlayer.InventoryManager.TryGiveItemstack(slicestack))
                         {
                             Api.World.SpawnItemEntity(slicestack, Pos);

--- a/BlockEntity/BEPie.cs
+++ b/BlockEntity/BEPie.cs
@@ -262,16 +262,15 @@ namespace Vintagestory.GameContent
 
         public bool CanAddIngredient(ItemStack stack)
         {
-            int dummy1 = 0;
-            string? dummy2 = null;
-            string? dummy3 = null;
-            return CanAddIngredient(stack, ref dummy1, ref dummy2, ref dummy3);
+            return CanAddIngredient(stack, out _, out _, out _);
         }
 
-        public bool CanAddIngredient(ItemStack stack, ref int emptySlotIndex, ref string? errCode, ref string? errMessage)
+        public bool CanAddIngredient(ItemStack stack, out int emptySlotIndex, out string? errCode, out string? errMessage)
         {
             InPieProperties pieProps = stack.ItemAttributes?["inPieProperties"]?.AsObject<InPieProperties?>(null, stack.Collectible.Code.Domain);
 
+            errCode = null;
+            errMessage = null;
             emptySlotIndex = -1;
 
             if (pieProps == null)
@@ -372,7 +371,7 @@ namespace Vintagestory.GameContent
             int emptySlotIndex = -1;
             string? errCode = null;
             string? errMessage = null;
-            if (!CanAddIngredient(slot.Itemstack, ref emptySlotIndex, ref errCode, ref errMessage))
+            if (!CanAddIngredient(slot.Itemstack, out emptySlotIndex, out errCode, out errMessage))
             {
                 capi?.TriggerIngameError(this, errCode, errMessage);
                 return false;

--- a/BlockEntity/BEPie.cs
+++ b/BlockEntity/BEPie.cs
@@ -235,6 +235,11 @@ namespace Vintagestory.GameContent
                 inv[0].Itemstack?.Attributes.SetFloat("quantityServings", 0.25f);
             }
 
+            if (byPlayer.Entity.Controls.ShiftKey)
+            {
+                return false;
+            }
+
             if (Api.Side == EnumAppSide.Server)
             {
                 if (!byPlayer.InventoryManager.TryGiveItemstack(inv[0].Itemstack))

--- a/BlockEntity/BEPie.cs
+++ b/BlockEntity/BEPie.cs
@@ -7,6 +7,8 @@ using Vintagestory.API.Common;
 using Vintagestory.API.Config;
 using Vintagestory.API.Datastructures;
 
+#nullable enable
+
 namespace Vintagestory.GameContent
 {
     public enum EnumPiePartType
@@ -170,8 +172,7 @@ namespace Vintagestory.GameContent
 
             ItemSlot? hotbarSlot = byPlayer.InventoryManager.ActiveHotbarSlot;
 
-            EnumTool? tool = hotbarSlot?.Itemstack?.Collectible.GetTool(hotbarSlot);
-            if (tool is EnumTool.Knife or EnumTool.Sword)
+            if (hotbarSlot?.Itemstack?.Collectible.GetTool(hotbarSlot) is { } tool && tool is EnumTool.Knife or EnumTool.Sword)
             {
                 if (pieBlock.State != "raw")
                 {
@@ -214,7 +215,7 @@ namespace Vintagestory.GameContent
             // If the pie can be picked up into the current hotbar slot,
             // skip trying to add the held stack as filling. Prevents
             // the cannot be added to pies" error message.
-            bool canPickUpIntoHand = hotbarSlot?.Empty == false && inv[0].Itemstack.Collectible.GetMergableQuantity(hotbarSlot.Itemstack, inv[0].Itemstack, EnumMergePriority.DirectMerge) > 0;
+            bool canPickUpIntoHand = hotbarSlot?.Empty == false && inv[0].Itemstack?.Collectible.GetMergableQuantity(hotbarSlot.Itemstack, inv[0].Itemstack, EnumMergePriority.DirectMerge) > 0;
 
             if (hotbarSlot?.Empty == false && !canPickUpIntoHand && pieBlock.State == "raw")
             {
@@ -260,20 +261,18 @@ namespace Vintagestory.GameContent
             return true;
         }
 
-        public bool CanAddIngredient(ItemStack stack)
+        public bool CanAddIngredient(ItemStack? stack)
         {
             return CanAddIngredient(stack, out _, out _, out _);
         }
 
-        public bool CanAddIngredient(ItemStack stack, out int emptySlotIndex, out string? errCode, out string? errMessage)
+        public bool CanAddIngredient(ItemStack? stack, out int emptySlotIndex, out string? errCode, out string? errMessage)
         {
-            InPieProperties pieProps = stack.ItemAttributes?["inPieProperties"]?.AsObject<InPieProperties?>(null, stack.Collectible.Code.Domain);
-
             errCode = null;
             errMessage = null;
             emptySlotIndex = -1;
 
-            if (pieProps == null)
+            if (stack?.ItemAttributes["inPieProperties"].AsObject<InPieProperties>(null, stack.Collectible.Code.Domain) is not { } pieProps)
             {
                 errCode = "notpieable";
                 errMessage = Lang.Get("This item can not be added to pies");
@@ -368,23 +367,22 @@ namespace Vintagestory.GameContent
         private bool TryAddIngredientFrom(ItemSlot slot, IPlayer? byPlayer = null)
         {
             ICoreClientAPI? capi = byPlayer != null ? Api as ICoreClientAPI : null;
-            int emptySlotIndex = -1;
-            string? errCode = null;
-            string? errMessage = null;
-            if (!CanAddIngredient(slot.Itemstack, out emptySlotIndex, out errCode, out errMessage))
+
+            if (inv[0].Itemstack?.Block is not BlockPie pieBlock) return false;
+
+            if (!CanAddIngredient(slot.Itemstack, out int emptySlotIndex, out string? errCode, out string? errMessage))
             {
                 capi?.TriggerIngameError(this, errCode, errMessage);
                 return false;
             }
 
-            BlockPie pieBlock = inv[0].Itemstack.Block as BlockPie;
-            ItemStack?[] cStacks = pieBlock.GetContents(Api.World, inv[0].Itemstack);
+            ItemStack[] cStacks = pieBlock.GetContents(Api.World, inv[0].Itemstack);
             if (emptySlotIndex == 5)
             {
                 if (cStacks[5] == null)
                 {
                     // Crust attribute must exist to stack together
-                    inv[0].Itemstack.Attributes.SetString("topCrustType", "full");
+                    inv[0].Itemstack?.Attributes.SetString("topCrustType", "full");
                 }
                 else
                 {

--- a/BlockEntity/BEPie.cs
+++ b/BlockEntity/BEPie.cs
@@ -260,19 +260,31 @@ namespace Vintagestory.GameContent
             return true;
         }
 
-        private bool TryAddIngredientFrom(ItemSlot slot, IPlayer? byPlayer = null)
+        public bool CanAddIngredient(ItemStack stack)
         {
-            ICoreClientAPI? capi = byPlayer != null ? Api as ICoreClientAPI : null;
-            var pieProps = slot.Itemstack?.ItemAttributes?["inPieProperties"]?.AsObject<InPieProperties?>(null, slot.Itemstack.Collectible.Code.Domain);
+            int dummy1 = 0;
+            string? dummy2 = null;
+            string? dummy3 = null;
+            return CanAddIngredient(stack, ref dummy1, ref dummy2, ref dummy3);
+        }
+
+        public bool CanAddIngredient(ItemStack stack, ref int emptySlotIndex, ref string? errCode, ref string? errMessage)
+        {
+            InPieProperties pieProps = stack.ItemAttributes?["inPieProperties"]?.AsObject<InPieProperties?>(null, stack.Collectible.Code.Domain);
+
+            emptySlotIndex = -1;
+
             if (pieProps == null)
             {
-                capi?.TriggerIngameError(this, "notpieable", Lang.Get("This item can not be added to pies"));
+                errCode = "notpieable";
+                errMessage = Lang.Get("This item can not be added to pies");
                 return false;
             }
 
-            if (slot.StackSize < 2)
+            if (stack.StackSize < 2)
             {
-                capi?.TriggerIngameError(this, "notpieable", Lang.Get("Need at least 2 items each"));
+                errCode = "notpieable";
+                errMessage = Lang.Get("Need at least 2 items each");
                 return false;
             }
 
@@ -280,49 +292,38 @@ namespace Vintagestory.GameContent
 
             ItemStack?[] cStacks = pieBlock.GetContents(Api.World, inv[0].Itemstack);
 
-            bool isFull = cStacks[1] != null && cStacks[2] != null && cStacks[3] != null && cStacks[4] != null;
-            bool hasFilling = cStacks[1] != null || cStacks[2] != null || cStacks[3] != null || cStacks[4] != null;
-
-            if (isFull)
+            if (HasAllFilling)
             {
                 if (pieProps.PartType == EnumPiePartType.Crust)
                 {
-                    if (cStacks[5] == null)
-                    {
-                        cStacks[5] = slot.TakeOut(2);
-                        pieBlock.SetContents(inv[0].Itemstack, cStacks);
-                        // crust attribute must exist to stack together
-                        inv[0].Itemstack.Attributes.SetString("topCrustType", "full");
-                    }
-                    else
-                    {
-                        inv[0].Itemstack = BlockPie.CycleTopCrustType(inv[0].Itemstack);
-                    }
+                    emptySlotIndex = 5;
                     return true;
                 }
-                capi?.TriggerIngameError(this, "piefullfilling", Lang.Get("Can't add more filling - already completely filled pie"));
-                return false;
+                else
+                {
+                    errCode = "piefullfilling";
+                    errMessage = Lang.Get("Can't add more filling - already completely filled pie");
+                    return false;
+                }
             }
 
             if (pieProps.PartType != EnumPiePartType.Filling)
             {
-                capi?.TriggerIngameError(this, "pieneedsfilling", Lang.Get("Need to add a filling next"));
+                errCode = "pieneedsfilling";
+                errMessage = Lang.Get("Need to add a filling next");
                 return false;
             }
 
-
-            if (!hasFilling)
+            if (!HasAnyFilling)
             {
-                cStacks[1] = slot.TakeOut(2);
-                pieBlock.SetContents(inv[0].Itemstack, cStacks);
+                emptySlotIndex = 1;
                 return true;
             }
 
             var foodCats = cStacks.Select(BlockPie.FillingFoodCategory).ToArray();
             var stackprops = cStacks.Select(stack => stack?.ItemAttributes?["inPieProperties"]?.AsObject<InPieProperties?>(null, stack.Collectible.Code.Domain)).ToArray();
 
-            ItemStack? cstack = slot.Itemstack;
-            EnumFoodCategory foodCat = BlockPie.FillingFoodCategory(cstack);
+            EnumFoodCategory foodCat = BlockPie.FillingFoodCategory(stack);
 
             bool equal = true;
             bool foodCatEquals = true;
@@ -331,43 +332,71 @@ namespace Vintagestory.GameContent
 
             for (int i = 1; (equal || foodCatEquals || mixCodes.Any()) && i < cStacks.Length - 1; i++)
             {
-                if (cstack == null) continue;
+                if (stack == null) continue;
 
-                equal &= cStacks[i] == null || cstack.Equals(Api.World, cStacks[i], GlobalConstants.IgnoredStackAttributes);
+                equal &= cStacks[i] == null || stack.Equals(Api.World, cStacks[i], GlobalConstants.IgnoredStackAttributes);
                 foodCatEquals &= cStacks[i] == null || foodCats[i] == foodCat;
                 allowMixing &= stackprops[i]?.AllowMixing != false;
                 mixCodes = stackprops[i]?.MixingCodes.Intersect(mixCodes) ?? mixCodes;
 
-                cstack = cStacks[i];
+                stack = cStacks[i];
                 foodCat = foodCats[i];
             }
 
-            int emptySlotIndex = 2 + (cStacks[2] != null ? 1 + (cStacks[3] != null ? 1 : 0) : 0);
+            emptySlotIndex = 2 + (cStacks[2] != null ? 1 + (cStacks[3] != null ? 1 : 0) : 0);
 
             if (equal)
             {
-                cStacks[emptySlotIndex] = slot.TakeOut(2);
-                pieBlock.SetContents(inv[0].Itemstack, cStacks);
                 return true;
             }
 
             if (!foodCatEquals && !mixCodes.Any())
             {
-                capi?.TriggerIngameError(this, "piefullfilling", Lang.Get("piemaking-unabletomixingredient"));
+                errCode = "piefullfilling";
+                errMessage = Lang.Get("piemaking-unabletomixingredient");
                 return false;
             }
-            else
+            else if (!allowMixing)
             {
-                if (!allowMixing)
-                {
-                    capi?.TriggerIngameError(this, "piefullfilling", Lang.Get("piemaking-mixingnotallowed"));
-                    return false;
-                }
-
-                cStacks[emptySlotIndex] = slot.TakeOut(2);
-                pieBlock.SetContents(inv[0].Itemstack, cStacks);
-                return true;
+                errCode = "piefullfilling";
+                errMessage = Lang.Get("piemaking-mixingnotallowed");
+                return false;
             }
+
+            return true;
+        }
+
+        private bool TryAddIngredientFrom(ItemSlot slot, IPlayer? byPlayer = null)
+        {
+            ICoreClientAPI? capi = byPlayer != null ? Api as ICoreClientAPI : null;
+            int emptySlotIndex = -1;
+            string? errCode = null;
+            string? errMessage = null;
+            if (!CanAddIngredient(slot.Itemstack, ref emptySlotIndex, ref errCode, ref errMessage))
+            {
+                capi?.TriggerIngameError(this, errCode, errMessage);
+                return false;
+            }
+
+            BlockPie pieBlock = inv[0].Itemstack.Block as BlockPie;
+            ItemStack?[] cStacks = pieBlock.GetContents(Api.World, inv[0].Itemstack);
+            if (emptySlotIndex == 5)
+            {
+                if (cStacks[5] == null)
+                {
+                    // Crust attribute must exist to stack together
+                    inv[0].Itemstack.Attributes.SetString("topCrustType", "full");
+                }
+                else
+                {
+                    inv[0].Itemstack = BlockPie.CycleTopCrustType(inv[0].Itemstack);
+                    return true;
+                }
+            }
+            cStacks[emptySlotIndex] = slot.TakeOut(2);
+            pieBlock.SetContents(inv[0].Itemstack, cStacks);
+
+            return true;
         }
 
         public override bool OnTesselation(ITerrainMeshPool mesher, ITesselatorAPI tessThreadTesselator)

--- a/BlockEntity/BEPie.cs
+++ b/BlockEntity/BEPie.cs
@@ -188,7 +188,8 @@ namespace Vintagestory.GameContent
                         );
                     }
 
-                } else
+                }
+                else
                 {
                     // Cycle top crust type
                     ItemStack?[] cStacks = pieBlock.GetContents(Api.World, inv[0].Itemstack);
@@ -250,17 +251,17 @@ namespace Vintagestory.GameContent
 
         private bool TryAddIngredientFrom(ItemSlot slot, IPlayer? byPlayer = null)
         {
-            var capi = Api as ICoreClientAPI;
+            ICoreClientAPI? capi = byPlayer != null ? Api as ICoreClientAPI : null;
             var pieProps = slot.Itemstack?.ItemAttributes?["inPieProperties"]?.AsObject<InPieProperties?>(null, slot.Itemstack.Collectible.Code.Domain);
             if (pieProps == null)
             {
-                if (byPlayer != null && capi != null) capi.TriggerIngameError(this, "notpieable", Lang.Get("This item can not be added to pies"));
+                capi?.TriggerIngameError(this, "notpieable", Lang.Get("This item can not be added to pies"));
                 return false;
             }
 
             if (slot.StackSize < 2)
             {
-                if (byPlayer != null && capi != null) capi.TriggerIngameError(this, "notpieable", Lang.Get("Need at least 2 items each"));
+                capi?.TriggerIngameError(this, "notpieable", Lang.Get("Need at least 2 items each"));
                 return false;
             }
 
@@ -281,16 +282,20 @@ namespace Vintagestory.GameContent
                         pieBlock.SetContents(inv[0].Itemstack, cStacks);
                         // crust attribute must exist to stack together
                         inv[0].Itemstack.Attributes.SetString("topCrustType", "full");
-                    } else inv[0].Itemstack = BlockPie.CycleTopCrustType(inv[0].Itemstack);
+                    }
+                    else
+                    {
+                        inv[0].Itemstack = BlockPie.CycleTopCrustType(inv[0].Itemstack);
+                    }
                     return true;
                 }
-                if (byPlayer != null && capi != null) capi.TriggerIngameError(this, "piefullfilling", Lang.Get("Can't add more filling - already completely filled pie"));
+                capi?.TriggerIngameError(this, "piefullfilling", Lang.Get("Can't add more filling - already completely filled pie"));
                 return false;
             }
 
             if (pieProps.PartType != EnumPiePartType.Filling)
             {
-                if (byPlayer != null && capi != null) capi.TriggerIngameError(this, "pieneedsfilling", Lang.Get("Need to add a filling next"));
+                capi?.TriggerIngameError(this, "pieneedsfilling", Lang.Get("Need to add a filling next"));
                 return false;
             }
 
@@ -337,13 +342,14 @@ namespace Vintagestory.GameContent
 
             if (!foodCatEquals && !mixCodes.Any())
             {
-                if (byPlayer != null && capi != null) capi.TriggerIngameError(this, "piefullfilling", Lang.Get("piemaking-unabletomixingredient"));
+                capi?.TriggerIngameError(this, "piefullfilling", Lang.Get("piemaking-unabletomixingredient"));
                 return false;
-            } else
+            }
+            else
             {
                 if (!allowMixing)
                 {
-                    if (byPlayer != null && capi != null) capi.TriggerIngameError(this, "piefullfilling", Lang.Get("piemaking-mixingnotallowed"));
+                    capi?.TriggerIngameError(this, "piefullfilling", Lang.Get("piemaking-mixingnotallowed"));
                     return false;
                 }
 

--- a/BlockEntity/BEPie.cs
+++ b/BlockEntity/BEPie.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -210,7 +210,12 @@ namespace Vintagestory.GameContent
             //    a.) be of same foodcat
             //    b.) have props.AllowMixing set to true
 
-            if (hotbarSlot?.Empty == false && pieBlock.State == "raw")
+            // If the pie can be picked up into the current hotbar slot,
+            // skip trying to add the held stack as filling. Prevents
+            // the cannot be added to pies" error message.
+            bool canPickUpIntoHand = hotbarSlot?.Empty == false && inv[0].Itemstack.Collectible.GetMergableQuantity(hotbarSlot.Itemstack, inv[0].Itemstack, EnumMergePriority.DirectMerge) > 0;
+
+            if (hotbarSlot?.Empty == false && !canPickUpIntoHand && pieBlock.State == "raw")
             {
                 bool added = TryAddIngredientFrom(hotbarSlot, byPlayer);
                 if (added)

--- a/BlockEntity/BEPie.cs
+++ b/BlockEntity/BEPie.cs
@@ -182,11 +182,11 @@ namespace Vintagestory.GameContent
 
             ItemSlot? hotbarSlot = byPlayer.InventoryManager.ActiveHotbarSlot;
 
-            if (hotbarSlot?.Itemstack?.Collectible.GetTool(hotbarSlot) is { } tool && tool is EnumTool.Knife or EnumTool.Sword)
+            if (hotbarSlot?.Itemstack?.Collectible.GetTool(hotbarSlot) is EnumTool tool && (tool is EnumTool.Knife || tool is EnumTool.Sword))
             {
                 if (pieBlock.State != "raw")
                 {
-                    if (Api.Side == EnumAppSide.Server && TakeSlice() is { } slicestack)
+                    if (Api.Side == EnumAppSide.Server && TakeSlice() is ItemStack slicestack)
                     {
                         hotbarSlot.Itemstack.Collectible.DamageItem(byPlayer.Entity.World, byPlayer.Entity, hotbarSlot);
                         if (!byPlayer.InventoryManager.TryGiveItemstack(slicestack))
@@ -276,13 +276,13 @@ namespace Vintagestory.GameContent
             return CanAddIngredient(stack, out _, out _, out _);
         }
 
-        public bool CanAddIngredient(ItemStack? stack, out int emptySlotIndex, out string? errCode, out string? errMessage)
+        public bool CanAddIngredient(ItemStack? prevStack, out int emptySlotIndex, out string? errCode, out string? errMessage)
         {
             errCode = null;
             errMessage = null;
             emptySlotIndex = -1;
 
-            if (InPieProperties.ReadFrom(stack) is not InPieProperties pieProps)
+            if (InPieProperties.ReadFrom(prevStack) is not InPieProperties pieProps)
             {
                 errCode = "notpieable";
                 errMessage = Lang.Get("This item can not be added to pies");
@@ -290,7 +290,7 @@ namespace Vintagestory.GameContent
             }
 
             // Not null if pieProps exists
-            if (stack!.StackSize < 2)
+            if (prevStack!.StackSize < 2)
             {
                 errCode = "notenoughingredients";
                 errMessage = Lang.Get("Need at least 2 items each");
@@ -329,37 +329,39 @@ namespace Vintagestory.GameContent
                 return true;
             }
 
-            var foodCats = cStacks.Select(BlockPie.FillingFoodCategory).ToArray();
-            var stackprops = cStacks.Select(InPieProperties.ReadFrom).ToArray();
+            EnumFoodCategory[] foodCats = cStacks.Select(BlockPie.FillingFoodCategory).ToArray();
+            InPieProperties?[] stackprops = cStacks.Select(InPieProperties.ReadFrom).ToArray();
 
-            EnumFoodCategory foodCat = BlockPie.FillingFoodCategory(stack);
+            EnumFoodCategory prevFoodCat = BlockPie.FillingFoodCategory(prevStack);
 
-            bool equal = true;
-            bool foodCatEquals = true;
+            bool singleIngredient = true;
+            bool singleFoodCat = true;
             bool allowMixing = true;
             IEnumerable<string> mixCodes = pieProps.MixingCodes;
 
-            for (int i = 1; (equal || foodCatEquals || mixCodes.Any()) && i < cStacks.Length - 1; i++)
+            for (int i = 1; (singleIngredient || singleFoodCat || mixCodes.Any()) && i < cStacks.Length - 1; i++)
             {
-                if (stack == null) continue;
+                if (prevStack == null) continue;
 
-                equal &= cStacks[i] == null || stack.Equals(Api.World, cStacks[i], GlobalConstants.IgnoredStackAttributes);
-                foodCatEquals &= cStacks[i] == null || foodCats[i] == foodCat;
-                allowMixing &= stackprops[i]?.AllowMixing != false;
+                singleIngredient &= cStacks[i] == null || prevStack.Equals(Api.World, cStacks[i], GlobalConstants.IgnoredStackAttributes);
+                singleFoodCat &= cStacks[i] == null || foodCats[i] == prevFoodCat;
+                allowMixing &= stackprops[i]?.AllowMixing == true;
                 mixCodes = stackprops[i]?.MixingCodes.Intersect(mixCodes) ?? mixCodes;
 
-                stack = cStacks[i];
-                foodCat = foodCats[i];
+                if (!singleIngredient && !singleFoodCat && !mixCodes.Any()) break;
+
+                prevStack = cStacks[i];
+                prevFoodCat = foodCats[i];
             }
 
             emptySlotIndex = 2 + (cStacks[2] != null ? 1 + (cStacks[3] != null ? 1 : 0) : 0);
 
-            if (equal)
+            if (singleIngredient)
             {
                 return true;
             }
 
-            if (!foodCatEquals && !mixCodes.Any())
+            if (!singleFoodCat && !mixCodes.Any())
             {
                 errCode = "piemismatchedmix";
                 errMessage = Lang.Get("piemaking-unabletomixingredient");

--- a/BlockEntity/BEPie.cs
+++ b/BlockEntity/BEPie.cs
@@ -292,7 +292,7 @@ namespace Vintagestory.GameContent
             // Not null if pieProps exists
             if (stack!.StackSize < 2)
             {
-                errCode = "notpieable";
+                errCode = "notenoughingredients";
                 errMessage = Lang.Get("Need at least 2 items each");
                 return false;
             }
@@ -361,13 +361,13 @@ namespace Vintagestory.GameContent
 
             if (!foodCatEquals && !mixCodes.Any())
             {
-                errCode = "piefullfilling";
+                errCode = "piemismatchedmix";
                 errMessage = Lang.Get("piemaking-unabletomixingredient");
                 return false;
             }
             else if (!allowMixing)
             {
-                errCode = "piefullfilling";
+                errCode = "pienonmixable";
                 errMessage = Lang.Get("piemaking-mixingnotallowed");
                 return false;
             }

--- a/BlockEntity/BEPie.cs
+++ b/BlockEntity/BEPie.cs
@@ -11,8 +11,6 @@ using System;
 using Vintagestory.API.Util;
 using Vintagestory.API;
 
-#nullable enable
-
 namespace Vintagestory.GameContent
 {
     public enum EnumPiePartType

--- a/BlockEntity/BEPie.cs
+++ b/BlockEntity/BEPie.cs
@@ -73,7 +73,7 @@ namespace Vintagestory.GameContent
         /// to determine which category mixing code to prepend in the case
         /// that the code is not already present.
         ///
-        /// A pie of the NoNutrition category cannot be added to pies unless
+        /// An ingredient of the NoNutrition category cannot be added to pies unless
         /// there is an explicit matching mixing code. A NoNutrition ingredient
         /// with no mixing codes is an error.
         /// <br/><br/>

--- a/BlockEntity/BEPie.cs
+++ b/BlockEntity/BEPie.cs
@@ -38,10 +38,12 @@ namespace Vintagestory.GameContent
 
         /// <summary>
         /// Is this filling allowed to mix with other ingredients?
-        /// Crusts and toppings ignore this.
+        /// Crusts and toppings ignore this, but toppings always
+        /// require a matching mixing code.
         /// <br/><br/>
         /// If false, MixingCodes has no effect because this ingredient
-        /// cannot be combined with anything else. Don't do this.
+        /// cannot be combined with anything else. Don't add mixing codes
+        /// if this is disabled.
         /// </summary>
         [DocumentAsJson("Optional")]
         public bool AllowMixing = true;
@@ -68,7 +70,8 @@ namespace Vintagestory.GameContent
         /// <summary>
         /// The food category of the ingredient when used in a pie. This does
         /// not affect the actual nutrition when consumed. It is only used
-        /// to determine which category mixing code to add.
+        /// to determine which category mixing code to prepend in the case
+        /// that the code is not already present.
         ///
         /// A pie of the NoNutrition category cannot be added to pies unless
         /// there is an explicit matching mixing code. A NoNutrition ingredient
@@ -113,6 +116,11 @@ namespace Vintagestory.GameContent
         /// a "mushroom" mixing code that would take precedence over "vegetable".
         /// <br/>
         /// [ "mushroom", "vegetable", "potpie" ]
+        /// <br/><br/>
+        /// An ingredient may have multiple food category mixing codes. It will be
+        /// allowed in any of those mixed pies and will not affect mixing codes.
+        /// If it is the only ingredient, its first mixing code will determine the
+        /// pie type.
         /// <br/><br/>
         /// If MixingCodes is empty, the food category code will always be added.
         /// It is an error for MixingCodes to be empty with NoNutrition.
@@ -236,7 +244,7 @@ namespace Vintagestory.GameContent
             inv = new InventoryGeneric(1, null, null);
         }
 
-        [MemberNotNull(nameof(ms), nameof(mesh))]
+        [MemberNotNull(nameof(ms))]
         public override void Initialize(ICoreAPI api)
         {
             base.Initialize(api);
@@ -342,6 +350,7 @@ namespace Vintagestory.GameContent
                         );
                     }
 
+                    MarkDirty(true);
                 }
                 else if (ToppingType == EnumPiePartType.Crust)
                 {
@@ -357,8 +366,8 @@ namespace Vintagestory.GameContent
             }
 
             // Filling rules:
-            // 1. get inPieProperties
-            // 2. any filing there yet? if not, all good
+            // 1. Get inPieProperties
+            // 2. Any filing there yet? If not, all good
             // 3. Is full: Can't add more.
             // 3. If partially full, must
             //    a.) be of same foodcat
@@ -366,7 +375,7 @@ namespace Vintagestory.GameContent
 
             // If the pie can be picked up into the current hotbar slot,
             // skip trying to add the held stack as filling. Prevents
-            // the cannot be added to pies" error message.
+            // the "cannot be added to pies" error message.
             bool canPickUpIntoHand = hotbarSlot?.Empty == false && inv[0].Itemstack?.Collectible.GetMergableQuantity(hotbarSlot.Itemstack, inv[0].Itemstack, EnumMergePriority.DirectMerge) > 0;
 
             if (hotbarSlot?.Empty == false && !canPickUpIntoHand && pieBlock.State == "raw")
@@ -608,7 +617,7 @@ namespace Vintagestory.GameContent
         void loadMesh()
         {
             if (Api == null || Api.Side == EnumAppSide.Server || inv[0].Empty) return;
-            mesh = ms.GetPieMesh(inv[0].Itemstack);
+            mesh = ms!.GetPieMesh(inv[0].Itemstack)!;
         }
 
         public override void GetBlockInfo(IPlayer forPlayer, StringBuilder dsc)

--- a/BlockEntity/BEPie.cs
+++ b/BlockEntity/BEPie.cs
@@ -34,7 +34,7 @@ namespace Vintagestory.GameContent
         /// shape of the entire pie, including the topping.
         /// </summary>
         [DocumentAsJson("Optional")]
-        public Shape? ToppingShape = null;
+        public string? ToppingShapeElement = null;
 
         /// <summary>
         /// Is this filling allowed to mix with other ingredients?

--- a/BlockEntity/BEPie.cs
+++ b/BlockEntity/BEPie.cs
@@ -22,8 +22,10 @@ namespace Vintagestory.GameContent
     /// Defines the type of ingredient (crust, filling, topping), food
     /// category, and what mixing codes it can be used with, if any.
     /// </summary>
+    [DocumentAsJson]
     public class InPieProperties
     {
+        [DocumentAsJson("Required")]
         public required AssetLocation Texture;
 
         /// <summary>
@@ -33,6 +35,7 @@ namespace Vintagestory.GameContent
         /// If false, MixingCodes has no effect because this ingredient
         /// cannot be combined with anything else.
         /// </summary>
+        [DocumentAsJson("Optional")]
         public bool AllowMixing = true;
 
         /// <summary>
@@ -51,6 +54,7 @@ namespace Vintagestory.GameContent
         ///   restricted by mixing codes. Any crust may be used in place
         ///   of a topping without being restricted by mixing codes.
         /// </summary>
+        [DocumentAsJson("Required")]
         public EnumPiePartType PartType;
 
         /// <summary>
@@ -79,6 +83,7 @@ namespace Vintagestory.GameContent
         /// Note that the field default is never used when created by ReadFrom, which
         /// has its own default value.
         /// </summary>
+        [DocumentAsJson("Optional")]
         public EnumFoodCategory FoodCategory = EnumFoodCategory.Unknown;
 
         /// <summary>
@@ -102,6 +107,7 @@ namespace Vintagestory.GameContent
         /// To disable the food category code entirely, see UseFoodCategoryMixingCode.
         /// If MixingCodes is empty, the food category code will always be added.
         /// </summary>
+        [DocumentAsJson("Optional")]
         public string[] MixingCodes = [];
 
         /// <summary>
@@ -113,6 +119,7 @@ namespace Vintagestory.GameContent
         /// <br/><br/>
         /// If MixingCodes is empty, the food category code will always be added.
         /// </summary>
+        [DocumentAsJson("Optional")]
         public bool UseFoodCategoryMixingCode = true;
 
         /// <summary>

--- a/BlockEntity/BEPie.cs
+++ b/BlockEntity/BEPie.cs
@@ -25,6 +25,16 @@ namespace Vintagestory.GameContent
         public required AssetLocation Texture;
         public EnumFoodCategory? FoodCategory;
         public string[] MixingCodes = [];
+
+        public static InPieProperties? ReadFrom(CollectibleObject? obj)
+        {
+            return obj?.Attributes?["inPieProperties"]?.AsObject<InPieProperties?>(null, obj.Code.Domain);
+        }
+
+        public static InPieProperties? ReadFrom(ItemStack? stack)
+        {
+            return ReadFrom(stack?.Collectible);
+        }
     }
 
     // Idea:
@@ -272,14 +282,15 @@ namespace Vintagestory.GameContent
             errMessage = null;
             emptySlotIndex = -1;
 
-            if (stack?.ItemAttributes["inPieProperties"].AsObject<InPieProperties>(null, stack.Collectible.Code.Domain) is not { } pieProps)
+            if (InPieProperties.ReadFrom(stack) is not InPieProperties pieProps)
             {
                 errCode = "notpieable";
                 errMessage = Lang.Get("This item can not be added to pies");
                 return false;
             }
 
-            if (stack.StackSize < 2)
+            // Not null if pieProps exists
+            if (stack!.StackSize < 2)
             {
                 errCode = "notpieable";
                 errMessage = Lang.Get("Need at least 2 items each");
@@ -319,7 +330,7 @@ namespace Vintagestory.GameContent
             }
 
             var foodCats = cStacks.Select(BlockPie.FillingFoodCategory).ToArray();
-            var stackprops = cStacks.Select(stack => stack?.ItemAttributes?["inPieProperties"]?.AsObject<InPieProperties?>(null, stack.Collectible.Code.Domain)).ToArray();
+            var stackprops = cStacks.Select(InPieProperties.ReadFrom).ToArray();
 
             EnumFoodCategory foodCat = BlockPie.FillingFoodCategory(stack);
 

--- a/BlockEntity/BEPie.cs
+++ b/BlockEntity/BEPie.cs
@@ -315,6 +315,33 @@ namespace Vintagestory.GameContent
 
             ItemStack pie = new(Block);
             (pie.Block as BlockPie)?.SetContents(pie, [doughStack, null, null, null, null, null]);
+
+            // Copy over the transition states so that we don't make a completely fresh pie from spoiling dough
+            if (doughStack.Collectible.UpdateAndGetTransitionStates(byPlayer?.Entity.World, new DummySlot(doughStack)) is TransitionState[] doughStates
+                && pie.Collectible.UpdateAndGetTransitionStates(byPlayer?.Entity.World, new DummySlot(pie)) is TransitionState[] pieStates)
+            {
+
+                for (int i = 0; i < doughStates.Length; i++)
+                {
+                    if (doughStates[i].TransitionLevel > 0)
+                    {
+                        float scaledHours = pieStates[i].FreshHours + pieStates[i].TransitionHours * doughStates[i].TransitionLevel;
+
+                        if (Api.Side.IsServer()) Api.Logger.Debug($"Scaled spoiling dough lifetime to pie; {pieStates[i].FreshHours} + {pieStates[i].TransitionHours} * {doughStates[i].TransitionLevel}");
+
+                        pie.Collectible.SetTransitionState(pie, doughStates[i].Props.Type, scaledHours);
+                    }
+                    else
+                    {
+                        float scaledHours = doughStates[i].TransitionedHours / (pieStates[i].TransitionHours / doughStates[i].TransitionHours);
+
+                        if (Api.Side.IsServer()) Api.Logger.Debug($"Scaled fresh dough lifetime to pie; {doughStates[i].TransitionedHours} / ({pieStates[i].TransitionHours} / {doughStates[i].TransitionHours}) = {scaledHours}");
+
+                        pie.Collectible.SetTransitionState(pie, doughStates[i].Props.Type, scaledHours);
+                    }
+                }
+            }
+
             pie.Attributes.SetInt("pieSize", 4);
             pie.Attributes.SetBool("bakeable", false);
             if (State != "raw" && !pie.Attributes.HasAttribute("quantityServings"))
@@ -567,15 +594,13 @@ namespace Vintagestory.GameContent
         {
             ICoreClientAPI? capi = byPlayer != null ? Api as ICoreClientAPI : null;
 
-            if (inv[0].Itemstack?.Block is not BlockPie pieBlock) return false;
+            if (PieBlock == null) return false;
 
             if (!CanAddIngredient(slot.Itemstack, out int? emptySlotIndex, out string? errCode, out string? errMessage))
             {
                 capi?.TriggerIngameError(this, errCode, errMessage);
                 return false;
             }
-
-            ItemStack[] cStacks = pieBlock.GetContents(Api.World, inv[0].Itemstack);
 
             if (InPieProperties.ReadFrom(slot.Itemstack)!.PartType == EnumPiePartType.Crust)
             {
@@ -593,16 +618,41 @@ namespace Vintagestory.GameContent
                 }
             }
 
+            ItemStack ingStack;
+
             if (byPlayer?.WorldData.CurrentGameMode == EnumGameMode.Creative)
             {
-                cStacks[(int)emptySlotIndex!] = slot.Itemstack!.Clone();
-                cStacks[(int)emptySlotIndex].StackSize = 2;
+                ingStack = slot.Itemstack!.Clone();
+                ingStack.StackSize = 2;
             }
             else
             {
-                cStacks[(int)emptySlotIndex!] = slot.TakeOut(2);
+                ingStack = slot.TakeOut(2);
             }
-            pieBlock.SetContents(inv[0].Itemstack, cStacks);
+
+            ItemStack[] cStacks = PieBlock.GetContents(Api.World, inv[0].Itemstack);
+            int ingredientCount = cStacks.Where(stack => stack != null).Count();
+
+            // Average transition states before adding
+            float t = (float)1 / (1 + ingredientCount);
+            if (byPlayer?.Entity.World != null
+                && ingStack.Collectible.UpdateAndGetTransitionStates(byPlayer.Entity.World, new DummySlot(ingStack)) is TransitionState[] ingStates
+                && PieBlock.UpdateAndGetTransitionStates(byPlayer.Entity.World, inv[0]) is TransitionState[] pieStates)
+            {
+                for (int i = 0; i < ingStates.Length; i++)
+                {
+                    float totalIngHours = ingStates[i].FreshHours + ingStates[i].TransitionHours;
+                    float totalPieHours = pieStates[i].FreshHours + pieStates[i].TransitionHours;
+                    float scaledIngTransitionedHours = ingStates[i].TransitionedHours / (totalIngHours / totalPieHours);
+
+                    var avgTransitionedHours = scaledIngTransitionedHours * t + pieStates[i].TransitionedHours * (1 - t);
+                    if (Api.Side.IsServer()) Api.Logger.Debug($"Averaged new ingredient: {ingStates[i].TransitionedHours / (totalIngHours / totalPieHours)} * {t} + {pieStates[i].TransitionedHours} * {1 - t}");
+                    PieBlock.SetTransitionState(inv[0].Itemstack, ingStates[i].Props.Type, avgTransitionedHours);
+                }
+            }
+
+            cStacks[(int)emptySlotIndex!] = ingStack;
+            PieBlock.SetContents(inv[0].Itemstack, cStacks);
 
             return true;
         }

--- a/BlockEntity/BEPie.cs
+++ b/BlockEntity/BEPie.cs
@@ -7,6 +7,10 @@ using Vintagestory.API.Common;
 using Vintagestory.API.Config;
 using Vintagestory.API.Datastructures;
 
+using System;
+using Vintagestory.API.Util;
+using Vintagestory.API;
+
 #nullable enable
 
 namespace Vintagestory.GameContent
@@ -16,84 +20,160 @@ namespace Vintagestory.GameContent
         Crust, Filling, Topping
     }
 
+    /// <summary>
+    /// Defines the type of ingredient (crust, filling, topping), food
+    /// category, and what mixing codes it can be used with, if any.
+    /// </summary>
     public class InPieProperties
     {
+        public required AssetLocation Texture;
+
         /// <summary>
-        /// Is this ingredient allowed to mix with other ingredients?
-        ///
-        /// If false, MixingCodes has no effect.
+        /// Is this filling allowed to mix with other ingredients?
+        /// Crusts and toppings ignore this.
+        /// <br/><br/>
+        /// If false, MixingCodes has no effect because this ingredient
+        /// cannot be combined with anything else.
         /// </summary>
         public bool AllowMixing = true;
 
         /// <summary>
         /// Is this a crust, filling, or topping?
+        /// <br/><br/>
+        /// * Crust is used as the pie's base. The ingredient used to
+        ///   create a pie must be a crust. Crust can also be used
+        ///   as a topping and is not restricted by mixing codes.
+        /// <br/>
+        /// * Filling is what's inside the pie. AllowMixing determines
+        ///   if it can only be used for single-ingredient pies. If it
+        ///   can be mixed, other ingredients must have a matching
+        ///   mixing code.
+        /// <br/>
+        /// * Topping is the pie's last layer. Like filling, it is
+        ///   restricted by mixing codes. Any crust may be used in place
+        ///   of a topping without being restricted by mixing codes.
         /// </summary>
         public EnumPiePartType PartType;
 
-        public required AssetLocation Texture;
-
         /// <summary>
         /// The food category of the ingredient when used in a pie.
-        ///
+        /// <br/><br/>
         /// Checks in order, stopping once a value is found:
+        /// <br/><br/>
         ///   1. If stack is null, default to vegetable
+        /// <br/>
         ///   2. InPieProperties.FoodCategory
+        /// <br/>
         ///   3. If stack has ContainableProps:
+        /// <br/>
         ///     3a. NutritionPropsPerLitreWhenInMeal.FoodCategory
+        /// <br/>
         ///     3b. NutritionPropsPerLitre.FoodCategory
+        /// <br/>
         ///   4. If stack has NutritionProps:
+        /// <br/>
         ///     4a. NutritionPropsWhenInMeal.FoodCategory
+        /// <br/>
         ///     4b. NutritionProps.FoodCategory
+        /// <br/>
         ///   5. Default to vegetable
-        ///
-        /// Note that the field default isn't actually used because we
-        /// null-coalesce from our checks in ReadFrom, so if you want to
-        /// change it, you need to do it there.
+        /// <br/><br/>
+        /// Note that the field default is never used when created by ReadFrom, which
+        /// has its own default value.
         /// </summary>
-        public EnumFoodCategory FoodCategory = EnumFoodCategory.Vegetable;
+        public EnumFoodCategory FoodCategory = EnumFoodCategory.Unknown;
 
         /// <summary>
-        /// A list of mixing codes that are allowed for this ingredient.
+        /// A list of mixing codes that are allowed for this ingredient. When
+        /// checking for mixing codes, the first mixing code present in all
+        /// ingredients is used for the pie type.
+        /// <br/><br/>
+        /// If UseFoodCategoryMixingCode is true and the ingredient does
+        /// not already include the code for its food category, it will
+        /// be prepended to the front. This means that by default, mixing codes
+        /// are of a lower priority than the food category:
+        /// <br/>
+        /// [ "potpie" ] -> [ "vegetable", "potpie" ]
+        /// <br/><br/>
+        /// By including the food category in the list of mixing codes, other codes
+        /// can be given a higher priority. For example, the following would create
+        /// a "mushroom" mixing code that would take precedence over "vegetable".
+        /// <br/>
+        /// [ "mushroom", "vegetable", "potpie" ]
+        /// <br/><br/>
+        /// To disable the food category code entirely, see UseFoodCategoryMixingCode.
+        /// If MixingCodes is empty, the food category code will always be added.
         /// </summary>
         public string[] MixingCodes = [];
 
+        /// <summary>
+        /// If disabled, prevents the food category tag from being added if it isn't
+        /// present. The ingredient will not be usable in generic pies for its food
+        /// category, instead only being usable with its specific mixing codes.
+        /// 
+        /// If not present in the pie properties, tries to use the object's nutritionPropsWhenInMeal.
+        /// <br/><br/>
+        /// If MixingCodes is empty, the food category code will always be added.
+        /// </summary>
+        public bool UseFoodCategoryMixingCode = true;
+
+        /// <summary>
+        /// Read pie properties from Attributes
+        /// </summary>
+        /// <returns>Null if "inPieProperties" is malformed or does not exist.</returns>
         public static InPieProperties? ReadFrom(CollectibleObject? obj)
         {
             if (obj?.Attributes?["inPieProperties"]?.AsObject<InPieProperties>(null, obj.Code.Domain) is not InPieProperties props) return null;
 
-            // This will always override the default for FoodCategory.
+            // Get the food category manually. It doesn't need to be present in the pie properties,
+            // but making the field nullable is unnecessary after parsing.
+            if (props.FoodCategory == EnumFoodCategory.Unknown)
             {
                 EnumFoodCategory? foodCat = null;
 
                 if (BlockLiquidContainerBase.GetContainableProps(obj) is WaterTightContainableProps liquidProps)
                 {
-                    foodCat = liquidProps.NutritionPropsPerLitreWhenInMeal?.FoodCategory;
+                    foodCat ??= liquidProps.NutritionPropsPerLitreWhenInMeal?.FoodCategory;
                     foodCat ??= liquidProps.NutritionPropsPerLitre?.FoodCategory;
                 }
 
                 foodCat ??= obj?.Attributes?["nutritionPropsWhenInMeal"]?.AsObject<FoodNutritionProperties>()?.FoodCategory;
                 foodCat ??= obj?.GetNutritionProperties(null, null, null)?.FoodCategory;
 
-                props.FoodCategory = foodCat ?? EnumFoodCategory.Vegetable;
+                props.FoodCategory = foodCat ?? EnumFoodCategory.Unknown;
+            }
+
+            string foodCatCode = props.FoodCategory.ToString().ToLowerInvariant();
+            bool missingFoodCatCode = props.UseFoodCategoryMixingCode && !props.MixingCodes.Contains(foodCatCode);
+            if (props.MixingCodes.Length == 0 || missingFoodCatCode)
+            {
+                props.MixingCodes = props.MixingCodes.Prepend(foodCatCode).ToArray();
             }
 
             return props;
         }
 
+        /// <summary>
+        /// Read pie properties from ItemAttributes
+        /// </summary>
+        /// <returns>Null if "inPieProperties" is malformed or does not exist.</returns>
         public static InPieProperties? ReadFrom(ItemStack? stack)
         {
             return ReadFrom(stack?.Collectible);
         }
     }
 
-    // Idea:
-    // BlockEntityPie is a single slot inventory BE that hold a pie item stack
-    // that pie item stack is a container with always 6 slots:
-    // [0] = base dough
-    // [1-4] = filling
-    // [5] = crust dough
-    //
-    // Eliminates the need to convert it to an itemstack once its placed in inventory
+    /// <summary>
+    /// A single-slot inventory that hold a BlockPie ItemStack. The pie itemstack
+    /// is a container with 6 slots. This makes it easy to convert it to a normal
+    /// pie ItemStack.
+    /// 
+    /// [0]: Base dough
+    /// [1-4]: Filling
+    /// [5]: Crust dough
+    /// 
+    /// The number of content stacks is always 6. Unused slots are represented as null.
+    /// </summary>
     public class BlockEntityPie : BlockEntityContainer
     {
         InventoryGeneric inv;
@@ -101,13 +181,20 @@ namespace Vintagestory.GameContent
 
         public override string InventoryClassName => "pie";
 
+        public BlockPie? PieBlock
+        {
+            get
+            {
+                return inv[0].Itemstack?.Block as BlockPie;
+            }
+        }
 
         public bool HasAnyFilling
         {
             get
             {
-                ItemStack?[]? cStacks = (inv[0].Itemstack?.Block as BlockPie)?.GetContents(Api.World, inv[0].Itemstack);
-                return cStacks?[1] != null || cStacks?[2] != null || cStacks?[3] != null || cStacks?[4] != null;
+                if (PieBlock?.GetContents(Api.World, inv[0].Itemstack) is not ItemStack?[] cStacks) return false;
+                return cStacks[1] != null || cStacks[2] != null || cStacks[3] != null || cStacks[4] != null;
             }
         }
 
@@ -115,20 +202,23 @@ namespace Vintagestory.GameContent
         {
             get
             {
-                ItemStack?[]? cStacks = (inv[0].Itemstack?.Block as BlockPie)?.GetContents(Api.World, inv[0].Itemstack);
-                return cStacks?[1] != null && cStacks?[2] != null && cStacks?[3] != null && cStacks?[4] != null;
+                if (PieBlock?.GetContents(Api.World, inv[0].Itemstack) is not ItemStack?[] cStacks) return false;
+                return cStacks[1] != null && cStacks[2] != null && cStacks[3] != null && cStacks[4] != null;
             }
         }
 
-        public bool HasCrust
+        /// <summary>
+        /// If this pie's topping exists, is it a Topping or a Crust?
+        /// </summary>
+        public EnumPiePartType? ToppingType
         {
             get
             {
-                return (inv[0].Itemstack?.Block as BlockPie)?.GetContents(Api.World, inv[0].Itemstack)[5] != null;
+                return InPieProperties.ReadFrom(PieBlock?.GetContents(Api.World, inv[0].Itemstack)?[5])?.PartType;
             }
         }
 
-        public string? State => (inv[0].Itemstack?.Block as BlockPie)?.State;
+        public string? State => PieBlock?.State;
 
 
 
@@ -171,41 +261,26 @@ namespace Vintagestory.GameContent
 
         public int SlicesLeft => inv[0].Itemstack?.Attributes.GetAsInt("pieSize") ?? 0;
 
+        /// <summary>
+        /// Take a slice from the pie and set pieSize and quantityServings.
+        /// 
+        /// Once sliced, a pie is no longer bakeable.
+        /// </summary>
         public ItemStack? TakeSlice()
         {
-            if (inv[0].Itemstack?.Clone() is not { } stack) return null;
+            if (inv[0].Itemstack?.Clone() is not ItemStack stack) return null;
 
-            int size = SlicesLeft;
-            float servings = inv[0].Itemstack?.Attributes.GetFloat("quantityServings") ?? 0;
-            MarkDirty(true);
+            ItemStack? outStack = BlockPie.TakeSlice(ref stack!);
 
-            if (size <= 1)
+            if (stack == null)
             {
-                if (!stack.Attributes.HasAttribute("quantityServings"))
-                {
-                    stack.Attributes.SetFloat("quantityServings", 0.25f);
-                }
-                inv[0].Itemstack = null;
                 Api.World.BlockAccessor.SetBlock(0, Pos);
             }
-            else
-            {
-                inv[0].Itemstack?.Attributes.SetInt("pieSize", size - 1);
-                if (inv[0].Itemstack?.Attributes.HasAttribute("quantityServings") == true)
-                {
-                    inv[0].Itemstack?.Attributes.SetFloat("quantityServings", servings - 0.25f);
-                }
-
-                stack.Attributes.SetInt("pieSize", 1);
-                stack.Attributes.SetFloat("quantityServings", 0.25f);
-            }
-
-            stack.Attributes.SetBool("bakeable", false);
 
             loadMesh();
             MarkDirty(true);
 
-            return stack;
+            return outStack;
         }
 
         public void OnPlaced(IPlayer? byPlayer)
@@ -250,7 +325,7 @@ namespace Vintagestory.GameContent
                     }
 
                 }
-                else
+                else if (ToppingType == EnumPiePartType.Crust)
                 {
                     // Cycle top crust type
                     ItemStack?[] cStacks = pieBlock.GetContents(Api.World, inv[0].Itemstack);
@@ -320,18 +395,33 @@ namespace Vintagestory.GameContent
             return true;
         }
 
+        /// <summary>
+        /// CanAddIngredient without error handling for a raw "yes or no" answer
+        /// </summary>
+        /// <param name="stack"></param>
+        /// <returns></returns>
         public bool CanAddIngredient(ItemStack? stack)
         {
             return CanAddIngredient(stack, out _, out _, out _);
         }
 
-        public bool CanAddIngredient(ItemStack? prevStack, out int emptySlotIndex, out string? errCode, out string? errMessage)
+        /// <summary>
+        /// Check if the given ItemStack can be added to this pie.
+        /// <br/><br/>
+        /// Does not add the ingredient. See <see cref="TryAddIngredientFrom" />
+        /// </summary>
+        /// <param name="stack">The item to add to the pie.</param>
+        /// <param name="emptySlotIndex">If the ingredient can be added, the slot to which is would be placed in.</param>
+        /// <param name="errCode">If the ingredient cannot be added, the error code describing what went wrong.</param>
+        /// <param name="errMessage">If the ingredient cannot be added, the localized error message to display.</param>
+        /// <returns>True if the stack can be added to the pie.</returns>
+        public bool CanAddIngredient(ItemStack? stack, out int? emptySlotIndex, out string? errCode, out string? errMessage)
         {
             errCode = null;
             errMessage = null;
-            emptySlotIndex = -1;
+            emptySlotIndex = null;
 
-            if (InPieProperties.ReadFrom(prevStack) is not InPieProperties pieProps)
+            if (InPieProperties.ReadFrom(stack) is not InPieProperties pieProps)
             {
                 errCode = "notpieable";
                 errMessage = Lang.Get("This item can not be added to pies");
@@ -339,7 +429,7 @@ namespace Vintagestory.GameContent
             }
 
             // Not null if pieProps exists
-            if (prevStack!.StackSize < 2)
+            if (stack!.StackSize < 2)
             {
                 errCode = "notenoughingredients";
                 errMessage = Lang.Get("Need at least 2 items each");
@@ -350,22 +440,43 @@ namespace Vintagestory.GameContent
 
             ItemStack?[] cStacks = pieBlock.GetContents(Api.World, inv[0].Itemstack);
 
-            if (HasAllFilling)
+            // Special case:
+            // Using a knife or crust on a pie with a crust topping should succeed without an error,
+            // but the emptySlotIndex is still null because we aren't actually adding anything.
+            if (ToppingType != null)
             {
-                if (pieProps.PartType == EnumPiePartType.Crust)
+                bool addingCrust = pieProps.PartType == EnumPiePartType.Crust;
+                EnumTool? tool = stack.Collectible.GetTool(new DummySlot(stack));
+                bool usingCuttingTool = tool == EnumTool.Knife || tool == EnumTool.Sword;
+
+                if (ToppingType == EnumPiePartType.Crust && (addingCrust || usingCuttingTool))
                 {
-                    emptySlotIndex = 5;
                     return true;
                 }
                 else
+                {
+                    errCode = "piefinished";
+                    errMessage = Lang.Get("piemaking-alreadycomplete");
+                    return false;
+                }
+            }
+
+            if (HasAllFilling)
+            {
+                if (pieProps.PartType == EnumPiePartType.Filling)
                 {
                     errCode = "piefullfilling";
                     errMessage = Lang.Get("Can't add more filling - already completely filled pie");
                     return false;
                 }
+                else if (pieProps.PartType == EnumPiePartType.Crust)
+                {
+                    emptySlotIndex = 5;
+                    return true;
+                }
             }
 
-            if (pieProps.PartType != EnumPiePartType.Filling)
+            if (!HasAllFilling && pieProps.PartType != EnumPiePartType.Filling)
             {
                 errCode = "pieneedsfilling";
                 errMessage = Lang.Get("Need to add a filling next");
@@ -378,50 +489,49 @@ namespace Vintagestory.GameContent
                 return true;
             }
 
-            EnumFoodCategory[] foodCats = cStacks.Select(BlockPie.IngredientFoodCategory).ToArray();
-            InPieProperties?[] stackprops = cStacks.Select(InPieProperties.ReadFrom).ToArray();
-
-            EnumFoodCategory prevFoodCat = BlockPie.IngredientFoodCategory(prevStack);
+            InPieProperties?[] stackPieProps = cStacks.Select(InPieProperties.ReadFrom).ToArray();
 
             bool singleIngredient = true;
-            bool singleFoodCat = true;
-            bool allowMixing = true;
+            bool allowMixing = pieProps.AllowMixing;
             IEnumerable<string> mixCodes = pieProps.MixingCodes;
 
-            for (int i = 1; (singleIngredient || singleFoodCat || mixCodes.Any()) && i < cStacks.Length - 1; i++)
+            // Note that we check the topping slot here because non-crust toppings are restricted by mixing codes.
+            for (int i = 1; i < cStacks.Length; i++)
             {
-                if (prevStack == null) continue;
+                if (cStacks[i] == null) break;
 
-                singleIngredient &= cStacks[i] == null || prevStack.Equals(Api.World, cStacks[i], GlobalConstants.IgnoredStackAttributes);
-                singleFoodCat &= cStacks[i] == null || foodCats[i] == prevFoodCat;
-                allowMixing &= stackprops[i]?.AllowMixing == true;
-                mixCodes = stackprops[i]?.MixingCodes.Intersect(mixCodes) ?? mixCodes;
+                singleIngredient &= cStacks[i]!.Equals(Api.World, stack, GlobalConstants.IgnoredStackAttributes);
+                allowMixing &= stackPieProps[i]!.AllowMixing == true || pieProps.PartType == EnumPiePartType.Topping;
+                mixCodes = stackPieProps[i]!.MixingCodes.Intersect(mixCodes) ?? [];
 
-                if (!singleIngredient && !singleFoodCat && !mixCodes.Any()) break;
-
-                prevStack = cStacks[i];
-                prevFoodCat = foodCats[i];
+                if (!singleIngredient && !mixCodes.Any()) break;
             }
 
-            emptySlotIndex = 2 + (cStacks[2] != null ? 1 + (cStacks[3] != null ? 1 : 0) : 0);
-
-            if (singleIngredient)
+            if (!mixCodes.Any())
             {
-                return true;
-            }
-
-            if (!singleFoodCat && !mixCodes.Any())
-            {
-                errCode = "piemismatchedmix";
-                errMessage = Lang.Get("piemaking-unabletomixingredient");
+                if (pieProps.PartType == EnumPiePartType.Filling)
+                {
+                    errCode = "piemismatchedmix";
+                    errMessage = Lang.Get("piemaking-unabletomixingredient");
+                }
+                else
+                {
+                    errCode = "piemismatchedtopping";
+                    errMessage = Lang.Get("piemaking-unabletoaddtopping");
+                }
                 return false;
             }
-            else if (!allowMixing)
+            else if (!singleIngredient && !allowMixing)
             {
                 errCode = "pienonmixable";
                 errMessage = Lang.Get("piemaking-mixingnotallowed");
                 return false;
             }
+
+            if (cStacks[4] != null) emptySlotIndex = 5;
+            else if (cStacks[3] != null) emptySlotIndex = 4;
+            else if (cStacks[2] != null) emptySlotIndex = 3;
+            else emptySlotIndex = 2;
 
             return true;
         }
@@ -432,27 +542,31 @@ namespace Vintagestory.GameContent
 
             if (inv[0].Itemstack?.Block is not BlockPie pieBlock) return false;
 
-            if (!CanAddIngredient(slot.Itemstack, out int emptySlotIndex, out string? errCode, out string? errMessage))
+            if (!CanAddIngredient(slot.Itemstack, out int? emptySlotIndex, out string? errCode, out string? errMessage))
             {
                 capi?.TriggerIngameError(this, errCode, errMessage);
                 return false;
             }
 
             ItemStack[] cStacks = pieBlock.GetContents(Api.World, inv[0].Itemstack);
-            if (emptySlotIndex == 5)
+
+            if (InPieProperties.ReadFrom(slot.Itemstack)!.PartType == EnumPiePartType.Crust)
             {
-                if (cStacks[5] == null)
+                if (emptySlotIndex == null)
+                {
+                    // Using a knife to cycle crust type
+                    inv[0].Itemstack = BlockPie.CycleTopCrustType(inv[0].Itemstack);
+                    return true;
+                }
+
+                if (emptySlotIndex == 5)
                 {
                     // Crust attribute must exist to stack together
                     inv[0].Itemstack?.Attributes.SetString("topCrustType", "full");
                 }
-                else
-                {
-                    inv[0].Itemstack = BlockPie.CycleTopCrustType(inv[0].Itemstack);
-                    return true;
-                }
             }
-            cStacks[emptySlotIndex] = slot.TakeOut(2);
+
+            cStacks[(int)emptySlotIndex!] = slot.TakeOut(2);
             pieBlock.SetContents(inv[0].Itemstack, cStacks);
 
             return true;

--- a/BlockEntity/BEPie.cs
+++ b/BlockEntity/BEPie.cs
@@ -30,11 +30,10 @@ namespace Vintagestory.GameContent
         public required AssetLocation Texture;
 
         /// <summary>
-        /// The shape to use if this is a topping. Must be the
-        /// shape of the entire pie, including the topping.
+        /// The shape to use if this is a topping.
         /// </summary>
-        [DocumentAsJson("Optional")]
-        public string? ToppingShapeElement = null;
+        [DocumentAsJson("Optional", "origin/base/top crust full/*")]
+        public string ToppingShapeElement = "origin/base/top crust full/*";
 
         /// <summary>
         /// Is this filling allowed to mix with other ingredients?
@@ -45,7 +44,7 @@ namespace Vintagestory.GameContent
         /// cannot be combined with anything else. Don't add mixing codes
         /// if this is disabled.
         /// </summary>
-        [DocumentAsJson("Optional")]
+        [DocumentAsJson("Optional", "true")]
         public bool AllowMixing = true;
 
         /// <summary>
@@ -97,7 +96,7 @@ namespace Vintagestory.GameContent
         /// <br/>
         ///   5. Default to NoNutrition
         /// </summary>
-        [DocumentAsJson("Optional")]
+        [DocumentAsJson("Optional", "EnumFoodCategory.NoNutrition")]
         public EnumFoodCategory FoodCategory = EnumFoodCategory.NoNutrition;
 
         /// <summary>
@@ -125,11 +124,11 @@ namespace Vintagestory.GameContent
         /// If MixingCodes is empty, the food category code will always be added.
         /// It is an error for MixingCodes to be empty with NoNutrition.
         /// </summary>
-        [DocumentAsJson("Optional")]
+        [DocumentAsJson("Optional", "[]")]
         public string[] MixingCodes = [];
 
         /// <summary>
-        /// Read pie properties from Attributes
+        /// Read pie properties from Attributes.
         /// </summary>
         /// <returns>Null if "inPieProperties" is malformed or does not exist.</returns>
         public static InPieProperties? ReadFrom(CollectibleObject? obj)

--- a/BlockEntity/BEPie.cs
+++ b/BlockEntity/BEPie.cs
@@ -15,20 +15,69 @@ namespace Vintagestory.GameContent
     {
         Crust, Filling, Topping
     }
+
     public class InPieProperties
     {
         /// <summary>
-        /// If true, allows mixing of the same nutritionprops food category
+        /// Is this ingredient allowed to mix with other ingredients?
+        ///
+        /// If false, MixingCodes has no effect.
         /// </summary>
         public bool AllowMixing = true;
+
+        /// <summary>
+        /// Is this a crust, filling, or topping?
+        /// </summary>
         public EnumPiePartType PartType;
+
         public required AssetLocation Texture;
-        public EnumFoodCategory? FoodCategory;
+
+        /// <summary>
+        /// The food category of the ingredient when used in a pie.
+        ///
+        /// Checks in order, stopping once a value is found:
+        ///   1. If stack is null, default to vegetable
+        ///   2. InPieProperties.FoodCategory
+        ///   3. If stack has ContainableProps:
+        ///     3a. NutritionPropsPerLitreWhenInMeal.FoodCategory
+        ///     3b. NutritionPropsPerLitre.FoodCategory
+        ///   4. If stack has NutritionProps:
+        ///     4a. NutritionPropsWhenInMeal.FoodCategory
+        ///     4b. NutritionProps.FoodCategory
+        ///   5. Default to vegetable
+        ///
+        /// Note that the field default isn't actually used because we
+        /// null-coalesce from our checks in ReadFrom, so if you want to
+        /// change it, you need to do it there.
+        /// </summary>
+        public EnumFoodCategory FoodCategory = EnumFoodCategory.Vegetable;
+
+        /// <summary>
+        /// A list of mixing codes that are allowed for this ingredient.
+        /// </summary>
         public string[] MixingCodes = [];
 
         public static InPieProperties? ReadFrom(CollectibleObject? obj)
         {
-            return obj?.Attributes?["inPieProperties"]?.AsObject<InPieProperties?>(null, obj.Code.Domain);
+            if (obj?.Attributes?["inPieProperties"]?.AsObject<InPieProperties>(null, obj.Code.Domain) is not InPieProperties props) return null;
+
+            // This will always override the default for FoodCategory.
+            {
+                EnumFoodCategory? foodCat = null;
+
+                if (BlockLiquidContainerBase.GetContainableProps(obj) is WaterTightContainableProps liquidProps)
+                {
+                    foodCat = liquidProps.NutritionPropsPerLitreWhenInMeal?.FoodCategory;
+                    foodCat ??= liquidProps.NutritionPropsPerLitre?.FoodCategory;
+                }
+
+                foodCat ??= obj?.Attributes?["nutritionPropsWhenInMeal"]?.AsObject<FoodNutritionProperties>()?.FoodCategory;
+                foodCat ??= obj?.GetNutritionProperties(null, null, null)?.FoodCategory;
+
+                props.FoodCategory = foodCat ?? EnumFoodCategory.Vegetable;
+            }
+
+            return props;
         }
 
         public static InPieProperties? ReadFrom(ItemStack? stack)
@@ -329,10 +378,10 @@ namespace Vintagestory.GameContent
                 return true;
             }
 
-            EnumFoodCategory[] foodCats = cStacks.Select(BlockPie.FillingFoodCategory).ToArray();
+            EnumFoodCategory[] foodCats = cStacks.Select(BlockPie.IngredientFoodCategory).ToArray();
             InPieProperties?[] stackprops = cStacks.Select(InPieProperties.ReadFrom).ToArray();
 
-            EnumFoodCategory prevFoodCat = BlockPie.FillingFoodCategory(prevStack);
+            EnumFoodCategory prevFoodCat = BlockPie.IngredientFoodCategory(prevStack);
 
             bool singleIngredient = true;
             bool singleFoodCat = true;

--- a/BlockEntity/BEPie.cs
+++ b/BlockEntity/BEPie.cs
@@ -10,6 +10,7 @@ using Vintagestory.API.Datastructures;
 using System;
 using Vintagestory.API.Util;
 using Vintagestory.API;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Vintagestory.GameContent
 {
@@ -19,8 +20,8 @@ namespace Vintagestory.GameContent
     }
 
     /// <summary>
-    /// Defines the type of ingredient (crust, filling, topping), food
-    /// category, and what mixing codes it can be used with, if any.
+    /// Defines the type of ingredient (crust, filling, topping), food category
+    /// for mixing, and what mixing codes it can be used with, if any.
     /// </summary>
     [DocumentAsJson]
     public class InPieProperties
@@ -29,11 +30,18 @@ namespace Vintagestory.GameContent
         public required AssetLocation Texture;
 
         /// <summary>
+        /// The shape to use if this is a topping. Must be the
+        /// shape of the entire pie, including the topping.
+        /// </summary>
+        [DocumentAsJson("Optional")]
+        public Shape? ToppingShape = null;
+
+        /// <summary>
         /// Is this filling allowed to mix with other ingredients?
         /// Crusts and toppings ignore this.
         /// <br/><br/>
         /// If false, MixingCodes has no effect because this ingredient
-        /// cannot be combined with anything else.
+        /// cannot be combined with anything else. Don't do this.
         /// </summary>
         [DocumentAsJson("Optional")]
         public bool AllowMixing = true;
@@ -58,7 +66,13 @@ namespace Vintagestory.GameContent
         public EnumPiePartType PartType;
 
         /// <summary>
-        /// The food category of the ingredient when used in a pie.
+        /// The food category of the ingredient when used in a pie. This does
+        /// not affect the actual nutrition when consumed. It is only used
+        /// to determine which category mixing code to add.
+        ///
+        /// A pie of the NoNutrition category cannot be added to pies unless
+        /// there is an explicit matching mixing code. A NoNutrition ingredient
+        /// with no mixing codes is an error.
         /// <br/><br/>
         /// Checks in order, stopping once a value is found:
         /// <br/><br/>
@@ -78,23 +92,19 @@ namespace Vintagestory.GameContent
         /// <br/>
         ///     4b. NutritionProps.FoodCategory
         /// <br/>
-        ///   5. Default to vegetable
-        /// <br/><br/>
-        /// Note that the field default is never used when created by ReadFrom, which
-        /// has its own default value.
+        ///   5. Default to NoNutrition
         /// </summary>
         [DocumentAsJson("Optional")]
-        public EnumFoodCategory FoodCategory = EnumFoodCategory.Unknown;
+        public EnumFoodCategory FoodCategory = EnumFoodCategory.NoNutrition;
 
         /// <summary>
         /// A list of mixing codes that are allowed for this ingredient. When
         /// checking for mixing codes, the first mixing code present in all
         /// ingredients is used for the pie type.
         /// <br/><br/>
-        /// If UseFoodCategoryMixingCode is true and the ingredient does
-        /// not already include the code for its food category, it will
-        /// be prepended to the front. This means that by default, mixing codes
-        /// are of a lower priority than the food category:
+        /// If the ingredient's food category is not NoNutrition and the category
+        /// code is not already present, it will be prepended. This means that by
+        /// default, mixing codes are of a lower priority than the food category:
         /// <br/>
         /// [ "potpie" ] -> [ "vegetable", "potpie" ]
         /// <br/><br/>
@@ -104,23 +114,11 @@ namespace Vintagestory.GameContent
         /// <br/>
         /// [ "mushroom", "vegetable", "potpie" ]
         /// <br/><br/>
-        /// To disable the food category code entirely, see UseFoodCategoryMixingCode.
         /// If MixingCodes is empty, the food category code will always be added.
+        /// It is an error for MixingCodes to be empty with NoNutrition.
         /// </summary>
         [DocumentAsJson("Optional")]
         public string[] MixingCodes = [];
-
-        /// <summary>
-        /// If disabled, prevents the food category tag from being added if it isn't
-        /// present. The ingredient will not be usable in generic pies for its food
-        /// category, instead only being usable with its specific mixing codes.
-        /// 
-        /// If not present in the pie properties, tries to use the object's nutritionPropsWhenInMeal.
-        /// <br/><br/>
-        /// If MixingCodes is empty, the food category code will always be added.
-        /// </summary>
-        [DocumentAsJson("Optional")]
-        public bool UseFoodCategoryMixingCode = true;
 
         /// <summary>
         /// Read pie properties from Attributes
@@ -132,7 +130,7 @@ namespace Vintagestory.GameContent
 
             // Get the food category manually. It doesn't need to be present in the pie properties,
             // but making the field nullable is unnecessary after parsing.
-            if (props.FoodCategory == EnumFoodCategory.Unknown)
+            if (props.FoodCategory == EnumFoodCategory.NoNutrition)
             {
                 EnumFoodCategory? foodCat = null;
 
@@ -145,12 +143,15 @@ namespace Vintagestory.GameContent
                 foodCat ??= obj?.Attributes?["nutritionPropsWhenInMeal"]?.AsObject<FoodNutritionProperties>()?.FoodCategory;
                 foodCat ??= obj?.GetNutritionProperties(null, null, null)?.FoodCategory;
 
-                props.FoodCategory = foodCat ?? EnumFoodCategory.Unknown;
+                props.FoodCategory = foodCat ?? EnumFoodCategory.NoNutrition;
             }
 
+            // Never add the code for NoNutrition.
+            if (props.FoodCategory == EnumFoodCategory.NoNutrition) return props;
+
+            // Add the food category code if there are no mixing codes or if it wasn't explicitly added.
             string foodCatCode = props.FoodCategory.ToString().ToLowerInvariant();
-            bool missingFoodCatCode = props.UseFoodCategoryMixingCode && !props.MixingCodes.Contains(foodCatCode);
-            if (props.MixingCodes.Length == 0 || missingFoodCatCode)
+            if (props.MixingCodes.Length == 0 || !props.MixingCodes.Contains(foodCatCode))
             {
                 props.MixingCodes = props.MixingCodes.Prepend(foodCatCode).ToArray();
             }
@@ -169,15 +170,15 @@ namespace Vintagestory.GameContent
     }
 
     /// <summary>
-    /// A single-slot inventory that hold a BlockPie ItemStack. The pie itemstack
+    /// A single-slot inventory that hold a <see cref="BlockPie" /> ItemStack. The pie itemstack
     /// is a container with 6 slots. This makes it easy to convert it to a normal
     /// pie ItemStack.
-    /// 
+    ///
+    /// GetContents() is an ItemStack[6]. Unused slots are represented as null.
+    ///
     /// [0]: Base dough
     /// [1-4]: Filling
     /// [5]: Crust dough
-    /// 
-    /// The number of content stacks is always 6. Unused slots are represented as null.
     /// </summary>
     public class BlockEntityPie : BlockEntityContainer
     {
@@ -227,14 +228,15 @@ namespace Vintagestory.GameContent
 
 
 
-        MealMeshCache? ms;
-        MeshData? mesh;
+        MealMeshCache ms = null!;
+        MeshData mesh = null!;
 
         public BlockEntityPie() : base()
         {
             inv = new InventoryGeneric(1, null, null);
         }
 
+        [MemberNotNull(nameof(ms), nameof(mesh))]
         public override void Initialize(ICoreAPI api)
         {
             base.Initialize(api);
@@ -290,7 +292,18 @@ namespace Vintagestory.GameContent
 
         public void OnPlaced(IPlayer? byPlayer)
         {
-            if (byPlayer?.InventoryManager.ActiveHotbarSlot.TakeOut(2) is not ItemStack doughStack) return;
+            ItemStack? doughStack;
+            if (byPlayer?.WorldData.CurrentGameMode == EnumGameMode.Creative)
+            {
+                doughStack = byPlayer?.InventoryManager.ActiveHotbarSlot.Itemstack?.Clone();
+                if (doughStack != null) doughStack.StackSize = 2;
+            }
+            else
+            {
+                doughStack = byPlayer?.InventoryManager.ActiveHotbarSlot.TakeOut(2);
+            }
+
+            if (doughStack == null) return;
 
             ItemStack pie = new(Block);
             (pie.Block as BlockPie)?.SetContents(pie, [doughStack, null, null, null, null, null]);
@@ -426,7 +439,7 @@ namespace Vintagestory.GameContent
             errMessage = null;
             emptySlotIndex = null;
 
-            if (InPieProperties.ReadFrom(stack) is not InPieProperties pieProps)
+            if (InPieProperties.ReadFrom(stack) is not InPieProperties pieProps || pieProps.FoodCategory == EnumFoodCategory.NoNutrition)
             {
                 errCode = "notpieable";
                 errMessage = Lang.Get("This item can not be added to pies");
@@ -571,7 +584,15 @@ namespace Vintagestory.GameContent
                 }
             }
 
-            cStacks[(int)emptySlotIndex!] = slot.TakeOut(2);
+            if (byPlayer?.WorldData.CurrentGameMode == EnumGameMode.Creative)
+            {
+                cStacks[(int)emptySlotIndex!] = slot.Itemstack!.Clone();
+                cStacks[(int)emptySlotIndex].StackSize = 2;
+            }
+            else
+            {
+                cStacks[(int)emptySlotIndex!] = slot.TakeOut(2);
+            }
             pieBlock.SetContents(inv[0].Itemstack, cStacks);
 
             return true;
@@ -587,7 +608,7 @@ namespace Vintagestory.GameContent
         void loadMesh()
         {
             if (Api == null || Api.Side == EnumAppSide.Server || inv[0].Empty) return;
-            mesh = ms!.GetPieMesh(inv[0].Itemstack);
+            mesh = ms.GetPieMesh(inv[0].Itemstack);
         }
 
         public override void GetBlockInfo(IPlayer forPlayer, StringBuilder dsc)

--- a/BlockEntity/BEPie.cs
+++ b/BlockEntity/BEPie.cs
@@ -64,7 +64,7 @@ namespace Vintagestory.GameContent
         ///   of a topping without being restricted by mixing codes.
         /// </summary>
         [DocumentAsJson("Required")]
-        public EnumPiePartType PartType;
+        public required EnumPiePartType PartType;
 
         /// <summary>
         /// The food category of the ingredient when used in a pie. This does

--- a/BlockEntity/BEPie.cs
+++ b/BlockEntity/BEPie.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -7,32 +7,273 @@ using Vintagestory.API.Common;
 using Vintagestory.API.Config;
 using Vintagestory.API.Datastructures;
 
+using System;
+using Vintagestory.API.Util;
+using Vintagestory.API;
+using System.Diagnostics.CodeAnalysis;
+
 namespace Vintagestory.GameContent
 {
     public enum EnumPiePartType
     {
         Crust, Filling, Topping
     }
+
+    /// <summary>
+    /// Defines the type of ingredient (crust, filling, topping), food category
+    /// for mixing, and what mixing codes it can be used with, if any.
+    /// </summary>
+    [DocumentAsJson]
     public class InPieProperties
     {
-        /// <summary>
-        /// If true, allows mixing of the same nutritionprops food category
-        /// </summary>
-        public bool AllowMixing = true;
-        public EnumPiePartType PartType;
+        [DocumentAsJson("Required")]
         public required AssetLocation Texture;
-        public EnumFoodCategory? FoodCategory;
+
+        /// <summary>
+        /// The shape to use if this is a topping.
+        /// </summary>
+        [DocumentAsJson("Optional", "origin/base/top crust full/*")]
+        public string ToppingShapeElement = "origin/base/top crust full/*";
+
+        /// <summary>
+        /// Is this filling allowed to mix with other ingredients?
+        /// Crusts and toppings ignore this, but toppings always
+        /// require a matching mixing code.
+        /// <br/><br/>
+        /// If false, MixingCodes has no effect because this ingredient
+        /// cannot be combined with anything else. Don't add mixing codes
+        /// if this is disabled.
+        /// </summary>
+        [DocumentAsJson("Optional", "true")]
+        public bool AllowMixing = true;
+
+        /// <summary>
+        /// Is this a crust, filling, or topping?
+        /// <br/><br/>
+        /// * Crust is used as the pie's base. The ingredient used to
+        ///   create a pie must be a crust. Crust can also be used
+        ///   as a topping and is not restricted by mixing codes.
+        /// <br/>
+        /// * Filling is what's inside the pie. AllowMixing determines
+        ///   if it can only be used for single-ingredient pies. If it
+        ///   can be mixed, only ingredients with at least one matching
+        ///   mixing code can be added.
+        ///
+        ///   Pies with only one filling are always named after that ingredient.
+        /// <br/>
+        /// * Topping is the pie's last layer. Like filling, it is
+        ///   restricted by mixing codes. Any crust may be used in place
+        ///   of a topping without being restricted by mixing codes.
+        /// </summary>
+        [DocumentAsJson("Required")]
+        public required EnumPiePartType PartType;
+
+        /// <summary>
+        /// The food category of the ingredient when used in a pie. This does
+        /// not affect the actual nutrition when consumed. It is only used
+        /// to determine which category mixing code to prepend in the case
+        /// that the code is not already present.
+        /// <br/><br/>
+        /// An ingredient of the NoNutrition category cannot be added to pies unless
+        /// it has at least one explicit mixing code or mixing has been disabled.
+        /// NoNutrition may be used explicitly, skipping the process below.
+        /// <br/><br/>
+        /// Checks in order, stopping once a value is found:
+        /// <br/><br/>
+        ///   1. inPieProperties["foodCategory"]
+        /// <br/>
+        ///   2. If stack has WaterTightContainableProps:
+        /// <br/>
+        ///     2a. NutritionPropsPerLitreWhenInMeal.FoodCategory
+        /// <br/>
+        ///     2b. NutritionPropsPerLitre.FoodCategory
+        /// <br/>
+        ///   3. If stack has NutritionProps:
+        /// <br/>
+        ///     3a. NutritionPropsWhenInMeal.FoodCategory
+        /// <br/>
+        ///     3b. NutritionProps.FoodCategory
+        /// <br/>
+        ///   4. Use NoNutrition. If no nutrition props are present,
+        ///      the InPieProperties are always null.
+        /// </summary>
+        [DocumentAsJson("Optional", "See process in docstring")]
+        public EnumFoodCategory FoodCategory = EnumFoodCategory.NoNutrition;
+
+        /// <summary>
+        /// A list of mixing codes that are allowed for this ingredient. When
+        /// checking for mixing codes, the first mixing code present in all
+        /// ingredients is used for the pie type. Mixing codes do not apply
+        /// to crust ingredients and will be ignored.
+        /// <br/><br/>
+        /// If the ingredient's food category is not NoNutrition and the category
+        /// code is not already present, it will be prepended. This means that by
+        /// default, mixing codes are of a lower priority than the food category.
+        /// <br/>
+        /// [ "potpie" ] -> [ "vegetable", "potpie" ]
+        /// <br/><br/>
+        /// By including the food category in the list of mixing codes, other codes
+        /// can be given a higher priority. For example, the following would create
+        /// a "mushroom" mixing code that would take precedence over "vegetable".
+        /// <br/>
+        /// [ "mushroom", "vegetable", "potpie" ]
+        /// <br/><br/>
+        /// An ingredient may have multiple food category mixing codes. It will be
+        /// allowed in any of those mixed pies. Other mixing codes will not be
+        /// affected.
+        /// <br/><br/>
+        /// If MixingCodes is empty, the food category code will always be added.
+        /// It is an error for a NoNutrition ingredient to have no mixing codes
+        /// unless it cannot be mixed.
+        /// </summary>
+        [DocumentAsJson("Optional", "[]")]
         public string[] MixingCodes = [];
+
+        /// <summary>
+        /// For items; The number of items in the stack used for one layer.
+        /// </summary>
+        [DocumentAsJson("Optional", "2")]
+        public int PortionSize = 2;
+
+        /// <summary>
+        /// For liquids; The number of liters used for one layer.
+        /// </summary>
+        [DocumentAsJson("Optional", "1")]
+        public float PortionSizeLitres = 1;
+
+        public bool IsLiquid = false;
+
+        /// <summary>
+        /// The appropriate portion size based on whether the ingredient is an item or liquid.
+        /// </summary>
+        public float GetPortionSize() => IsLiquid ? PortionSizeLitres : PortionSize;
+
+        public float ItemsPerLitre = 100f;
+
+        /// <summary>
+        /// The number of actual content items per portion.
+        /// </summary>
+        public int ItemsPerPortion() => IsLiquid ? (int)(PortionSizeLitres * ItemsPerLitre) : PortionSize;
+
+        /// <summary>
+        /// Read pie properties from Attributes.
+        /// </summary>
+        /// <returns>Null if "inPieProperties" is malformed or does not exist.</returns>
+        public static InPieProperties? ReadFrom(CollectibleObject? obj, out string? errMessage)
+        {
+            errMessage = null;
+
+            if (obj?.Attributes?["inPieProperties"]?.AsObject<InPieProperties>(null, obj.Code.Domain) is not InPieProperties props) return null;
+
+            WaterTightContainableProps? liquidProps = BlockLiquidContainerBase.GetContainableProps(new ItemStack(obj));
+            FoodNutritionProperties? nutriProps = obj.GetNutritionProperties(null, null, null);
+            FoodNutritionProperties? nutriPropsInMeal = obj.Attributes["nutritionPropsWhenInMeal"]?.AsObject<FoodNutritionProperties>();
+
+            // This ingredient has no nutrition properties at all, so it would do nothing in a pie.
+            if (nutriProps == null && nutriPropsInMeal == null && (liquidProps == null || (liquidProps.NutritionPropsPerLitre == null && liquidProps.NutritionPropsPerLitreWhenInMeal == null)))
+            {
+                errMessage = $"{obj.Code} has inPieProperties, but no nutrition properties. It cannot be used in pies.";
+                return null;
+            }
+
+            // Do not attempt to overwrite NoNutrition if it was set manually, only if it was defaulted to.
+            if (!obj.Attributes["inPieProperties"]["foodCategory"].Exists)
+            {
+                // Get the food category manually. It doesn't need to be present in the pie properties.
+                // We do this handling here to avoid making the field unnecessarily nullable.
+
+                EnumFoodCategory? foodCat = null;
+
+                if (liquidProps != null)
+                {
+                    foodCat ??= liquidProps.NutritionPropsPerLitreWhenInMeal?.FoodCategory;
+                    foodCat ??= liquidProps.NutritionPropsPerLitre?.FoodCategory;
+                }
+
+                foodCat ??= nutriPropsInMeal?.FoodCategory;
+                foodCat ??= nutriProps?.FoodCategory;
+
+                // This ingredient has no food category at all, so it would do nothing in a pie.
+                if (foodCat == null)
+                {
+                    errMessage = $"{obj.Code} has inPieProperties and nutrition properties, but no food category. It cannot be used in pies.";
+                    return null;
+                }
+
+                props.FoodCategory = foodCat.Value;
+            }
+
+            if (liquidProps != null)
+            {
+                props.IsLiquid = true;
+                props.ItemsPerLitre = liquidProps.ItemsPerLitre;
+            }
+
+            // Never add the code for NoNutrition.
+            if (props.FoodCategory != EnumFoodCategory.NoNutrition)
+            {
+                // Add the food category code if there are no mixing codes or if it wasn't explicitly added.
+                string foodCatCode = props.FoodCategory.ToString().ToLowerInvariant();
+                if (props.MixingCodes.Length == 0 || !props.MixingCodes.Contains(foodCatCode))
+                {
+                    props.MixingCodes = props.MixingCodes.Prepend(foodCatCode).ToArray();
+                }
+            }
+
+            // Nonsensical quantity.
+            if (props.GetPortionSize() <= 0)
+            {
+                errMessage = $"inPieProperties for {obj.Code} has a portion size of 0 or less. It cannot be used in pies.";
+                return null;
+            }
+
+            // Ingredient can be mixed, but nothing is compatible.
+            if ((props.PartType == EnumPiePartType.Filling || props.PartType == EnumPiePartType.Topping)
+                && props.AllowMixing && props.MixingCodes.Length == 0 && props.FoodCategory == EnumFoodCategory.NoNutrition)
+            {
+                errMessage = $"InPieProperties for {(props.PartType == EnumPiePartType.Filling ? "filling" : "topping")} {obj.Code} has no mixing codes and the food category NoNutrition. It cannot be added to pies unless you explicitly disable mixing.";
+                return null;
+            }
+
+            // Crusts cannot be liquid
+            if (props.PartType == EnumPiePartType.Crust && props.IsLiquid)
+            {
+                errMessage = $"Pie ingredient {obj.Code} is a liquid, but it is marked as crust. Ignoring invalid dough.";
+            }
+
+            return props;
+        }
+
+        /// <summary>
+        /// Read pie properties from Attributes.
+        /// </summary>
+        /// <returns>Null if the ingredient is unusable or "inPieProperties" does not exist.</returns>
+        public static InPieProperties? ReadFrom(CollectibleObject? obj)
+        {
+            return obj != null ? ReadFrom(obj, out _) : null;
+        }
+
+        /// <summary>
+        /// Read pie properties from ItemAttributes.
+        /// </summary>
+        /// <returns>Null if the ingredient is unusable or "inPieProperties" does not exist.</returns>
+        public static InPieProperties? ReadFrom(ItemStack? stack)
+        {
+            return ReadFrom(stack?.Collectible);
+        }
     }
 
-    // Idea:
-    // BlockEntityPie is a single slot inventory BE that hold a pie item stack
-    // that pie item stack is a container with always 6 slots:
-    // [0] = base dough
-    // [1-4] = filling
-    // [5] = crust dough
-    //
-    // Eliminates the need to convert it to an itemstack once its placed in inventory
+    /// <summary>
+    /// A single-slot inventory that hold a <see cref="BlockPie" /> ItemStack. The pie itemstack
+    /// is a container with 6 slots. This makes it easy to convert it to a normal
+    /// pie ItemStack.
+    ///
+    /// GetContents() is an ItemStack[6]. Unused slots are represented as null.
+    ///
+    /// [0]: Base dough
+    /// [1-4]: Filling
+    /// [5]: Crust dough
+    /// </summary>
     public class BlockEntityPie : BlockEntityContainer
     {
         InventoryGeneric inv;
@@ -40,13 +281,20 @@ namespace Vintagestory.GameContent
 
         public override string InventoryClassName => "pie";
 
+        public BlockPie? PieBlock
+        {
+            get
+            {
+                return inv[0].Itemstack?.Block as BlockPie;
+            }
+        }
 
         public bool HasAnyFilling
         {
             get
             {
-                ItemStack?[]? cStacks = (inv[0].Itemstack?.Block as BlockPie)?.GetContents(Api.World, inv[0].Itemstack);
-                return cStacks?[1] != null || cStacks?[2] != null || cStacks?[3] != null || cStacks?[4] != null;
+                if (PieBlock?.GetContents(Api.World, inv[0].Itemstack) is not ItemStack?[] cStacks) return false;
+                return cStacks[1] != null || cStacks[2] != null || cStacks[3] != null || cStacks[4] != null;
             }
         }
 
@@ -54,31 +302,35 @@ namespace Vintagestory.GameContent
         {
             get
             {
-                ItemStack?[]? cStacks = (inv[0].Itemstack?.Block as BlockPie)?.GetContents(Api.World, inv[0].Itemstack);
-                return cStacks?[1] != null && cStacks?[2] != null && cStacks?[3] != null && cStacks?[4] != null;
+                if (PieBlock?.GetContents(Api.World, inv[0].Itemstack) is not ItemStack?[] cStacks) return false;
+                return cStacks[1] != null && cStacks[2] != null && cStacks[3] != null && cStacks[4] != null;
             }
         }
 
-        public bool HasCrust
+        /// <summary>
+        /// If this pie's topping exists, is it a Topping or a Crust?
+        /// </summary>
+        public EnumPiePartType? ToppingType
         {
             get
             {
-                return (inv[0].Itemstack?.Block as BlockPie)?.GetContents(Api.World, inv[0].Itemstack)[5] != null;
+                return InPieProperties.ReadFrom(PieBlock?.GetContents(Api.World, inv[0].Itemstack)?[5])?.PartType;
             }
         }
 
-        public string? State => (inv[0].Itemstack?.Block as BlockPie)?.State;
+        public string? State => PieBlock?.State;
 
 
 
-        MealMeshCache? ms;
-        MeshData? mesh;
+        MealMeshCache ms = null!;
+        MeshData mesh = null!;
 
         public BlockEntityPie() : base()
         {
             inv = new InventoryGeneric(1, null, null);
         }
 
+        [MemberNotNull(nameof(ms))]
         public override void Initialize(ICoreAPI api)
         {
             base.Initialize(api);
@@ -110,49 +362,73 @@ namespace Vintagestory.GameContent
 
         public int SlicesLeft => inv[0].Itemstack?.Attributes.GetAsInt("pieSize") ?? 0;
 
+        /// <summary>
+        /// Take a slice from the pie and set pieSize and quantityServings.
+        /// 
+        /// Once sliced, a pie is no longer bakeable.
+        /// </summary>
         public ItemStack? TakeSlice()
         {
-            if (inv[0].Itemstack?.Clone() is not { } stack) return null;
+            if (inv[0].Itemstack?.Clone() is not ItemStack stack) return null;
 
-            int size = SlicesLeft;
-            float servings = inv[0].Itemstack?.Attributes.GetFloat("quantityServings") ?? 0;
-            MarkDirty(true);
+            ItemStack? outStack = BlockPie.TakeSlice(ref stack!);
 
-            if (size <= 1)
+            if (stack == null)
             {
-                if (!stack.Attributes.HasAttribute("quantityServings"))
-                {
-                    stack.Attributes.SetFloat("quantityServings", 0.25f);
-                }
-                inv[0].Itemstack = null;
                 Api.World.BlockAccessor.SetBlock(0, Pos);
             }
-            else
-            {
-                inv[0].Itemstack?.Attributes.SetInt("pieSize", size - 1);
-                if (inv[0].Itemstack?.Attributes.HasAttribute("quantityServings") == true)
-                {
-                    inv[0].Itemstack?.Attributes.SetFloat("quantityServings", servings - 0.25f);
-                }
-
-                stack.Attributes.SetInt("pieSize", 1);
-                stack.Attributes.SetFloat("quantityServings", 0.25f);
-            }
-
-            stack.Attributes.SetBool("bakeable", false);
 
             loadMesh();
             MarkDirty(true);
 
-            return stack;
+            return outStack;
         }
 
         public void OnPlaced(IPlayer? byPlayer)
         {
-            if (byPlayer?.InventoryManager.ActiveHotbarSlot.TakeOut(2) is not ItemStack doughStack) return;
+            if (byPlayer?.InventoryManager.ActiveHotbarSlot.Itemstack?.Clone() is not ItemStack doughStack
+                || InPieProperties.ReadFrom(doughStack) is not InPieProperties pieProps
+                || pieProps.PartType != EnumPiePartType.Crust)
+            {
+                return;
+            }
+
+            doughStack.StackSize = pieProps.PortionSize;
+
+            if (byPlayer.WorldData.CurrentGameMode != EnumGameMode.Creative)
+            {
+                byPlayer.InventoryManager.ActiveHotbarSlot.TakeOut(pieProps.PortionSize);
+            }
 
             ItemStack pie = new(Block);
             (pie.Block as BlockPie)?.SetContents(pie, [doughStack, null, null, null, null, null]);
+
+            // Copy over the transition states so that we don't make a completely fresh pie from spoiling dough
+            if (doughStack.Collectible.UpdateAndGetTransitionStates(byPlayer?.Entity.World, new DummySlot(doughStack)) is TransitionState[] doughStates
+                && pie.Collectible.UpdateAndGetTransitionStates(byPlayer?.Entity.World, new DummySlot(pie)) is TransitionState[] pieStates)
+            {
+
+                for (int i = 0; i < doughStates.Length; i++)
+                {
+                    if (doughStates[i].TransitionLevel > 0)
+                    {
+                        float scaledHours = pieStates[i].FreshHours + pieStates[i].TransitionHours * doughStates[i].TransitionLevel;
+
+                        if (Api.Side.IsServer()) Api.Logger.Debug($"Scaled spoiling dough lifetime to pie; {pieStates[i].FreshHours} + {pieStates[i].TransitionHours} * {doughStates[i].TransitionLevel}");
+
+                        pie.Collectible.SetTransitionState(pie, doughStates[i].Props.Type, scaledHours);
+                    }
+                    else
+                    {
+                        float scaledHours = doughStates[i].TransitionedHours / (pieStates[i].TransitionHours / doughStates[i].TransitionHours);
+
+                        if (Api.Side.IsServer()) Api.Logger.Debug($"Scaled fresh dough lifetime to pie; {doughStates[i].TransitionedHours} / ({pieStates[i].TransitionHours} / {doughStates[i].TransitionHours}) = {scaledHours}");
+
+                        pie.Collectible.SetTransitionState(pie, doughStates[i].Props.Type, scaledHours);
+                    }
+                }
+            }
+
             pie.Attributes.SetInt("pieSize", 4);
             pie.Attributes.SetBool("bakeable", false);
             if (State != "raw" && !pie.Attributes.HasAttribute("quantityServings"))
@@ -170,12 +446,11 @@ namespace Vintagestory.GameContent
 
             ItemSlot? hotbarSlot = byPlayer.InventoryManager.ActiveHotbarSlot;
 
-            EnumTool? tool = hotbarSlot?.Itemstack?.Collectible.GetTool(hotbarSlot);
-            if (tool is EnumTool.Knife or EnumTool.Sword)
+            if (hotbarSlot?.Itemstack?.Collectible.GetTool(hotbarSlot) is EnumTool tool && (tool is EnumTool.Knife || tool is EnumTool.Sword))
             {
                 if (pieBlock.State != "raw")
                 {
-                    if (Api.Side == EnumAppSide.Server && TakeSlice() is { } slicestack)
+                    if (Api.Side == EnumAppSide.Server && TakeSlice() is ItemStack slicestack)
                     {
                         if (!byPlayer.InventoryManager.TryGiveItemstack(slicestack))
                         {
@@ -188,7 +463,9 @@ namespace Vintagestory.GameContent
                         );
                     }
 
-                } else
+                    MarkDirty(true);
+                }
+                else if (ToppingType == EnumPiePartType.Crust)
                 {
                     // Cycle top crust type
                     ItemStack?[] cStacks = pieBlock.GetContents(Api.World, inv[0].Itemstack);
@@ -202,12 +479,12 @@ namespace Vintagestory.GameContent
             }
 
             // Filling rules:
-            // 1. get inPieProperties
-            // 2. any filing there yet? if not, all good
-            // 3. Is full: Can't add more.
-            // 3. If partially full, must
-            //    a.) be of same foodcat
-            //    b.) have props.AllowMixing set to true
+            // 1. Get inPieProperties
+            // 2. If pie is empty, add it.
+            // 3. If pie is full, stop.
+            // 3. If pie is partially full, must
+            //    a.) Have props.AllowMixing set to true
+            //    b.) Have at least one matching mixing code
 
             if (hotbarSlot?.Empty == false && pieBlock.State == "raw")
             {
@@ -229,6 +506,11 @@ namespace Vintagestory.GameContent
                 inv[0].Itemstack?.Attributes.SetFloat("quantityServings", 0.25f);
             }
 
+            if (byPlayer.Entity.Controls.ShiftKey)
+            {
+                return false;
+            }
+
             if (Api.Side == EnumAppSide.Server)
             {
                 if (!byPlayer.InventoryManager.TryGiveItemstack(inv[0].Itemstack))
@@ -248,19 +530,68 @@ namespace Vintagestory.GameContent
             return true;
         }
 
-        private bool TryAddIngredientFrom(ItemSlot slot, IPlayer? byPlayer = null)
+        /// <summary>
+        /// CanAddIngredient without error handling for a raw "yes or no" answer
+        /// </summary>
+        /// <param name="stack"></param>
+        /// <returns></returns>
+        public bool CanAddIngredient(ItemStack stack)
         {
-            var capi = Api as ICoreClientAPI;
-            var pieProps = slot.Itemstack?.ItemAttributes?["inPieProperties"]?.AsObject<InPieProperties?>(null, slot.Itemstack.Collectible.Code.Domain);
-            if (pieProps == null)
+            return CanAddIngredient(stack, out _, out _, out _);
+        }
+
+        /// <summary>
+        /// Check if the given ItemStack can be added to this pie.
+        /// <br/><br/>
+        /// Does not add the ingredient. See <see cref="TryAddIngredientFrom" />
+        /// </summary>
+        /// <param name="stack">The item to add to the pie.</param>
+        /// <param name="emptySlotIndex">If the ingredient can be added, the slot into which it would be placed.</param>
+        /// <param name="errCode">If the ingredient cannot be added, the error code describing what went wrong.</param>
+        /// <param name="errMessage">If the ingredient cannot be added, the localized error message to display.</param>
+        /// <returns>True if the stack can be added to the pie. Note that if the action should succeed, but no stack
+        /// is actually added, such as changing crust type, it will return true but leave emptySlotIndex null.</returns>
+        public bool CanAddIngredient(ItemStack stack, out int? emptySlotIndex, out string? errCode, out string? errMessage)
+        {
+            errCode = null;
+            errMessage = null;
+            emptySlotIndex = null;
+
+            ILiquidSource? container = stack.Collectible.GetCollectibleInterface<ILiquidSource>();
+            if (container?.AllowHeldLiquidTransfer == false)
             {
-                if (byPlayer != null && capi != null) capi.TriggerIngameError(this, "notpieable", Lang.Get("This item can not be added to pies"));
+                errCode = "notpieable";
+                errMessage = Lang.Get("This item can not be added to pies");
                 return false;
             }
 
-            if (slot.StackSize < 2)
+            ItemStack contentStack = stack;
+            if (container != null)
             {
-                if (byPlayer != null && capi != null) capi.TriggerIngameError(this, "notpieable", Lang.Get("Need at least 2 items each"));
+                if (container.GetContent(stack) is ItemStack cStack)
+                {
+                    contentStack = cStack;
+                }
+                else
+                {
+                    errCode = "notpieable";
+                    errMessage = Lang.Get("This item can not be added to pies");
+                    return false;
+                }
+            }
+
+            if (InPieProperties.ReadFrom(contentStack) is not InPieProperties pieProps)
+            {
+                errCode = "notpieable";
+                errMessage = Lang.Get("This item can not be added to pies");
+                return false;
+            }
+
+            float totalPortions = contentStack.StackSize / pieProps.ItemsPerPortion();
+            if (totalPortions < 1)
+            {
+                errCode = "notenoughingredients";
+                errMessage = Lang.Get(container != null ? "piemaking-notenoughliquid" : "piemaking-notenoughitems", pieProps.GetPortionSize());
                 return false;
             }
 
@@ -268,89 +599,203 @@ namespace Vintagestory.GameContent
 
             ItemStack?[] cStacks = pieBlock.GetContents(Api.World, inv[0].Itemstack);
 
-            bool isFull = cStacks[1] != null && cStacks[2] != null && cStacks[3] != null && cStacks[4] != null;
-            bool hasFilling = cStacks[1] != null || cStacks[2] != null || cStacks[3] != null || cStacks[4] != null;
-
-            if (isFull)
+            // Special case:
+            // Using a knife or crust on a pie with a crust topping should succeed without an error,
+            // but the emptySlotIndex is still null because we aren't actually adding anything.
+            if (ToppingType is EnumPiePartType toppingType)
             {
-                if (pieProps.PartType == EnumPiePartType.Crust)
+                bool addingCrust = pieProps.PartType == EnumPiePartType.Crust;
+                EnumTool? tool = stack?.Collectible.GetTool(new DummySlot(stack));
+                bool usingCuttingTool = tool == EnumTool.Knife || tool == EnumTool.Sword;
+
+                if (toppingType == EnumPiePartType.Crust && (addingCrust || usingCuttingTool))
                 {
-                    if (cStacks[5] == null)
-                    {
-                        cStacks[5] = slot.TakeOut(2);
-                        pieBlock.SetContents(inv[0].Itemstack, cStacks);
-                        // crust attribute must exist to stack together
-                        inv[0].Itemstack.Attributes.SetString("topCrustType", "full");
-                    } else inv[0].Itemstack = BlockPie.CycleTopCrustType(inv[0].Itemstack);
                     return true;
                 }
-                if (byPlayer != null && capi != null) capi.TriggerIngameError(this, "piefullfilling", Lang.Get("Can't add more filling - already completely filled pie"));
-                return false;
-            }
-
-            if (pieProps.PartType != EnumPiePartType.Filling)
-            {
-                if (byPlayer != null && capi != null) capi.TriggerIngameError(this, "pieneedsfilling", Lang.Get("Need to add a filling next"));
-                return false;
-            }
-
-
-            if (!hasFilling)
-            {
-                cStacks[1] = slot.TakeOut(2);
-                pieBlock.SetContents(inv[0].Itemstack, cStacks);
-                return true;
-            }
-
-            var foodCats = cStacks.Select(BlockPie.FillingFoodCategory).ToArray();
-            var stackprops = cStacks.Select(stack => stack?.ItemAttributes?["inPieProperties"]?.AsObject<InPieProperties?>(null, stack.Collectible.Code.Domain)).ToArray();
-
-            ItemStack? cstack = slot.Itemstack;
-            EnumFoodCategory foodCat = BlockPie.FillingFoodCategory(cstack);
-
-            bool equal = true;
-            bool foodCatEquals = true;
-            bool allowMixing = true;
-            IEnumerable<string> mixCodes = pieProps.MixingCodes;
-
-            for (int i = 1; (equal || foodCatEquals || mixCodes.Any()) && i < cStacks.Length - 1; i++)
-            {
-                if (cstack == null) continue;
-
-                equal &= cStacks[i] == null || cstack.Equals(Api.World, cStacks[i], GlobalConstants.IgnoredStackAttributes);
-                foodCatEquals &= cStacks[i] == null || foodCats[i] == foodCat;
-                allowMixing &= stackprops[i]?.AllowMixing != false;
-                mixCodes = stackprops[i]?.MixingCodes.Intersect(mixCodes) ?? mixCodes;
-
-                cstack = cStacks[i];
-                foodCat = foodCats[i];
-            }
-
-            int emptySlotIndex = 2 + (cStacks[2] != null ? 1 + (cStacks[3] != null ? 1 : 0) : 0);
-
-            if (equal)
-            {
-                cStacks[emptySlotIndex] = slot.TakeOut(2);
-                pieBlock.SetContents(inv[0].Itemstack, cStacks);
-                return true;
-            }
-
-            if (!foodCatEquals && !mixCodes.Any())
-            {
-                if (byPlayer != null && capi != null) capi.TriggerIngameError(this, "piefullfilling", Lang.Get("piemaking-unabletomixingredient"));
-                return false;
-            } else
-            {
-                if (!allowMixing)
+                else
                 {
-                    if (byPlayer != null && capi != null) capi.TriggerIngameError(this, "piefullfilling", Lang.Get("piemaking-mixingnotallowed"));
+                    errCode = "piefinished";
+                    errMessage = Lang.Get("piemaking-alreadycomplete");
                     return false;
                 }
+            }
 
-                cStacks[emptySlotIndex] = slot.TakeOut(2);
-                pieBlock.SetContents(inv[0].Itemstack, cStacks);
+            if (HasAllFilling)
+            {
+                if (pieProps.PartType == EnumPiePartType.Filling)
+                {
+                    errCode = "piefullfilling";
+                    errMessage = Lang.Get("piemaking-alreadycomplete");
+                    return false;
+                }
+                else if (pieProps.PartType == EnumPiePartType.Crust)
+                {
+                    emptySlotIndex = 5;
+                    return true;
+                }
+            }
+
+            if (!HasAllFilling && pieProps.PartType != EnumPiePartType.Filling)
+            {
+                errCode = "pieneedsfilling";
+                errMessage = Lang.Get("Need to add a filling next");
+                return false;
+            }
+
+            if (!HasAnyFilling)
+            {
+                emptySlotIndex = 1;
                 return true;
             }
+
+            InPieProperties?[] stackPieProps = cStacks.Select(stack =>
+            {
+                InPieProperties? pieProps = InPieProperties.ReadFrom(stack);
+                if (stack != null && pieProps == null)
+                {
+                    // An ingredient already in a pie is missing its inPieProperties
+                    BlockPie.ReportMissingPieProps(Api.Logger, stack.Collectible.Code);
+                }
+                return pieProps;
+            }).ToArray();
+
+            bool singleIngredient = true;
+            bool allowMixing = pieProps.AllowMixing;
+            IEnumerable<string> mixCodes = pieProps.MixingCodes;
+
+            // Note that we check the topping slot here because non-crust toppings are restricted by mixing codes.
+            for (int i = 1; i < cStacks.Length; i++)
+            {
+                if (cStacks[i] == null) break;
+
+                singleIngredient &= cStacks[i]!.Equals(Api.World, stack, GlobalConstants.IgnoredStackAttributes);
+
+                if (stackPieProps[i] != null)
+                {
+                    allowMixing &= stackPieProps[i]!.AllowMixing == true || pieProps.PartType == EnumPiePartType.Topping;
+                    mixCodes = stackPieProps[i]!.MixingCodes.Intersect(mixCodes) ?? [];
+                }
+
+                if (!singleIngredient && !mixCodes.Any()) break;
+            }
+
+
+            if (!singleIngredient && !allowMixing)
+            {
+                errCode = "pienonmixable";
+                errMessage = Lang.Get("piemaking-mixingnotallowed");
+                return false;
+            }
+            else if (!singleIngredient && !mixCodes.Any())
+            {
+                if (pieProps.PartType == EnumPiePartType.Filling)
+                {
+                    errCode = "piemismatchedmix";
+                    errMessage = Lang.Get("piemaking-unabletomixingredient");
+                }
+                else
+                {
+                    errCode = "piemismatchedtopping";
+                    errMessage = Lang.Get("piemaking-unabletoaddtopping");
+                }
+                return false;
+            }
+
+            if (cStacks[4] != null) emptySlotIndex = 5;
+            else if (cStacks[3] != null) emptySlotIndex = 4;
+            else if (cStacks[2] != null) emptySlotIndex = 3;
+            else emptySlotIndex = 2;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Try to actually add an ingredient. Calls CanAddIngredient and emits error information in-game.
+        /// </summary>
+        /// <param name="slot">The player's held item slot.</param>
+        /// <returns>True if the ingredient was added successfully. False if it failed.</returns>
+        private bool TryAddIngredientFrom(ItemSlot slot, IPlayer byPlayer)
+        {
+            ICoreClientAPI? capi = Api as ICoreClientAPI;
+            ItemSlot takeFromSlot = byPlayer?.WorldData.CurrentGameMode == EnumGameMode.Creative ? new DummySlot(slot.Itemstack?.Clone()) : slot;
+
+            if (PieBlock == null || takeFromSlot.Itemstack == null) return false;
+
+            if (!CanAddIngredient(takeFromSlot.Itemstack, out int? emptySlotIndex, out string? errCode, out string? errMessage))
+            {
+                capi?.TriggerIngameError(this, errCode, errMessage);
+                return false;
+            }
+
+            ILiquidSource? container = takeFromSlot.Itemstack.Collectible.GetCollectibleInterface<ILiquidSource>();
+            ItemStack contentStack = takeFromSlot.Itemstack;
+            if (container?.GetContent(takeFromSlot.Itemstack) is ItemStack cStack)
+            {
+                contentStack = cStack;
+            }
+
+            // CanAddIngredient already made sure the pie props are valid
+            InPieProperties pieProps = InPieProperties.ReadFrom(contentStack)!;
+            if (pieProps.PartType == EnumPiePartType.Crust)
+            {
+                if (emptySlotIndex == null)
+                {
+                    // Using a knife to cycle crust type
+                    inv[0].Itemstack = BlockPie.CycleTopCrustType(inv[0].Itemstack);
+                    return true;
+                }
+
+                if (emptySlotIndex == 5)
+                {
+                    // Crust attribute must exist to stack together
+                    inv[0].Itemstack?.Attributes.SetString("topCrustType", "full");
+                }
+            }
+
+            ItemStack ingStack;
+            if (container != null)
+            {
+                if (container.TryTakeContent(takeFromSlot.Itemstack, pieProps.ItemsPerPortion()) is ItemStack taken && taken.StackSize >= pieProps.ItemsPerPortion())
+                {
+                    ingStack = contentStack.Clone();
+                    ingStack.StackSize = pieProps.ItemsPerPortion();
+                }
+                else
+                {
+                    Api.Logger.Error($"BEPie.TryAddIngredientFrom expected at least {pieProps.ItemsPerPortion()} liquid items, but there were only {takeFromSlot.Itemstack.StackSize}. There is likely a bug either here or in CanAddIngredient.");
+                    return false;
+                }
+            }
+            else
+            {
+                ingStack = takeFromSlot.TakeOut(pieProps.ItemsPerPortion());
+            }
+
+            ItemStack[] cStacks = PieBlock.GetContents(Api.World, inv[0].Itemstack);
+            int ingredientCount = cStacks.Where(stack => stack != null).Count();
+
+            // Average transition states before adding
+            float t = (float)1 / (1 + ingredientCount);
+            if (byPlayer?.Entity.World != null
+                && ingStack.Collectible.UpdateAndGetTransitionStates(byPlayer.Entity.World, new DummySlot(ingStack)) is TransitionState[] ingStates
+                && PieBlock.UpdateAndGetTransitionStates(byPlayer.Entity.World, inv[0]) is TransitionState[] pieStates)
+            {
+                for (int i = 0; i < ingStates.Length; i++)
+                {
+                    float totalIngHours = ingStates[i].FreshHours + ingStates[i].TransitionHours;
+                    float totalPieHours = pieStates[i].FreshHours + pieStates[i].TransitionHours;
+                    float scaledIngTransitionedHours = ingStates[i].TransitionedHours / (totalIngHours / totalPieHours);
+
+                    var avgTransitionedHours = scaledIngTransitionedHours * t + pieStates[i].TransitionedHours * (1 - t);
+                    //if (Api.Side.IsServer()) Api.Logger.Debug($"Averaged new ingredient: {ingStates[i].TransitionedHours / (totalIngHours / totalPieHours)} * {t} + {pieStates[i].TransitionedHours} * {1 - t}");
+                    PieBlock.SetTransitionState(inv[0].Itemstack, ingStates[i].Props.Type, avgTransitionedHours);
+                }
+            }
+
+            cStacks[(int)emptySlotIndex!] = ingStack;
+            PieBlock.SetContents(inv[0].Itemstack, cStacks);
+
+            return true;
         }
 
         public override bool OnTesselation(ITerrainMeshPool mesher, ITesselatorAPI tessThreadTesselator)
@@ -363,7 +808,7 @@ namespace Vintagestory.GameContent
         void loadMesh()
         {
             if (Api == null || Api.Side == EnumAppSide.Server || inv[0].Empty) return;
-            mesh = ms!.GetPieMesh(inv[0].Itemstack);
+            mesh = ms!.GetPieMesh(inv[0].Itemstack)!;
         }
 
         public override void GetBlockInfo(IPlayer forPlayer, StringBuilder dsc)

--- a/Item/ItemDough.cs
+++ b/Item/ItemDough.cs
@@ -1,39 +1,39 @@
-﻿using System.Collections.Generic;
+﻿using System.Linq;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Config;
 using Vintagestory.API.Util;
 
-#nullable disable
+#nullable enable
 
 namespace Vintagestory.GameContent
 {
     public class ItemDough : Item
     {
-        static ItemStack[] tableStacks;
+        static WorldInteraction[]? interactions = null;
 
         public override void OnLoaded(ICoreAPI api)
         {
-            if (tableStacks == null)
-            {
-                List<ItemStack> foundStacks = new List<ItemStack>();
-                api.World.Collectibles.ForEach(obj =>
-                {
-                    if (obj is Block block && block.Attributes?.IsTrue("pieFormingSurface") == true)
-                    {
-                        foundStacks.Add(new ItemStack(obj));
-                    }
-                });
+            base.OnLoaded(api);
 
-                tableStacks = foundStacks.ToArray();
+            if (api is ICoreClientAPI && interactions == null)
+            {
+                ItemStack[] tableStacks = api.World.Collectibles
+                    .Where(obj => (obj as Block)?.Attributes?.IsTrue("pieFormingSurface") == true)
+                    .Select(obj => new ItemStack(obj))
+                    .ToArray();
+
+                interactions = [
+                    new ()
+                    {
+                        ActionLangCode = "heldhelp-makepie",
+                        Itemstacks = tableStacks,
+                        HotKeyCode = "shift",
+                        MouseButton = EnumMouseButton.Right,
+                    }
+                ];
             }
         }
-
-        public override void OnUnloaded(ICoreAPI api)
-        {
-            tableStacks = null;
-        }
-
 
         public override void OnHeldInteractStart(ItemSlot slot, EntityAgent byEntity, BlockSelection blockSel, EntitySelection entitySel, bool firstEvent, ref EnumHandHandling handling)
         {
@@ -44,12 +44,11 @@ namespace Vintagestory.GameContent
                 {
                     if (slot.StackSize >= 2)
                     {
-                        BlockPie blockform = api.World.GetBlock(new AssetLocation("pie-raw")) as BlockPie;
-                        blockform.TryPlacePie(byEntity, blockSel);
-                    } else
+                        (api.World.GetBlock(new AssetLocation("pie-raw")) as BlockPie)?.TryPlacePie(byEntity, blockSel);
+                    }
+                    else
                     {
-                        ICoreClientAPI capi = api as ICoreClientAPI;
-                        if (capi != null) capi.TriggerIngameError(this, "notpieable", Lang.Get("Need at least 2 dough"));
+                        (api as ICoreClientAPI)?.TriggerIngameError(this, "notpieable", Lang.Get("Need at least 2 dough"));
                     }
 
                     handling = EnumHandHandling.PreventDefault;
@@ -62,15 +61,7 @@ namespace Vintagestory.GameContent
 
         public override WorldInteraction[] GetHeldInteractionHelp(ItemSlot inSlot)
         {
-            return new WorldInteraction[] {
-                new WorldInteraction()
-                {
-                    ActionLangCode = "heldhelp-makepie",
-                    Itemstacks = tableStacks,
-                    HotKeyCode = "shift",
-                    MouseButton = EnumMouseButton.Right,
-                }
-            }.Append(base.GetHeldInteractionHelp(inSlot));
+            return interactions!.Append(base.GetHeldInteractionHelp(inSlot));
         }
     }
 }

--- a/Item/ItemDough.cs
+++ b/Item/ItemDough.cs
@@ -4,8 +4,6 @@ using Vintagestory.API.Common;
 using Vintagestory.API.Config;
 using Vintagestory.API.Util;
 
-#nullable enable
-
 namespace Vintagestory.GameContent
 {
     public class ItemDough : Item

--- a/Item/ItemDough.cs
+++ b/Item/ItemDough.cs
@@ -37,9 +37,9 @@ namespace Vintagestory.GameContent
 
         public override void OnHeldInteractStart(ItemSlot slot, EntityAgent byEntity, BlockSelection blockSel, EntitySelection entitySel, bool firstEvent, ref EnumHandHandling handling)
         {
-            if (blockSel != null)
+            if (blockSel != null && byEntity.Controls.ShiftKey)
             {
-                var block = api.World.BlockAccessor.GetBlock(blockSel.Position);
+                Block block = api.World.BlockAccessor.GetBlock(blockSel.Position);
                 if (block.Attributes?.IsTrue("pieFormingSurface") == true)
                 {
                     if (slot.StackSize >= 2)

--- a/Item/ItemDough.cs
+++ b/Item/ItemDough.cs
@@ -1,11 +1,11 @@
 ﻿using System.Linq;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
-using Vintagestory.API.Config;
 using Vintagestory.API.Util;
 
 namespace Vintagestory.GameContent
 {
+    // The functionality for creating pies has been moved to BlockBehaviorPieFormingSurface
     public class ItemDough : Item
     {
         static WorldInteraction[]? interactions = null;
@@ -17,7 +17,7 @@ namespace Vintagestory.GameContent
             if (api is ICoreClientAPI && interactions == null)
             {
                 ItemStack[] tableStacks = api.World.Collectibles
-                    .Where(obj => (obj as Block)?.Attributes?.IsTrue("pieFormingSurface") == true)
+                    .Where(obj => (obj as Block)?.GetBehavior<BlockBehaviorPieFormingSurface>() != null)
                     .Select(obj => new ItemStack(obj))
                     .ToArray();
 
@@ -31,39 +31,6 @@ namespace Vintagestory.GameContent
                     }
                 ];
             }
-        }
-
-        public override void OnHeldInteractStart(ItemSlot slot, EntityAgent byEntity, BlockSelection blockSel, EntitySelection entitySel, bool firstEvent, ref EnumHandHandling handling)
-        {
-            if (blockSel != null && byEntity.Controls.ShiftKey)
-            {
-                Block block = api.World.BlockAccessor.GetBlock(blockSel.Position);
-                if (block.Attributes?.IsTrue("pieFormingSurface") == true)
-                {
-                    ICoreClientAPI? capi = api as ICoreClientAPI;
-                    InPieProperties? pieProps = InPieProperties.ReadFrom(slot.Itemstack);
-                    if (pieProps == null)
-                    {
-                        capi?.TriggerIngameError(this, "notpieable", Lang.Get("This item can not be added to pies"));
-                        api.Logger.Error($"Dough item {slot.Itemstack?.Collectible.Code} does not have inPieProperties. Cannot create the pie.");
-                        return;
-                    }
-
-                    if (slot.StackSize >= pieProps!.PortionSize)
-                    {
-                        (api.World.GetBlock(new AssetLocation("pie-raw")) as BlockPie)?.TryPlacePie(byEntity, blockSel);
-                    }
-                    else
-                    {
-                        capi?.TriggerIngameError(this, "notenoughingredients", Lang.Get("Need at least {0} dough", pieProps.PortionSize));
-                    }
-
-                    handling = EnumHandHandling.PreventDefault;
-                    return;
-                }
-            }
-
-            base.OnHeldInteractStart(slot, byEntity, blockSel, entitySel, firstEvent, ref handling);
         }
 
         public override WorldInteraction[] GetHeldInteractionHelp(ItemSlot inSlot)

--- a/Item/ItemDough.cs
+++ b/Item/ItemDough.cs
@@ -1,55 +1,61 @@
-﻿using System.Collections.Generic;
+﻿using System.Linq;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Config;
 using Vintagestory.API.Util;
 
-#nullable disable
-
 namespace Vintagestory.GameContent
 {
     public class ItemDough : Item
     {
-        static ItemStack[] tableStacks;
+        static WorldInteraction[]? interactions = null;
 
         public override void OnLoaded(ICoreAPI api)
         {
-            if (tableStacks == null)
-            {
-                List<ItemStack> foundStacks = new List<ItemStack>();
-                api.World.Collectibles.ForEach(obj =>
-                {
-                    if (obj is Block block && block.Attributes?.IsTrue("pieFormingSurface") == true)
-                    {
-                        foundStacks.Add(new ItemStack(obj));
-                    }
-                });
+            base.OnLoaded(api);
 
-                tableStacks = foundStacks.ToArray();
+            if (api is ICoreClientAPI && interactions == null)
+            {
+                ItemStack[] tableStacks = api.World.Collectibles
+                    .Where(obj => (obj as Block)?.Attributes?.IsTrue("pieFormingSurface") == true)
+                    .Select(obj => new ItemStack(obj))
+                    .ToArray();
+
+                interactions = [
+                    new ()
+                    {
+                        ActionLangCode = "heldhelp-makepie",
+                        Itemstacks = tableStacks,
+                        HotKeyCode = "shift",
+                        MouseButton = EnumMouseButton.Right,
+                    }
+                ];
             }
         }
 
-        public override void OnUnloaded(ICoreAPI api)
-        {
-            tableStacks = null;
-        }
-
-
         public override void OnHeldInteractStart(ItemSlot slot, EntityAgent byEntity, BlockSelection blockSel, EntitySelection entitySel, bool firstEvent, ref EnumHandHandling handling)
         {
-            if (blockSel != null)
+            if (blockSel != null && byEntity.Controls.ShiftKey)
             {
-                var block = api.World.BlockAccessor.GetBlock(blockSel.Position);
+                Block block = api.World.BlockAccessor.GetBlock(blockSel.Position);
                 if (block.Attributes?.IsTrue("pieFormingSurface") == true)
                 {
-                    if (slot.StackSize >= 2)
+                    ICoreClientAPI? capi = api as ICoreClientAPI;
+                    InPieProperties? pieProps = InPieProperties.ReadFrom(slot.Itemstack);
+                    if (pieProps == null)
                     {
-                        BlockPie blockform = api.World.GetBlock(new AssetLocation("pie-raw")) as BlockPie;
-                        blockform.TryPlacePie(byEntity, blockSel);
-                    } else
+                        capi?.TriggerIngameError(this, "notpieable", Lang.Get("This item can not be added to pies"));
+                        api.Logger.Error($"Dough item {slot.Itemstack?.Collectible.Code} does not have inPieProperties. Cannot create the pie.");
+                        return;
+                    }
+
+                    if (slot.StackSize >= pieProps!.PortionSize)
                     {
-                        ICoreClientAPI capi = api as ICoreClientAPI;
-                        if (capi != null) capi.TriggerIngameError(this, "notpieable", Lang.Get("Need at least 2 dough"));
+                        (api.World.GetBlock(new AssetLocation("pie-raw")) as BlockPie)?.TryPlacePie(byEntity, blockSel);
+                    }
+                    else
+                    {
+                        capi?.TriggerIngameError(this, "notenoughingredients", Lang.Get("Need at least {0} dough", pieProps.PortionSize));
                     }
 
                     handling = EnumHandHandling.PreventDefault;
@@ -62,15 +68,7 @@ namespace Vintagestory.GameContent
 
         public override WorldInteraction[] GetHeldInteractionHelp(ItemSlot inSlot)
         {
-            return new WorldInteraction[] {
-                new WorldInteraction()
-                {
-                    ActionLangCode = "heldhelp-makepie",
-                    Itemstacks = tableStacks,
-                    HotKeyCode = "shift",
-                    MouseButton = EnumMouseButton.Right,
-                }
-            }.Append(base.GetHeldInteractionHelp(inSlot));
+            return interactions!.Append(base.GetHeldInteractionHelp(inSlot));
         }
     }
 }

--- a/Item/ItemEgg.cs
+++ b/Item/ItemEgg.cs
@@ -3,8 +3,6 @@ using Vintagestory.API.Common;
 using Vintagestory.API.Config;
 using Vintagestory.API.Datastructures;
 
-#nullable enable
-
 namespace Vintagestory.GameContent
 {
     public class ItemEgg : Item

--- a/Systems/Cooking/BlockCookedContainer.cs
+++ b/Systems/Cooking/BlockCookedContainer.cs
@@ -128,7 +128,7 @@ namespace Vintagestory.GameContent
             CookingRecipe? recipe = GetCookingRecipe(capi.World, itemstack);
             ItemStack[] contents = GetNonEmptyContents(capi.World, itemstack);
 
-            MultiTextureMeshRef? meshref = meshCache.GetOrCreateMealInContainerMeshRef(this, recipe, contents, new Vec3f(0, yoff/16f, 0));
+            MultiTextureMeshRef? meshref = meshCache.GetOrCreateMealInContainerMeshRef(this, recipe, contents, new Vec3f(0, yoff / 16f, 0));
             if (meshref != null) renderinfo.ModelRef = meshref;
         }
 
@@ -259,7 +259,8 @@ namespace Vintagestory.GameContent
                             world.SpawnItemEntity(stacks[i], entityItem.Pos.XYZ);
                         }
                     }
-                } else
+                }
+                else
                 {
                     ItemStack rndStack = stacks[world.Rand.Next(stacks.Length)];
                     world.SpawnCubeParticles(entityItem.Pos.XYZ, rndStack, 0.3f, 25, 1, null);
@@ -322,10 +323,6 @@ namespace Vintagestory.GameContent
             if (inSlot.Itemstack is not ItemStack cookedContStack) return;
             base.GetHeldItemInfo(inSlot, dsc, world, withDebugInfo);
             float temp = GetTemperature(world, cookedContStack);
-            if (temp > 20)
-            {
-                dsc.AppendLine(Lang.Get("Temperature: {0}°C", (int)temp));
-            }
 
             CookingRecipe? recipe = GetMealRecipe(world, cookedContStack);
             float servings = cookedContStack.Attributes.GetFloat("quantityServings");
@@ -333,7 +330,8 @@ namespace Vintagestory.GameContent
             ItemStack[] stacks = GetNonEmptyContents(world, cookedContStack);
 
 
-            if (recipe != null) {
+            if (recipe != null)
+            {
                 string message;
                 string outputName = recipe.GetOutputName(world, stacks);
                 if (recipe.CooksInto != null)

--- a/Systems/Cooking/BlockMeal.cs
+++ b/Systems/Cooking/BlockMeal.cs
@@ -693,9 +693,9 @@ namespace Vintagestory.GameContent
                 sb.AppendLine(Lang.Get("nutrition-facts-line-satiety", Lang.Get("foodcategory-" + val.Key.ToString().ToLowerInvariant()), Math.Round(val.Value)));
             }
 
-            if (totalHealth != 0)
+            if (Math.Round(totalHealth, 2) != 0)
             {
-                sb.AppendLine("- " + Lang.Get("Health: {0}{1} hp", totalHealth > 0 ? "+" : "", totalHealth));
+                sb.AppendLine("- " + Lang.Get("Health: {0}{1} hp", totalHealth > 0 ? "+" : "", Math.Round(totalHealth, 2)));
             }
 
             return sb.ToString();

--- a/Systems/Cooking/BlockMeal.cs
+++ b/Systems/Cooking/BlockMeal.cs
@@ -685,6 +685,7 @@ namespace Vintagestory.GameContent
             }
 
             StringBuilder sb = new StringBuilder();
+            sb.AppendLine(Lang.Get("When eaten: {0} sat", Math.Round(totalSaturation.Values.Sum())));
             sb.AppendLine(Lang.Get("Nutrition Facts"));
 
             foreach (var val in totalSaturation)

--- a/Systems/Cooking/BlockMeal.cs
+++ b/Systems/Cooking/BlockMeal.cs
@@ -333,15 +333,19 @@ namespace Vintagestory.GameContent
                 }
                 else
                 {
-                    ItemStack? splitStack = slot.TakeOut(1);
-                    (foodSourceStack.Collectible as BlockMeal)?.SetQuantityServings(byEntity.World, splitStack, servingsLeft);
+                    ItemStack? partiallyEatenStack = slot.TakeOut(1);
+                    (foodSourceStack.Collectible as BlockMeal)?.SetQuantityServings(byEntity.World, partiallyEatenStack, servingsLeft);
 
-                    ItemStack originalStack = slot.Itemstack;
-                    slot.Itemstack = splitStack;
+                    ItemStack fullMealsStack = slot.TakeOutWhole();
+                    slot.Itemstack = partiallyEatenStack;
 
-                    if (!player.InventoryManager.TryGiveItemstack(originalStack, true))
+                    if (!player.InventoryManager.TryGiveItemstack(fullMealsStack, true))
                     {
-                        byEntity.World.SpawnItemEntity(originalStack, byEntity.Pos.XYZ);
+                        // If the player doesn't have an empty slot, make sure we give them
+                        // the stack of full meals instead of dropping everything except
+                        // the partially eaten one.
+                        slot.Itemstack = fullMealsStack;
+                        byEntity.World.SpawnItemEntity(partiallyEatenStack, byEntity.Pos.XYZ);
                     }
                 }
             }

--- a/Systems/Cooking/BlockMeal.cs
+++ b/Systems/Cooking/BlockMeal.cs
@@ -808,11 +808,6 @@ namespace Vintagestory.GameContent
         {
             if (inSlot.Itemstack is not ItemStack mealStack) return;
             base.GetHeldItemInfo(inSlot, dsc, world, withDebugInfo);
-            float temp = GetTemperature(world, mealStack);
-            if (temp > 20)
-            {
-                dsc.AppendLine(Lang.Get("Temperature: {0}°C", (int)temp));
-            }
 
             CookingRecipe? recipe = GetCookingRecipe(world, mealStack);
 

--- a/Systems/Cooking/BlockMeal.cs
+++ b/Systems/Cooking/BlockMeal.cs
@@ -297,7 +297,8 @@ namespace Vintagestory.GameContent
                 servingsLeft = Consume(byEntity.World, player, slot, stacks, servingsLeft, string.IsNullOrEmpty(recipeCode));
             }
 
-            if (servingsLeft <= 0)
+            // Delete tiny servings
+            if (servingsLeft < 0.01)
             {
                 if (handleAllServingsConsumed)
                 {

--- a/Systems/Cooking/BlockMeal.cs
+++ b/Systems/Cooking/BlockMeal.cs
@@ -138,7 +138,7 @@ namespace Vintagestory.GameContent
 
         protected virtual bool tryHeldBeginEatMeal(ItemSlot slot, EntityAgent byEntity, ref EnumHandHandling handHandling)
         {
-            if (!byEntity.Controls.ShiftKey && GetContentNutritionProperties(api.World, slot, byEntity) != null)
+            if (GetContentNutritionProperties(api.World, slot, byEntity) != null)
             {
                 byEntity.World.RegisterCallback((dt) =>
                 {

--- a/Systems/Cooking/BlockMeal.cs
+++ b/Systems/Cooking/BlockMeal.cs
@@ -62,7 +62,8 @@ namespace Vintagestory.GameContent
 
             if (CollisionBoxes[0] != null) gsSmokePos.Y = CollisionBoxes[0].MaxY;
 
-            BlockMeal[] mealBowls = ObjectCacheUtil.GetOrCreate(api, "allMealBowls", () => {
+            BlockMeal[] mealBowls = ObjectCacheUtil.GetOrCreate(api, "allMealBowls", () =>
+            {
                 List<BlockMeal> mealList = new();
                 foreach (var b in api.World.Blocks)
                 {
@@ -922,7 +923,8 @@ namespace Vintagestory.GameContent
                             world.SpawnItemEntity(stacks[i], entityItem.Pos.XYZ);
                         }
                     }
-                } else
+                }
+                else
                 {
                     ItemStack rndStack = stacks[world.Rand.Next(stacks.Length)];
                     world.SpawnCubeParticles(entityItem.Pos.XYZ, rndStack, 0.3f, 25, 1, null);

--- a/Systems/Cooking/BlockMeal.cs
+++ b/Systems/Cooking/BlockMeal.cs
@@ -9,6 +9,8 @@ using Vintagestory.API.Config;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Util;
 
+#nullable enable
+
 namespace Vintagestory.GameContent
 {
     public interface IBlockMealContainer

--- a/Systems/Cooking/BlockMeal.cs
+++ b/Systems/Cooking/BlockMeal.cs
@@ -9,8 +9,6 @@ using Vintagestory.API.Config;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Util;
 
-#nullable enable
-
 namespace Vintagestory.GameContent
 {
     public interface IBlockMealContainer

--- a/Systems/Cooking/BlockMeal.cs
+++ b/Systems/Cooking/BlockMeal.cs
@@ -140,7 +140,8 @@ namespace Vintagestory.GameContent
 
         protected virtual bool tryHeldBeginEatMeal(ItemSlot slot, EntityAgent byEntity, ref EnumHandHandling handHandling)
         {
-            if (GetContentNutritionProperties(api.World, slot, byEntity) != null)
+            bool shouldGroundStore = byEntity.Controls.ShiftKey && (byEntity as EntityPlayer)?.BlockSelection != null;
+            if (!shouldGroundStore && GetContentNutritionProperties(api.World, slot, byEntity) != null)
             {
                 byEntity.World.RegisterCallback((dt) =>
                 {

--- a/Systems/Cooking/BlockMeal.cs
+++ b/Systems/Cooking/BlockMeal.cs
@@ -587,10 +587,10 @@ namespace Vintagestory.GameContent
 
                 float spoilState = 0;
                 DummySlot slot = new DummySlot(contentStack, inSlot.Inventory);
-                if (!timeFrozen)
+                // Pie contents do not transition
+                if (!timeFrozen && inSlot.Itemstack.Block is not BlockPie)
                 {
-                    TransitionState? state = contentStack.Collectible.UpdateAndGetTransitionState(world, slot, EnumTransitionType.Perish);
-                    spoilState = state != null ? state.TransitionLevel : 0;
+                    spoilState = contentStack.Collectible.UpdateAndGetTransitionState(world, slot, EnumTransitionType.Perish)?.TransitionLevel ?? 0;
                 }
 
                 float satLossMul = GlobalConstants.FoodSpoilageSatLossMul(spoilState, mealStack, forEntity);

--- a/Systems/Cooking/BlockMeal.cs
+++ b/Systems/Cooking/BlockMeal.cs
@@ -62,7 +62,8 @@ namespace Vintagestory.GameContent
 
             if (CollisionBoxes[0] != null) gsSmokePos.Y = CollisionBoxes[0].MaxY;
 
-            BlockMeal[] mealBowls = ObjectCacheUtil.GetOrCreate(api, "allMealBowls", () => {
+            BlockMeal[] mealBowls = ObjectCacheUtil.GetOrCreate(api, "allMealBowls", () =>
+            {
                 List<BlockMeal> mealList = new();
                 foreach (var b in api.World.Blocks)
                 {
@@ -582,10 +583,10 @@ namespace Vintagestory.GameContent
 
                 float spoilState = 0;
                 DummySlot slot = new DummySlot(contentStack, inSlot.Inventory);
-                if (!timeFrozen)
+                // Pie contents do not transition
+                if (!timeFrozen && inSlot.Itemstack.Block is not BlockPie)
                 {
-                    TransitionState? state = contentStack.Collectible.UpdateAndGetTransitionState(world, slot, EnumTransitionType.Perish);
-                    spoilState = state != null ? state.TransitionLevel : 0;
+                    spoilState = contentStack.Collectible.UpdateAndGetTransitionState(world, slot, EnumTransitionType.Perish)?.TransitionLevel ?? 0;
                 }
 
                 float satLossMul = GlobalConstants.FoodSpoilageSatLossMul(spoilState, mealStack, forEntity);
@@ -922,7 +923,8 @@ namespace Vintagestory.GameContent
                             world.SpawnItemEntity(stacks[i], entityItem.Pos.XYZ);
                         }
                     }
-                } else
+                }
+                else
                 {
                     ItemStack rndStack = stacks[world.Rand.Next(stacks.Length)];
                     world.SpawnCubeParticles(entityItem.Pos.XYZ, rndStack, 0.3f, 25, 1, null);

--- a/Systems/Cooking/Clayoven/BEClayOven.cs
+++ b/Systems/Cooking/Clayoven/BEClayOven.cs
@@ -184,6 +184,11 @@ namespace Vintagestory.GameContent
 
                 if (colObj.Attributes?.IsTrue("isClayOvenFuel") == true)
                 {
+                    if (byPlayer.WorldData.CurrentGameMode == EnumGameMode.Creative)
+                    {
+                        slot = new DummySlot(slot.Itemstack.Clone());
+                    }
+
                     if (TryAddFuel(slot))
                     {
                         SoundAttributes? sound = slot.Itemstack?.Block?.Sounds?.Place;
@@ -780,7 +785,7 @@ namespace Vintagestory.GameContent
                     break;
                 case EnumOvenContentMode.Quadrants:
                     // Top left
-                    offs[0] = new Vec3f(-2/16f, 1 / 16f, -2.5f / 16f);
+                    offs[0] = new Vec3f(-2 / 16f, 1 / 16f, -2.5f / 16f);
                     // Top right
                     offs[1] = new Vec3f(-2 / 16f, 1 / 16f, 2.5f / 16f);
                     // Bot left
@@ -789,7 +794,7 @@ namespace Vintagestory.GameContent
                     offs[3] = new Vec3f(3 / 16f, 1 / 16f, 2.5f / 16f);
                     break;
                 case EnumOvenContentMode.SingleCenter:
-                    offs[0] = new Vec3f(0, 1/16f, 0);
+                    offs[0] = new Vec3f(0, 1 / 16f, 0);
                     break;
             }
 

--- a/Systems/Cooking/Clayoven/BEClayOven.cs
+++ b/Systems/Cooking/Clayoven/BEClayOven.cs
@@ -166,7 +166,8 @@ namespace Vintagestory.GameContent
 
         public virtual bool OnInteract(IPlayer byPlayer, BlockSelection bs)
         {
-            ItemSlot slot = byPlayer.InventoryManager.ActiveHotbarSlot;
+            ItemSlot hotbarSlot = byPlayer.InventoryManager.ActiveHotbarSlot;
+            ItemSlot slot = byPlayer.WorldData.CurrentGameMode == EnumGameMode.Creative ? new DummySlot(hotbarSlot.Itemstack?.Clone()) : hotbarSlot;
 
             if (slot.Empty)
             {
@@ -780,7 +781,7 @@ namespace Vintagestory.GameContent
                     break;
                 case EnumOvenContentMode.Quadrants:
                     // Top left
-                    offs[0] = new Vec3f(-2/16f, 1 / 16f, -2.5f / 16f);
+                    offs[0] = new Vec3f(-2 / 16f, 1 / 16f, -2.5f / 16f);
                     // Top right
                     offs[1] = new Vec3f(-2 / 16f, 1 / 16f, 2.5f / 16f);
                     // Bot left
@@ -789,7 +790,7 @@ namespace Vintagestory.GameContent
                     offs[3] = new Vec3f(3 / 16f, 1 / 16f, 2.5f / 16f);
                     break;
                 case EnumOvenContentMode.SingleCenter:
-                    offs[0] = new Vec3f(0, 1/16f, 0);
+                    offs[0] = new Vec3f(0, 1 / 16f, 0);
                     break;
             }
 

--- a/Systems/Cooking/CookingRecipe.cs
+++ b/Systems/Cooking/CookingRecipe.cs
@@ -28,7 +28,7 @@ namespace Vintagestory.GameContent
         /// <returns>The name of the food type.</returns>
         public string GetNameForIngredients(IWorldAccessor worldForResolve, string recipeCode, ItemStack[] stacks)
         {
-            API.Datastructures.OrderedDictionary<ItemStack, int> quantitiesByStack = new ();
+            API.Datastructures.OrderedDictionary<ItemStack, int> quantitiesByStack = new();
             quantitiesByStack = mergeStacks(worldForResolve, stacks);
 
             CookingRecipe recipe = worldForResolve.Api.GetCookingRecipe(recipeCode);
@@ -529,7 +529,7 @@ namespace Vintagestory.GameContent
 
         protected static API.Datastructures.OrderedDictionary<ItemStack, int> mergeStacks(IWorldAccessor worldForResolve, ItemStack[] stacks)
         {
-            API.Datastructures.OrderedDictionary<ItemStack, int> dict = new ();
+            API.Datastructures.OrderedDictionary<ItemStack, int> dict = new();
 
             List<ItemStack> stackslist = [.. stacks];
             while (stackslist.Count > 0)
@@ -742,7 +742,8 @@ namespace Vintagestory.GameContent
 
                         if (BlockLiquidContainerBase.GetContainableProps(inputStack) is WaterTightContainableProps props)
                         {
-                            stackPortion = (int)(inputStack.StackSize / jstack.StackSize / props.ItemsPerLitre / ingred.PortionSizeLitres);
+                            // Casting to float is necessary if the stack size ratio is not a whole number
+                            stackPortion = (int)((float)inputStack.StackSize / jstack.StackSize / props.ItemsPerLitre / ingred.PortionSizeLitres);
                         }
 
                         totalOutputQuantity = Math.Min(totalOutputQuantity, stackPortion);
@@ -773,7 +774,10 @@ namespace Vintagestory.GameContent
                 int jStackSize = GetIngrendientFor(stack)?.GetMatchingStack(stack)?.StackSize ?? 1;
                 if (BlockLiquidContainerBase.GetContainableProps(stack) is WaterTightContainableProps props)
                 {
-                    if (stack.StackSize / jStackSize != (int)(quantityServings * props.ItemsPerLitre * (GetIngrendientFor(stack)?.PortionSizeLitres ?? 100))) quantityServings = -1;
+                    // See SurvivalHandbook.CreateCachedMealRecipeStacks
+                    int wantItems = stack.StackSize / jStackSize;
+                    int haveItems = (int)Math.Ceiling(quantityServings * props.ItemsPerLitre * (GetIngrendientFor(stack)?.PortionSizeLitres ?? 100));
+                    if (wantItems != haveItems) quantityServings = -1;
                 }
                 else if (stack.StackSize / jStackSize != quantityServings) quantityServings = -1;
 
@@ -851,8 +855,10 @@ namespace Vintagestory.GameContent
 
             List<ItemStack?> randomMeal = new();
 
-            while (!Matches(randomMeal.ToArray()))
+            int limit = 0;
+            while (!Matches(randomMeal.ToArray()) && limit < 10)
             {
+                limit++;
                 var valIngStacks = new Dictionary<CookingRecipeIngredient, List<ItemStack?>>();
                 foreach (var entry in validStacksByIngredient) valIngStacks.Add(entry.Key.Clone(), entry.Value.ToList());
                 valIngStacks = valIngStacks.OrderBy(x => api.World.Rand.Next()).ToDictionary(item => item.Key, item => item.Value);

--- a/Systems/Cooking/MealMeshCache.cs
+++ b/Systems/Cooking/MealMeshCache.cs
@@ -161,6 +161,7 @@ namespace Vintagestory.GameContent
             if (nowTesselatingBlock == null) return null;  //This will occur if the pieStack changed to rot
 
             contentStacks = nowTesselatingBlock.GetContents(capi!.World, pieStack);
+            if (contentStacks.Length == 0) return null;
 
             int pieSize = pieStack?.Attributes.GetAsInt("pieSize") ?? 0;
             if (pieSize <= 0 || pieSize > 4) return null; // Prevent bad array access crash for pies with incorrect sizes
@@ -379,7 +380,7 @@ namespace Vintagestory.GameContent
                     {
                         source.ForStack = contentStacks[0]!;
 
-                        CompositeShape? cshape = contentStacks[0]!.ItemAttributes["inBowlShape"]?.AsObject(new CompositeShape() { Base = new ("shapes/block/food/meal/pickled.json") });
+                        CompositeShape? cshape = contentStacks[0]!.ItemAttributes["inBowlShape"]?.AsObject(new CompositeShape() { Base = new("shapes/block/food/meal/pickled.json") });
 
                         Shape contentShape = API.Common.Shape.TryGet(capi, cshape?.Base.WithPathAppendixOnce(".json").WithPathPrefixOnce("shapes/"));
                         capi!.Tesselator.TesselateShape("picklednmealcontents", contentShape, out MeshData contentMesh, source);

--- a/Systems/Cooking/MealMeshCache.cs
+++ b/Systems/Cooking/MealMeshCache.cs
@@ -163,6 +163,7 @@ namespace Vintagestory.GameContent
             contentStacks = nowTesselatingBlock.GetContents(capi!.World, pieStack);
 
             int pieSize = pieStack?.Attributes.GetAsInt("pieSize") ?? 0;
+            if (pieSize <= 0 || pieSize > 4) return null; // Prevent bad array access crash for pies with incorrect sizes
 
 
             // At this spot we have to determine the textures for "dough" and "filling"

--- a/Systems/Cooking/MealMeshCache.cs
+++ b/Systems/Cooking/MealMeshCache.cs
@@ -9,6 +9,7 @@ using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Util;
 
+#nullable enable
 
 namespace Vintagestory.GameContent
 {
@@ -153,91 +154,58 @@ namespace Vintagestory.GameContent
 
         public MeshData? GetPieMesh(ItemStack? pieStack, ModelTransform? transform = null)
         {
-            // Slot 0: Base dough
-            // Slot 1: Filling
-            // Slot 2: Crust dough
-
             nowTesselatingBlock = pieStack?.Block as BlockPie;
-            if (nowTesselatingBlock == null) return null;  //This will occur if the pieStack changed to rot
+            if (nowTesselatingBlock == null) return null;  // This will occur if the pieStack changed to rot.
 
             contentStacks = nowTesselatingBlock.GetContents(capi!.World, pieStack);
-            if (contentStacks.Length == 0) return null;
+            if (contentStacks.Length < 6) return null; // Pies are supposed to always have 6 stacks.
 
             int pieSize = pieStack?.Attributes.GetAsInt("pieSize") ?? 0;
-            if (pieSize <= 0 || pieSize > 4) return null; // Prevent bad array access crash for pies with incorrect sizes
+            if (pieSize <= 0 || pieSize > 4) return null; // Prevent bad array access crash for pies with invalid sizes.
 
-
-            // At this spot we have to determine the textures for "dough" and "filling"
-            // Texture determination rules:
-            // 1. dough is simple: first itemstack must be dough, take from attributes
-            // 2. pie allows 4 items as fillings, but with specific mixing rules
-            //    - berries/fruit can be mixed
-            //    - vegetables can be mixed
-            //    - meat can be mixed
-            // no other mixing allowed
-
-            // Thus we deduce: It's enough to test if
-            // a) all 4 fillings are equal: Then use texture from inPieProperties from first one
-            // b) Otherwise use hardcoded
-            //    for item.NutritionProps.FoodCategory == Vegetable   => block/food/pie/fill-mixedvegetable.png
-            //    for item.NutritionProps.FoodCategory == Protein   => block/food/pie/fill-mixedmeat.png
-            //    for item.NutritionProps.FoodCategory == Fruit   => block/food/pie/fill-mixedfruit.png
-
-            var stackprops = contentStacks.Select(InPieProperties.ReadFrom).ToArray();
+            // This is where we find the dough and filling textures.
+            //
+            // For dough, the texture is taken from the attributes. Vanilla doughs
+            // use the path "block/food/pie/{type}{bakeLevel}"
+            //
+            // For filling, we need to check whether the pie is single-ingredient. If not,
+            // we look for the texture named after the first mixing code.
+            //
+            // Single-ingredient: "block/food/pie/fill-<name>.png"
+            // By mixing code: "block/food/pie/fill-mixed<tag>.png"
 
             int bakeLevel = pieStack?.Attributes.GetAsInt("bakeLevel", 0) ?? 0;
+            InPieProperties[] stackPieProps = contentStacks.Select(InPieProperties.ReadFrom).ToArray()!;
 
-            if (stackprops.Length == 0) return null;
-
-
-            ItemStack cstack = contentStacks[1];
-            var foodCats = contentStacks.Select(BlockPie.IngredientFoodCategory).ToArray();
-            EnumFoodCategory foodCat = foodCats[1];
-
-            bool equal = true;
-            bool foodCatEquals = true;
-            IEnumerable<string> mixCodes = stackprops[1]?.MixingCodes ?? [];
-            for (int i = 2; (equal || foodCatEquals || mixCodes.Any()) && i < contentStacks.Length - 1; i++)
+            bool singleIngredient = true;
+            IEnumerable<string> mixCodes = stackPieProps[1].MixingCodes ?? [];
+            for (int i = 2; i < contentStacks.Length - 1; i++)
             {
-                if (contentStacks[i] == null || cstack == null) continue;
+                if (contentStacks[i] == null) continue;
 
-                equal &= cstack.Equals(capi.World, contentStacks[i], GlobalConstants.IgnoredStackAttributes);
-                foodCatEquals &= contentStacks[i] == null || foodCats[i] == foodCats[1];
-                mixCodes = stackprops[i]?.MixingCodes.Intersect(mixCodes) ?? [];
+                singleIngredient &= contentStacks[1].Equals(capi.World, contentStacks[i], GlobalConstants.IgnoredStackAttributes);
+                mixCodes = stackPieProps[i].MixingCodes.Intersect(mixCodes) ?? [];
 
-                cstack = contentStacks[i];
-                foodCat = foodCats[i];
+                if (!singleIngredient && !mixCodes.Any()) break;
             }
 
-
-            if (ContentsRotten(contentStacks))
+            if (stackPieProps[0] != null)
             {
-                crustTextureLoc = new AssetLocation("block/rot/rot");
-                fillingTextureLoc = new AssetLocation("block/rot/rot");
-                topCrustTextureLoc = new AssetLocation("block/rot/rot");
+                crustTextureLoc = stackPieProps[0]!.Texture.Clone();
+                crustTextureLoc.Path = crustTextureLoc.Path.Replace("{bakelevel}", "" + (bakeLevel + 1));
+                fillingTextureLoc = new AssetLocation("block/transparent");
             }
-            else
+
+            topCrustTextureLoc = new AssetLocation("block/transparent");
+            if (stackPieProps[5] != null)
             {
-                if (stackprops[0] != null)
-                {
-                    crustTextureLoc = stackprops[0]!.Texture.Clone();
-                    crustTextureLoc.Path = crustTextureLoc.Path.Replace("{bakelevel}", "" + (bakeLevel + 1));
-                    fillingTextureLoc = new AssetLocation("block/transparent");
-                }
+                topCrustTextureLoc = stackPieProps[5]!.Texture.Clone();
+                topCrustTextureLoc.Path = topCrustTextureLoc.Path.Replace("{bakelevel}", "" + (bakeLevel + 1));
+            }
 
-                topCrustTextureLoc = new AssetLocation("block/transparent");
-                if (stackprops[5] != null)
-                {
-                    topCrustTextureLoc = stackprops[5]!.Texture.Clone();
-                    topCrustTextureLoc.Path = topCrustTextureLoc.Path.Replace("{bakelevel}", "" + (bakeLevel + 1));
-                }
-
-                if (contentStacks[1] != null)
-                {
-                    var fillingCat = foodCats[1];
-                    if (fillingCat == EnumFoodCategory.NoNutrition) fillingCat = EnumFoodCategory.Unknown;
-                    fillingTextureLoc = getPieFillingTexture(stackprops, mixCodes.ToArray(), equal, foodCatEquals, fillingCat);
-                }
+            if (contentStacks[1] != null)
+            {
+                fillingTextureLoc = getPieFillingTexture(stackPieProps, mixCodes.FirstOrDefault(), singleIngredient);
             }
 
 
@@ -259,32 +227,23 @@ namespace Vintagestory.GameContent
         }
 
         public Dictionary<int, AssetLocation> pieMixingCodeFillingTextures = [];
-        private AssetLocation? getPieFillingTexture(InPieProperties?[] pieProps, string[] mixingCodes, bool singleFilling, bool singleFoodCat, EnumFoodCategory fillingCat)
+        private AssetLocation? getPieFillingTexture(InPieProperties?[] pieProps, string? mixingCode, bool singleIngredient)
         {
-            if (singleFilling) return pieProps[1]?.Texture;
+            // Correct for the actual file name
+            if (mixingCode == "protein") mixingCode = "meat";
+            if (mixingCode == "dairy") mixingCode = "cheese";
 
-            if (!singleFoodCat && mixingCodes.Length > 0)
+            if (singleIngredient) return pieProps[1]?.Texture;
+            if (mixingCode == null) return new("block/food/pie/fill-unknown");
+
+            if (!pieMixingCodeFillingTextures.TryGetValue(mixingCode.GetHashCode(), out AssetLocation? loc))
             {
-                if (pieMixingCodeFillingTextures.TryGetValue(mixingCodes[0].GetHashCode(), out var loc))
-                {
-                    return loc;
-                }
-                else pieMixingCodeFillingTextures.Add(mixingCodes[0].GetHashCode(), new("block/food/pie/fill-mixed" + mixingCodes[0]));
+                loc = new("block/food/pie/fill-mixed" + mixingCode);
+                pieMixingCodeFillingTextures.Add(mixingCode.GetHashCode(), loc);
             }
 
-            return pieMixedCategoryFillingTextures[(int)fillingCat];
+            return loc;
         }
-
-
-        public AssetLocation[] pieMixedCategoryFillingTextures = [
-            new ("block/food/pie/fill-mixedfruit"),
-            new ("block/food/pie/fill-mixedvegetable"),
-            new ("block/food/pie/fill-mixedmeat"),
-            new ("block/food/pie/fill-mixedgrain"),
-            new ("block/food/pie/fill-mixedcheese"),
-            new ("block/food/pie/fill-unknown")
-        ];
-
 
         public Dictionary<int, MultiTextureMeshRef> GetCookedMeshRefs()
         {

--- a/Systems/Cooking/MealMeshCache.cs
+++ b/Systems/Cooking/MealMeshCache.cs
@@ -223,7 +223,15 @@ namespace Vintagestory.GameContent
             shapeloc.WithPathAppendixOnce(".json").WithPathPrefixOnce("shapes/");
             Shape shape = API.Common.Shape.TryGet(capi, shapeloc);
 
-            string topCrustShapeElement = BlockPie.TopCrustTypes.First(type => type.Code.EqualsFast(BlockPie.GetTopCrustType(pieStack) ?? "full")).ShapeElement;
+            string topCrustShapeElement;
+            if (stackPieProps[5]?.ToppingShapeElement is string toppingShapeElement)
+            {
+                topCrustShapeElement = toppingShapeElement;
+            }
+            else
+            {
+                topCrustShapeElement = BlockPie.TopCrustTypes.First(type => type.Code.EqualsFast(BlockPie.GetTopCrustType(pieStack) ?? "full")).ShapeElement;
+            }
             string[] selectiveElements = ["origin/base/crust regular/*", "origin/base/filling/*", "origin/base/base-quarter/*", "origin/base/fillingquarter/*", topCrustShapeElement];
 
             capi.Tesselator.TesselateShape("pie", shape, out MeshData mesh, this, null, 0, 0, 0, null, selectiveElements);

--- a/Systems/Cooking/MealMeshCache.cs
+++ b/Systems/Cooking/MealMeshCache.cs
@@ -183,7 +183,7 @@ namespace Vintagestory.GameContent
             //    for item.NutritionProps.FoodCategory == Protein   => block/food/pie/fill-mixedmeat.png
             //    for item.NutritionProps.FoodCategory == Fruit   => block/food/pie/fill-mixedfruit.png
 
-            var stackprops = contentStacks.Select(stack => stack?.ItemAttributes?["inPieProperties"]?.AsObject<InPieProperties?>(null, stack.Collectible.Code.Domain)).ToArray();
+            var stackprops = contentStacks.Select(InPieProperties.ReadFrom).ToArray();
 
             int bakeLevel = pieStack?.Attributes.GetAsInt("bakeLevel", 0) ?? 0;
 

--- a/Systems/Cooking/MealMeshCache.cs
+++ b/Systems/Cooking/MealMeshCache.cs
@@ -187,18 +187,26 @@ namespace Vintagestory.GameContent
                 if (!singleIngredient && !mixCodes.Any()) break;
             }
 
-            if (stackPieProps[0] != null)
+            if (stackPieProps[0]?.Texture != null)
             {
-                crustTextureLoc = stackPieProps[0]!.Texture.Clone();
+                crustTextureLoc = stackPieProps[0].Texture.Clone();
                 crustTextureLoc.Path = crustTextureLoc.Path.Replace("{bakelevel}", "" + (bakeLevel + 1));
                 fillingTextureLoc = new AssetLocation("block/transparent");
             }
+            else if (stackPieProps[0] != null)
+            {
+                capi!.Logger.Error($"Bottom crust {contentStacks[0].Collectible.Code} does not have a texture!");
+            }
 
             topCrustTextureLoc = new AssetLocation("block/transparent");
-            if (stackPieProps[5] != null)
+            if (stackPieProps[5]?.Texture != null)
             {
                 topCrustTextureLoc = stackPieProps[5]!.Texture.Clone();
                 topCrustTextureLoc.Path = topCrustTextureLoc.Path.Replace("{bakelevel}", "" + (bakeLevel + 1));
+            }
+            else if (stackPieProps[5] != null)
+            {
+                capi!.Logger.Error($"Topping {contentStacks[5].Collectible.Code} does not have a texture!");
             }
 
             if (contentStacks[1] != null)
@@ -232,12 +240,21 @@ namespace Vintagestory.GameContent
             if (mixingCode == "dairy") mixingCode = "cheese";
 
             if (singleIngredient) return pieProps[1]?.Texture;
-            if (mixingCode == null) return new("block/food/pie/fill-unknown");
+            if (mixingCode == null)
+            {
+                capi!.Logger.Error("Pie does not have any mixing codes. Using default unknown texture.");
+                return new("block/food/pie/fill-unknown");
+            }
 
             if (!pieMixingCodeFillingTextures.TryGetValue(mixingCode.GetHashCode(), out AssetLocation? loc))
             {
                 loc = new("block/food/pie/fill-mixed" + mixingCode);
                 pieMixingCodeFillingTextures.Add(mixingCode.GetHashCode(), loc);
+            }
+
+            if (loc == null)
+            {
+                capi!.Logger.Error($"No pie texture found for mixing code {mixingCode}.");
             }
 
             return loc;

--- a/Systems/Cooking/MealMeshCache.cs
+++ b/Systems/Cooking/MealMeshCache.cs
@@ -9,8 +9,6 @@ using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Util;
 
-#nullable enable
-
 namespace Vintagestory.GameContent
 {
     public class MealMeshCache : ModSystem, ITexPositionSource

--- a/Systems/Cooking/MealMeshCache.cs
+++ b/Systems/Cooking/MealMeshCache.cs
@@ -224,9 +224,9 @@ namespace Vintagestory.GameContent
             Shape shape = API.Common.Shape.TryGet(capi, shapeloc);
 
             string topCrustShapeElement;
-            if (stackPieProps[5]?.ToppingShapeElement is string toppingShapeElement)
+            if (stackPieProps[5]?.PartType == EnumPiePartType.Topping)
             {
-                topCrustShapeElement = toppingShapeElement;
+                topCrustShapeElement = stackPieProps[5].ToppingShapeElement;
             }
             else
             {

--- a/Systems/Cooking/MealMeshCache.cs
+++ b/Systems/Cooking/MealMeshCache.cs
@@ -191,7 +191,7 @@ namespace Vintagestory.GameContent
 
 
             ItemStack cstack = contentStacks[1];
-            var foodCats = contentStacks.Select(BlockPie.FillingFoodCategory).ToArray();
+            var foodCats = contentStacks.Select(BlockPie.IngredientFoodCategory).ToArray();
             EnumFoodCategory foodCat = foodCats[1];
 
             bool equal = true;

--- a/Systems/Cooking/MealMeshCache.cs
+++ b/Systems/Cooking/MealMeshCache.cs
@@ -176,7 +176,7 @@ namespace Vintagestory.GameContent
             InPieProperties[] stackPieProps = contentStacks.Select(InPieProperties.ReadFrom).ToArray()!;
 
             bool singleIngredient = true;
-            IEnumerable<string> mixCodes = stackPieProps[1].MixingCodes ?? [];
+            IEnumerable<string> mixCodes = stackPieProps[1]?.MixingCodes ?? [];
             for (int i = 2; i < contentStacks.Length - 1; i++)
             {
                 if (contentStacks[i] == null) continue;

--- a/Systems/Cooking/MealMeshCache.cs
+++ b/Systems/Cooking/MealMeshCache.cs
@@ -9,7 +9,6 @@ using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Util;
 
-
 namespace Vintagestory.GameContent
 {
     public class MealMeshCache : ModSystem, ITexPositionSource
@@ -153,89 +152,65 @@ namespace Vintagestory.GameContent
 
         public MeshData? GetPieMesh(ItemStack? pieStack, ModelTransform? transform = null)
         {
-            // Slot 0: Base dough
-            // Slot 1: Filling
-            // Slot 2: Crust dough
-
             nowTesselatingBlock = pieStack?.Block as BlockPie;
-            if (nowTesselatingBlock == null) return null;  //This will occur if the pieStack changed to rot
+            if (nowTesselatingBlock == null) return null;  // This will occur if the pieStack changed to rot.
 
             contentStacks = nowTesselatingBlock.GetContents(capi!.World, pieStack);
+            if (contentStacks.Length < 6) return null; // Pies are supposed to always have 6 stacks.
 
             int pieSize = pieStack?.Attributes.GetAsInt("pieSize") ?? 0;
 
-
-            // At this spot we have to determine the textures for "dough" and "filling"
-            // Texture determination rules:
-            // 1. dough is simple: first itemstack must be dough, take from attributes
-            // 2. pie allows 4 items as fillings, but with specific mixing rules
-            //    - berries/fruit can be mixed
-            //    - vegetables can be mixed
-            //    - meat can be mixed
-            // no other mixing allowed
-
-            // Thus we deduce: It's enough to test if
-            // a) all 4 fillings are equal: Then use texture from inPieProperties from first one
-            // b) Otherwise use hardcoded
-            //    for item.NutritionProps.FoodCategory == Vegetable   => block/food/pie/fill-mixedvegetable.png
-            //    for item.NutritionProps.FoodCategory == Protein   => block/food/pie/fill-mixedmeat.png
-            //    for item.NutritionProps.FoodCategory == Fruit   => block/food/pie/fill-mixedfruit.png
-
-            var stackprops = contentStacks.Select(stack => stack?.ItemAttributes?["inPieProperties"]?.AsObject<InPieProperties?>(null, stack.Collectible.Code.Domain)).ToArray();
+            // This is where we find the dough and filling textures.
+            //
+            // For dough, the texture is taken from the attributes. Vanilla doughs
+            // use the path "block/food/pie/{type}{bakeLevel}"
+            //
+            // For filling, we need to check whether the pie is single-ingredient. If not,
+            // we look for the texture named after the first mixing code.
+            //
+            // Single-ingredient: "block/food/pie/fill-<name>.png"
+            // By mixing code: "block/food/pie/fill-mixed<tag>.png"
 
             int bakeLevel = pieStack?.Attributes.GetAsInt("bakeLevel", 0) ?? 0;
+            InPieProperties?[] stackPieProps = contentStacks.Select(InPieProperties.ReadFrom).ToArray();
 
-            if (stackprops.Length == 0) return null;
-
-
-            ItemStack cstack = contentStacks[1];
-            var foodCats = contentStacks.Select(BlockPie.FillingFoodCategory).ToArray();
-            EnumFoodCategory foodCat = foodCats[1];
-
-            bool equal = true;
-            bool foodCatEquals = true;
-            IEnumerable<string> mixCodes = stackprops[1]?.MixingCodes ?? [];
-            for (int i = 2; (equal || foodCatEquals || mixCodes.Any()) && i < contentStacks.Length - 1; i++)
+            bool singleIngredient = true;
+            IEnumerable<string> mixCodes = stackPieProps[1]?.MixingCodes ?? [];
+            for (int i = 2; i < contentStacks.Length - 1; i++)
             {
-                if (contentStacks[i] == null || cstack == null) continue;
+                if (contentStacks[i] == null) continue;
 
-                equal &= cstack.Equals(capi.World, contentStacks[i], GlobalConstants.IgnoredStackAttributes);
-                foodCatEquals &= contentStacks[i] == null || foodCats[i] == foodCats[1];
-                mixCodes = stackprops[i]?.MixingCodes.Intersect(mixCodes) ?? [];
+                singleIngredient &= contentStacks[1].Equals(capi.World, contentStacks[i], GlobalConstants.IgnoredStackAttributes);
+                mixCodes = stackPieProps[i]?.MixingCodes.Intersect(mixCodes) ?? [];
 
-                cstack = contentStacks[i];
-                foodCat = foodCats[i];
+                if (!singleIngredient && !mixCodes.Any()) break;
             }
 
-
-            if (ContentsRotten(contentStacks))
+            if (stackPieProps[0]?.Texture is AssetLocation crustTexture)
             {
-                crustTextureLoc = new AssetLocation("block/rot/rot");
-                fillingTextureLoc = new AssetLocation("block/rot/rot");
-                topCrustTextureLoc = new AssetLocation("block/rot/rot");
+                crustTextureLoc = crustTexture.Clone();
+                crustTextureLoc.Path = crustTextureLoc.Path.Replace("{bakelevel}", "" + (bakeLevel + 1));
+                fillingTextureLoc = new AssetLocation("block/transparent");
             }
-            else
+            else if (stackPieProps[0] != null)
             {
-                if (stackprops[0] != null)
-                {
-                    crustTextureLoc = stackprops[0]!.Texture.Clone();
-                    crustTextureLoc.Path = crustTextureLoc.Path.Replace("{bakelevel}", "" + (bakeLevel + 1));
-                    fillingTextureLoc = new AssetLocation("block/transparent");
-                }
+                capi!.Logger.Error($"Bottom crust {contentStacks[0].Collectible.Code} does not have a texture!");
+            }
 
-                topCrustTextureLoc = new AssetLocation("block/transparent");
-                if (stackprops[5] != null)
-                {
-                    topCrustTextureLoc = stackprops[5]!.Texture.Clone();
-                    topCrustTextureLoc.Path = topCrustTextureLoc.Path.Replace("{bakelevel}", "" + (bakeLevel + 1));
-                }
+            topCrustTextureLoc = new AssetLocation("block/transparent");
+            if (stackPieProps[5]?.Texture is AssetLocation topCrustTexture)
+            {
+                topCrustTextureLoc = topCrustTexture.Clone();
+                topCrustTextureLoc.Path = topCrustTextureLoc.Path.Replace("{bakelevel}", "" + (bakeLevel + 1));
+            }
+            else if (stackPieProps[5] != null)
+            {
+                capi!.Logger.Error($"Topping {contentStacks[5].Collectible.Code} does not have a texture!");
+            }
 
-                if (contentStacks[1] != null)
-                {
-                    var fillingCat = foodCats[1];
-                    if (fillingCat == EnumFoodCategory.NoNutrition) fillingCat = EnumFoodCategory.Unknown;
-                    fillingTextureLoc = getPieFillingTexture(stackprops, mixCodes.ToArray(), equal, foodCatEquals, fillingCat);
-                }
+            if (contentStacks[1] != null)
+            {
+                fillingTextureLoc = getPieFillingTexture(stackPieProps, mixCodes.FirstOrDefault(), singleIngredient);
             }
 
 
@@ -247,7 +222,15 @@ namespace Vintagestory.GameContent
             shapeloc.WithPathAppendixOnce(".json").WithPathPrefixOnce("shapes/");
             Shape shape = API.Common.Shape.TryGet(capi, shapeloc);
 
-            string topCrustShapeElement = BlockPie.TopCrustTypes.First(type => type.Code.EqualsFast(BlockPie.GetTopCrustType(pieStack) ?? "full")).ShapeElement;
+            string topCrustShapeElement;
+            if (stackPieProps[5]?.PartType == EnumPiePartType.Topping)
+            {
+                topCrustShapeElement = stackPieProps[5]!.ToppingShapeElement;
+            }
+            else
+            {
+                topCrustShapeElement = BlockPie.TopCrustTypes.First(type => type.Code.EqualsFast(BlockPie.GetTopCrustType(pieStack) ?? "full")).ShapeElement;
+            }
             string[] selectiveElements = ["origin/base/crust regular/*", "origin/base/filling/*", "origin/base/base-quarter/*", "origin/base/fillingquarter/*", topCrustShapeElement];
 
             capi.Tesselator.TesselateShape("pie", shape, out MeshData mesh, this, null, 0, 0, 0, null, selectiveElements);
@@ -257,32 +240,35 @@ namespace Vintagestory.GameContent
         }
 
         public Dictionary<int, AssetLocation> pieMixingCodeFillingTextures = [];
-        private AssetLocation? getPieFillingTexture(InPieProperties?[] pieProps, string[] mixingCodes, bool singleFilling, bool singleFoodCat, EnumFoodCategory fillingCat)
+        private AssetLocation? getPieFillingTexture(InPieProperties?[] pieProps, string? mixingCode, bool singleIngredient)
         {
-            if (singleFilling) return pieProps[1]?.Texture;
+            if (singleIngredient) return pieProps[1]?.Texture;
 
-            if (!singleFoodCat && mixingCodes.Length > 0)
+            if (mixingCode == null)
             {
-                if (pieMixingCodeFillingTextures.TryGetValue(mixingCodes[0].GetHashCode(), out var loc))
-                {
-                    return loc;
-                }
-                else pieMixingCodeFillingTextures.Add(mixingCodes[0].GetHashCode(), new("block/food/pie/fill-mixed" + mixingCodes[0]));
+                capi!.Logger.Error("Pie does not have any mixing codes. Using default unknown texture.");
+                return new("block/food/pie/fill-unknown");
             }
 
-            return pieMixedCategoryFillingTextures[(int)fillingCat];
+            // Correct for the actual file name
+            if (mixingCode == "protein") mixingCode = "meat";
+            if (mixingCode == "dairy") mixingCode = "cheese";
+
+            int hashCode = mixingCode.GetHashCode();
+
+            if (!pieMixingCodeFillingTextures.TryGetValue(hashCode, out AssetLocation? loc))
+            {
+                loc = new("block/food/pie/fill-mixed" + mixingCode);
+                pieMixingCodeFillingTextures.Add(hashCode, loc);
+            }
+
+            if (loc == null)
+            {
+                capi!.Logger.Error($"No pie texture found for mixing code {mixingCode}.");
+            }
+
+            return loc;
         }
-
-
-        public AssetLocation[] pieMixedCategoryFillingTextures = [
-            new ("block/food/pie/fill-mixedfruit"),
-            new ("block/food/pie/fill-mixedvegetable"),
-            new ("block/food/pie/fill-mixedmeat"),
-            new ("block/food/pie/fill-mixedgrain"),
-            new ("block/food/pie/fill-mixedcheese"),
-            new ("block/food/pie/fill-unknown")
-        ];
-
 
         public Dictionary<int, MultiTextureMeshRef> GetCookedMeshRefs()
         {
@@ -378,7 +364,7 @@ namespace Vintagestory.GameContent
                     {
                         source.ForStack = contentStacks[0]!;
 
-                        CompositeShape? cshape = contentStacks[0]!.ItemAttributes["inBowlShape"]?.AsObject(new CompositeShape() { Base = new ("shapes/block/food/meal/pickled.json") });
+                        CompositeShape? cshape = contentStacks[0]!.ItemAttributes["inBowlShape"]?.AsObject(new CompositeShape() { Base = new("shapes/block/food/meal/pickled.json") });
 
                         Shape contentShape = API.Common.Shape.TryGet(capi, cshape?.Base.WithPathAppendixOnce(".json").WithPathPrefixOnce("shapes/"));
                         capi!.Tesselator.TesselateShape("picklednmealcontents", contentShape, out MeshData contentMesh, source);

--- a/Systems/Core.cs
+++ b/Systems/Core.cs
@@ -683,6 +683,7 @@ namespace Vintagestory.GameContent
             api.RegisterBlockBehaviorClass("Door", typeof(BlockBehaviorDoor));
             api.RegisterBlockBehaviorClass("TrapDoor", typeof(BlockBehaviorTrapDoor));
             api.RegisterBlockBehaviorClass("Reparable", typeof(BlockBehaviorReparable));
+            api.RegisterBlockBehaviorClass("PieFormingSurface", typeof(BlockBehaviorPieFormingSurface));
 
             api.RegisterBlockBehaviorClass("JonasBoilerDoor", typeof(BlockBehaviorJonasBoilerDoor));
             api.RegisterBlockBehaviorClass("JonasHydraulicPump", typeof(BlockBehaviorJonasHydraulicPump));

--- a/Systems/Handbook/CollectibleBehaviorHandbookTextAndExtraInfo.cs
+++ b/Systems/Handbook/CollectibleBehaviorHandbookTextAndExtraInfo.cs
@@ -49,7 +49,7 @@ namespace Vintagestory.GameContent
             //NOTE(Rennorb): Survival preloads this tag, but glint does not. Registering it here suppresses a bunch of warnings on each invocation for them.
             // We are early enough in the load process to still register tags when this first gets invoked, so we might aswell do it here.
             // This is acceptable even if the tag is not needed because collectible tags realistically don't run out.
-            if(fluxTag.IsEmpty) api.CollectibleTagRegistry.TryRegisterAndCreateTagSetAndLogIssues(out fluxTag, "flux");
+            if (fluxTag.IsEmpty) api.CollectibleTagRegistry.TryRegisterAndCreateTagSetAndLogIssues(out fluxTag, "flux");
 
             dummySmeltingInv = new InventorySmelting("smelting-handbook", api);
 
@@ -774,7 +774,7 @@ namespace Vintagestory.GameContent
             // Ground processes into
             if (stack.Collectible.GetCollectibleBehavior<CollectibleBehaviorGroundStoredProcessable>(true) is { } gsp)
             {
-                List<ItemStack> processedStacks = [..gsp.ProcessedStacks?.Select(pstack => pstack.ResolvedItemstack) ?? []];
+                List<ItemStack> processedStacks = [.. gsp.ProcessedStacks?.Select(pstack => pstack.ResolvedItemstack) ?? []];
                 if (gsp.RemainingItem?.ResolvedItemStack is { } rStack) processedStacks.Insert(0, rStack);
                 string extraTooltipText = null;
                 ItemStack[] toolStacks = null;
@@ -901,179 +901,179 @@ namespace Vintagestory.GameContent
             switch (stack.Block)
             {
                 case BlockToolMold:
-                {
-                    var metalsByCode = capi.ModLoader.GetModSystem<SurvivalCoreSystem>().metalsByCode;
-
-                    foreach (var metal in metalsByCode.Keys)
                     {
-                        if (capi.World.GetItem("metalbit-" + metal) is not Item bitObj) continue;
-                        ItemStack bitStack = new(bitObj);
-                        if (!getCanContainerSmelt(capi, containers, fuels, bitStack)) continue;
-                        outputs.AddRange(getMoldedOutput(stack, [bitStack]));
-                    }
+                        var metalsByCode = capi.ModLoader.GetModSystem<SurvivalCoreSystem>().metalsByCode;
 
-                    if (outputs.Count > 0)
-                    {
-                        AddHeading(components, capi, "handbook-processorfor-metalmolding-title", ref haveText);
-
-                        int firstPadding = TinyPadding;
-                        while (outputs.Count > 0)
+                        foreach (var metal in metalsByCode.Keys)
                         {
-                            ItemStack dstack = outputs[0];
-                            outputs.RemoveAt(0);
-                            if (dstack == null) continue;
-
-                            SlideshowItemstackTextComponent comp = new SlideshowItemstackTextComponent(capi, dstack, outputs, 40, EnumFloat.Inline, (cs) => openDetailPageFor(getPageCodeForStack(capi, cs)));
-                            comp.PaddingLeft = firstPadding;
-                            firstPadding = 0;
-                            components.Add(comp);
+                            if (capi.World.GetItem("metalbit-" + metal) is not Item bitObj) continue;
+                            ItemStack bitStack = new(bitObj);
+                            if (!getCanContainerSmelt(capi, containers, fuels, bitStack)) continue;
+                            outputs.AddRange(getMoldedOutput(stack, [bitStack]));
                         }
 
-                        components.Add(new RichTextComponent(capi, "\n", CairoFont.WhiteSmallText()));
-                    }
-
-                    break;
-                }
-                case BlockIngotMold:
-                {
-                    foreach (var val in allStacks)
-                    {
-                        if (val.Collectible is not ItemIngot) continue;
-                        if (capi.World.GetItem("metalbit-" + val.Collectible.LastCodePart()) is not Item bitObj) continue;
-                        if (!getCanContainerSmelt(capi, containers, fuels, new(bitObj))) continue;
-                        outputs.Add(val);
-                    }
-
-                    if (outputs.Count > 0)
-                    {
-                        AddHeading(components, capi, "handbook-processorfor-metalmolding-title", ref haveText);
-
-                        int firstPadding = TinyPadding;
-                        while (outputs.Count > 0)
+                        if (outputs.Count > 0)
                         {
-                            ItemStack dstack = outputs[0];
-                            outputs.RemoveAt(0);
-                            if (dstack == null) continue;
+                            AddHeading(components, capi, "handbook-processorfor-metalmolding-title", ref haveText);
 
-                            SlideshowItemstackTextComponent comp = new SlideshowItemstackTextComponent(capi, dstack, outputs, 40, EnumFloat.Inline, (cs) => openDetailPageFor(getPageCodeForStack(capi, cs)));
-                            comp.PaddingLeft = firstPadding;
-                            firstPadding = 0;
-                            components.Add(comp);
-                        }
-
-                        components.Add(new RichTextComponent(capi, "\n", CairoFont.WhiteSmallText()));
-                    }
-
-                    break;
-                }
-                case BlockFruitPress:
-                {
-                    foreach (var val in allStacks)
-                    {
-                        if (getjuiceableProps(val) is not { } jprops) continue;
-                        var litresLeft = val.Attributes?.GetDouble("juiceableLitresLeft") ?? 0;
-                        var jstack = jprops.LiquidStack.ResolvedItemStack.Clone();
-                        if (jprops.LitresPerItem != null)
-                        {
-                            jstack.StackSize = (int)(100 * jprops.LitresPerItem);
-                        }
-                        if (litresLeft > 0)
-                        {
-                            jstack.StackSize = (int)(100 * litresLeft);
-                        }
-
-                        if (!val.Equals(capi.World, jstack, GlobalConstants.IgnoredStackAttributes) && !outputs.Any(s => s.Equals(capi.World, jstack, GlobalConstants.IgnoredStackAttributes)))
-                        {
-                            outputs.Add(jstack);
-                        }
-
-                        if (jprops.ReturnStack?.ResolvedItemStack == null)
-                        {
-                            if (val.Equals(capi.World, jprops.PressedStack.ResolvedItemStack, GlobalConstants.IgnoredStackAttributes)) continue;
-                            var pstack = jprops.PressedStack.ResolvedItemStack.Clone();
-                            if (!val.Equals(capi.World, jstack, GlobalConstants.IgnoredStackAttributes) && !outputs.Any(s => s.Equals(capi.World, pstack, GlobalConstants.IgnoredStackAttributes)))
+                            int firstPadding = TinyPadding;
+                            while (outputs.Count > 0)
                             {
-                                outputs.Add(pstack);
+                                ItemStack dstack = outputs[0];
+                                outputs.RemoveAt(0);
+                                if (dstack == null) continue;
+
+                                SlideshowItemstackTextComponent comp = new SlideshowItemstackTextComponent(capi, dstack, outputs, 40, EnumFloat.Inline, (cs) => openDetailPageFor(getPageCodeForStack(capi, cs)));
+                                comp.PaddingLeft = firstPadding;
+                                firstPadding = 0;
+                                components.Add(comp);
                             }
+
+                            components.Add(new RichTextComponent(capi, "\n", CairoFont.WhiteSmallText()));
                         }
-                        else
+
+                        break;
+                    }
+                case BlockIngotMold:
+                    {
+                        foreach (var val in allStacks)
                         {
-                            var rstack = jprops.ReturnStack.ResolvedItemStack.Clone();
+                            if (val.Collectible is not ItemIngot) continue;
+                            if (capi.World.GetItem("metalbit-" + val.Collectible.LastCodePart()) is not Item bitObj) continue;
+                            if (!getCanContainerSmelt(capi, containers, fuels, new(bitObj))) continue;
+                            outputs.Add(val);
+                        }
+
+                        if (outputs.Count > 0)
+                        {
+                            AddHeading(components, capi, "handbook-processorfor-metalmolding-title", ref haveText);
+
+                            int firstPadding = TinyPadding;
+                            while (outputs.Count > 0)
+                            {
+                                ItemStack dstack = outputs[0];
+                                outputs.RemoveAt(0);
+                                if (dstack == null) continue;
+
+                                SlideshowItemstackTextComponent comp = new SlideshowItemstackTextComponent(capi, dstack, outputs, 40, EnumFloat.Inline, (cs) => openDetailPageFor(getPageCodeForStack(capi, cs)));
+                                comp.PaddingLeft = firstPadding;
+                                firstPadding = 0;
+                                components.Add(comp);
+                            }
+
+                            components.Add(new RichTextComponent(capi, "\n", CairoFont.WhiteSmallText()));
+                        }
+
+                        break;
+                    }
+                case BlockFruitPress:
+                    {
+                        foreach (var val in allStacks)
+                        {
+                            if (getjuiceableProps(val) is not { } jprops) continue;
+                            var litresLeft = val.Attributes?.GetDouble("juiceableLitresLeft") ?? 0;
+                            var jstack = jprops.LiquidStack.ResolvedItemStack.Clone();
                             if (jprops.LitresPerItem != null)
                             {
-                                rstack.StackSize /= (int)(1 / jprops.LitresPerItem);
+                                jstack.StackSize = (int)(100 * jprops.LitresPerItem);
+                            }
+                            if (litresLeft > 0)
+                            {
+                                jstack.StackSize = (int)(100 * litresLeft);
                             }
 
-                            if (!val.Equals(capi.World, jstack, GlobalConstants.IgnoredStackAttributes) && !outputs.Any(s => s.Equals(capi.World, rstack, GlobalConstants.IgnoredStackAttributes)))
+                            if (!val.Equals(capi.World, jstack, GlobalConstants.IgnoredStackAttributes) && !outputs.Any(s => s.Equals(capi.World, jstack, GlobalConstants.IgnoredStackAttributes)))
                             {
-                                outputs.Add(rstack);
+                                outputs.Add(jstack);
                             }
 
-                            var pstack = jprops.PressedStack.ResolvedItemStack.Clone();
-                            pstack.Attributes.SetDouble("juiceableLitresLeft", 1);
-
-                            if (!val.Equals(capi.World, pstack, GlobalConstants.IgnoredStackAttributes) && !outputs.Any(s => s.Equals(capi.World, pstack, GlobalConstants.IgnoredStackAttributes)))
+                            if (jprops.ReturnStack?.ResolvedItemStack == null)
                             {
-                                outputs.Add(pstack);
+                                if (val.Equals(capi.World, jprops.PressedStack.ResolvedItemStack, GlobalConstants.IgnoredStackAttributes)) continue;
+                                var pstack = jprops.PressedStack.ResolvedItemStack.Clone();
+                                if (!val.Equals(capi.World, jstack, GlobalConstants.IgnoredStackAttributes) && !outputs.Any(s => s.Equals(capi.World, pstack, GlobalConstants.IgnoredStackAttributes)))
+                                {
+                                    outputs.Add(pstack);
+                                }
+                            }
+                            else
+                            {
+                                var rstack = jprops.ReturnStack.ResolvedItemStack.Clone();
+                                if (jprops.LitresPerItem != null)
+                                {
+                                    rstack.StackSize /= (int)(1 / jprops.LitresPerItem);
+                                }
+
+                                if (!val.Equals(capi.World, jstack, GlobalConstants.IgnoredStackAttributes) && !outputs.Any(s => s.Equals(capi.World, rstack, GlobalConstants.IgnoredStackAttributes)))
+                                {
+                                    outputs.Add(rstack);
+                                }
+
+                                var pstack = jprops.PressedStack.ResolvedItemStack.Clone();
+                                pstack.Attributes.SetDouble("juiceableLitresLeft", 1);
+
+                                if (!val.Equals(capi.World, pstack, GlobalConstants.IgnoredStackAttributes) && !outputs.Any(s => s.Equals(capi.World, pstack, GlobalConstants.IgnoredStackAttributes)))
+                                {
+                                    outputs.Add(pstack);
+                                }
                             }
                         }
-                    }
 
-                    if (outputs.Count > 0)
-                    {
-                        AddHeading(components, capi, "handbook-processorfor-juicing-title", ref haveText);
-
-                        int firstPadding = TinyPadding;
-                        while (outputs.Count > 0)
+                        if (outputs.Count > 0)
                         {
-                            ItemStack dstack = outputs[0];
-                            outputs.RemoveAt(0);
-                            if (dstack == null) continue;
+                            AddHeading(components, capi, "handbook-processorfor-juicing-title", ref haveText);
 
-                            SlideshowItemstackTextComponent comp = new SlideshowItemstackTextComponent(capi, dstack, outputs, 40, EnumFloat.Inline, (cs) => openDetailPageFor(getPageCodeForStack(capi, cs)));
-                            comp.PaddingLeft = firstPadding;
-                            firstPadding = 0;
-                            components.Add(comp);
+                            int firstPadding = TinyPadding;
+                            while (outputs.Count > 0)
+                            {
+                                ItemStack dstack = outputs[0];
+                                outputs.RemoveAt(0);
+                                if (dstack == null) continue;
+
+                                SlideshowItemstackTextComponent comp = new SlideshowItemstackTextComponent(capi, dstack, outputs, 40, EnumFloat.Inline, (cs) => openDetailPageFor(getPageCodeForStack(capi, cs)));
+                                comp.PaddingLeft = firstPadding;
+                                firstPadding = 0;
+                                components.Add(comp);
+                            }
+
+                            components.Add(new RichTextComponent(capi, "\n", CairoFont.WhiteSmallText()));
                         }
 
-                        components.Add(new RichTextComponent(capi, "\n", CairoFont.WhiteSmallText()));
+                        break;
                     }
-
-                    break;
-                }
                 case BlockAnvil anvil:
-                {
-                    foreach (var val in capi.GetSmithingRecipes())
                     {
-                        if (outputs.Any(s => s.Equals(capi.World, val.Output.ResolvedItemStack, GlobalConstants.IgnoredStackAttributes))) continue;
-                        var workable = val.Ingredient.ResolvedItemStack.Collectible.GetCollectibleInterface<IAnvilWorkable>();
-                        if (workable?.GetRequiredAnvilTier(val.Ingredient.ResolvedItemStack) > anvil.MetalTier) continue;
-
-                        outputs.Add(val.Output.ResolvedItemStack);
-                    }
-
-                    if (outputs.Count > 0)
-                    {
-                        AddHeading(components, capi, "handbook-processorfor-smithing-title", ref haveText);
-
-                        int firstPadding = TinyPadding;
-                        while (outputs.Count > 0)
+                        foreach (var val in capi.GetSmithingRecipes())
                         {
-                            ItemStack dstack = outputs[0];
-                            outputs.RemoveAt(0);
-                            if (dstack == null) continue;
+                            if (outputs.Any(s => s.Equals(capi.World, val.Output.ResolvedItemStack, GlobalConstants.IgnoredStackAttributes))) continue;
+                            var workable = val.Ingredient.ResolvedItemStack.Collectible.GetCollectibleInterface<IAnvilWorkable>();
+                            if (workable?.GetRequiredAnvilTier(val.Ingredient.ResolvedItemStack) > anvil.MetalTier) continue;
 
-                            SlideshowItemstackTextComponent comp = new SlideshowItemstackTextComponent(capi, dstack, outputs, 40, EnumFloat.Inline, (cs) => openDetailPageFor(getPageCodeForStack(capi, cs)));
-                            comp.PaddingLeft = firstPadding;
-                            firstPadding = 0;
-                            components.Add(comp);
+                            outputs.Add(val.Output.ResolvedItemStack);
                         }
 
-                        components.Add(new RichTextComponent(capi, "\n", CairoFont.WhiteSmallText()));
-                    }
+                        if (outputs.Count > 0)
+                        {
+                            AddHeading(components, capi, "handbook-processorfor-smithing-title", ref haveText);
 
-                    break;
-                }
+                            int firstPadding = TinyPadding;
+                            while (outputs.Count > 0)
+                            {
+                                ItemStack dstack = outputs[0];
+                                outputs.RemoveAt(0);
+                                if (dstack == null) continue;
+
+                                SlideshowItemstackTextComponent comp = new SlideshowItemstackTextComponent(capi, dstack, outputs, 40, EnumFloat.Inline, (cs) => openDetailPageFor(getPageCodeForStack(capi, cs)));
+                                comp.PaddingLeft = firstPadding;
+                                firstPadding = 0;
+                                components.Add(comp);
+                            }
+
+                            components.Add(new RichTextComponent(capi, "\n", CairoFont.WhiteSmallText()));
+                        }
+
+                        break;
+                    }
                 case BlockQuern:
                     foreach (var val in allStacks)
                     {
@@ -1342,6 +1342,7 @@ namespace Vintagestory.GameContent
                 mealBlock.Attributes.SetString("topCrustType", BlockPie.TopCrustTypes[capi.World.Rand.Next(BlockPie.TopCrustTypes.Length)].Code);
                 mealBlock.Attributes.SetInt("bakeLevel", 2);
                 MealstackTextComponent comp = new(capi, mealBlock, recipe, 40, EnumFloat.Inline, (cs) => openDetailPageFor("handbook-mealrecipe-" + recipe.Code + "-pie"), 6, true, stack);
+
                 components.Add(comp);
             }
             capi.World.FrameProfiler.Mark("handbook-recipematch-addcomponents");
@@ -2641,7 +2642,7 @@ namespace Vintagestory.GameContent
             var dummySlot = new DummySlot();
 
             var allowedDresstypes = stack.ItemAttributes?["allowedDresstypes"].AsArray<string>();
-            string[] placementSurfaces = [..stack.Block?.GetBehavior<BlockBehaviorDisplay>()?.PlacementSurfaces.Select(ps => ps.DisplayCategory) ?? []];
+            string[] placementSurfaces = [.. stack.Block?.GetBehavior<BlockBehaviorDisplay>()?.PlacementSurfaces.Select(ps => ps.DisplayCategory) ?? []];
             foreach (var val in allStacks)
             {
                 if ((placementSurfaces.Length > 0 && placementSurfaces.Any(key => BlockBehaviorDisplay.GetDisplayableAttributes(new DummySlot(val), key) != null)) ||

--- a/Systems/Handbook/CollectibleBehaviorHandbookTextAndExtraInfo.cs
+++ b/Systems/Handbook/CollectibleBehaviorHandbookTextAndExtraInfo.cs
@@ -1337,11 +1337,8 @@ namespace Vintagestory.GameContent
                 pierecipes.RemoveAt(0);
                 if (recipe == null) continue;
 
-                ItemStack mealBlock = new(capi.World.BlockAccessor.GetBlock("pie-perfect"));
-                mealBlock.Attributes.SetInt("pieSize", 4);
-                mealBlock.Attributes.SetString("topCrustType", BlockPie.TopCrustTypes[capi.World.Rand.Next(BlockPie.TopCrustTypes.Length)].Code);
-                mealBlock.Attributes.SetInt("bakeLevel", 2);
-                MealstackTextComponent comp = new(capi, mealBlock, recipe, 40, EnumFloat.Inline, (cs) => openDetailPageFor("handbook-mealrecipe-" + recipe.Code + "-pie"), 6, true, stack);
+                ItemStack mealStack = new(capi.World.BlockAccessor.GetBlock("pie-perfect"));
+                MealstackTextComponent comp = new(capi, mealStack, recipe, 40, EnumFloat.Inline, (cs) => openDetailPageFor("handbook-mealrecipe-" + recipe.Code + "-pie"), 6, true, stack);
 
                 components.Add(comp);
             }
@@ -2715,9 +2712,6 @@ namespace Vintagestory.GameContent
                             if (recipe == null) continue;
 
                             ItemStack mealBlock = dstack.Clone();
-                            mealBlock.Attributes.SetInt("pieSize", 4);
-                            mealBlock.Attributes.SetString("topCrustType", BlockPie.TopCrustTypes[capi.World.Rand.Next(BlockPie.TopCrustTypes.Length)].Code);
-                            mealBlock.Attributes.SetInt("bakeLevel", 2);
                             MealstackTextComponent mealComp = new MealstackTextComponent(capi, mealBlock, recipe, 40, EnumFloat.Inline, (cs) => openDetailPageFor("handbook-mealrecipe-" + recipe.Code + "-pie"), 6, true);
                             components.Add(mealComp);
                         }

--- a/Systems/Handbook/CollectibleBehaviorHandbookTextAndExtraInfo.cs
+++ b/Systems/Handbook/CollectibleBehaviorHandbookTextAndExtraInfo.cs
@@ -49,7 +49,7 @@ namespace Vintagestory.GameContent
             //NOTE(Rennorb): Survival preloads this tag, but glint does not. Registering it here suppresses a bunch of warnings on each invocation for them.
             // We are early enough in the load process to still register tags when this first gets invoked, so we might aswell do it here.
             // This is acceptable even if the tag is not needed because collectible tags realistically don't run out.
-            if(fluxTag.IsEmpty) api.CollectibleTagRegistry.TryRegisterAndCreateTagSetAndLogIssues(out fluxTag, "flux");
+            if (fluxTag.IsEmpty) api.CollectibleTagRegistry.TryRegisterAndCreateTagSetAndLogIssues(out fluxTag, "flux");
 
             dummySmeltingInv = new InventorySmelting("smelting-handbook", api);
 
@@ -774,7 +774,7 @@ namespace Vintagestory.GameContent
             // Ground processes into
             if (stack.Collectible.GetCollectibleBehavior<CollectibleBehaviorGroundStoredProcessable>(true) is { } gsp)
             {
-                List<ItemStack> processedStacks = [..gsp.ProcessedStacks?.Select(pstack => pstack.ResolvedItemstack) ?? []];
+                List<ItemStack> processedStacks = [.. gsp.ProcessedStacks?.Select(pstack => pstack.ResolvedItemstack) ?? []];
                 if (gsp.RemainingItem?.ResolvedItemStack is { } rStack) processedStacks.Insert(0, rStack);
                 string extraTooltipText = null;
                 ItemStack[] toolStacks = null;
@@ -901,179 +901,179 @@ namespace Vintagestory.GameContent
             switch (stack.Block)
             {
                 case BlockToolMold:
-                {
-                    var metalsByCode = capi.ModLoader.GetModSystem<SurvivalCoreSystem>().metalsByCode;
-
-                    foreach (var metal in metalsByCode.Keys)
                     {
-                        if (capi.World.GetItem("metalbit-" + metal) is not Item bitObj) continue;
-                        ItemStack bitStack = new(bitObj);
-                        if (!getCanContainerSmelt(capi, containers, fuels, bitStack)) continue;
-                        outputs.AddRange(getMoldedOutput(stack, [bitStack]));
-                    }
+                        var metalsByCode = capi.ModLoader.GetModSystem<SurvivalCoreSystem>().metalsByCode;
 
-                    if (outputs.Count > 0)
-                    {
-                        AddHeading(components, capi, "handbook-processorfor-metalmolding-title", ref haveText);
-
-                        int firstPadding = TinyPadding;
-                        while (outputs.Count > 0)
+                        foreach (var metal in metalsByCode.Keys)
                         {
-                            ItemStack dstack = outputs[0];
-                            outputs.RemoveAt(0);
-                            if (dstack == null) continue;
-
-                            SlideshowItemstackTextComponent comp = new SlideshowItemstackTextComponent(capi, dstack, outputs, 40, EnumFloat.Inline, (cs) => openDetailPageFor(getPageCodeForStack(capi, cs)));
-                            comp.PaddingLeft = firstPadding;
-                            firstPadding = 0;
-                            components.Add(comp);
+                            if (capi.World.GetItem("metalbit-" + metal) is not Item bitObj) continue;
+                            ItemStack bitStack = new(bitObj);
+                            if (!getCanContainerSmelt(capi, containers, fuels, bitStack)) continue;
+                            outputs.AddRange(getMoldedOutput(stack, [bitStack]));
                         }
 
-                        components.Add(new RichTextComponent(capi, "\n", CairoFont.WhiteSmallText()));
-                    }
-
-                    break;
-                }
-                case BlockIngotMold:
-                {
-                    foreach (var val in allStacks)
-                    {
-                        if (val.Collectible is not ItemIngot) continue;
-                        if (capi.World.GetItem("metalbit-" + val.Collectible.LastCodePart()) is not Item bitObj) continue;
-                        if (!getCanContainerSmelt(capi, containers, fuels, new(bitObj))) continue;
-                        outputs.Add(val);
-                    }
-
-                    if (outputs.Count > 0)
-                    {
-                        AddHeading(components, capi, "handbook-processorfor-metalmolding-title", ref haveText);
-
-                        int firstPadding = TinyPadding;
-                        while (outputs.Count > 0)
+                        if (outputs.Count > 0)
                         {
-                            ItemStack dstack = outputs[0];
-                            outputs.RemoveAt(0);
-                            if (dstack == null) continue;
+                            AddHeading(components, capi, "handbook-processorfor-metalmolding-title", ref haveText);
 
-                            SlideshowItemstackTextComponent comp = new SlideshowItemstackTextComponent(capi, dstack, outputs, 40, EnumFloat.Inline, (cs) => openDetailPageFor(getPageCodeForStack(capi, cs)));
-                            comp.PaddingLeft = firstPadding;
-                            firstPadding = 0;
-                            components.Add(comp);
-                        }
-
-                        components.Add(new RichTextComponent(capi, "\n", CairoFont.WhiteSmallText()));
-                    }
-
-                    break;
-                }
-                case BlockFruitPress:
-                {
-                    foreach (var val in allStacks)
-                    {
-                        if (getjuiceableProps(val) is not { } jprops) continue;
-                        var litresLeft = val.Attributes?.GetDouble("juiceableLitresLeft") ?? 0;
-                        var jstack = jprops.LiquidStack.ResolvedItemStack.Clone();
-                        if (jprops.LitresPerItem != null)
-                        {
-                            jstack.StackSize = (int)(100 * jprops.LitresPerItem);
-                        }
-                        if (litresLeft > 0)
-                        {
-                            jstack.StackSize = (int)(100 * litresLeft);
-                        }
-
-                        if (!val.Equals(capi.World, jstack, GlobalConstants.IgnoredStackAttributes) && !outputs.Any(s => s.Equals(capi.World, jstack, GlobalConstants.IgnoredStackAttributes)))
-                        {
-                            outputs.Add(jstack);
-                        }
-
-                        if (jprops.ReturnStack?.ResolvedItemStack == null)
-                        {
-                            if (val.Equals(capi.World, jprops.PressedStack.ResolvedItemStack, GlobalConstants.IgnoredStackAttributes)) continue;
-                            var pstack = jprops.PressedStack.ResolvedItemStack.Clone();
-                            if (!val.Equals(capi.World, jstack, GlobalConstants.IgnoredStackAttributes) && !outputs.Any(s => s.Equals(capi.World, pstack, GlobalConstants.IgnoredStackAttributes)))
+                            int firstPadding = TinyPadding;
+                            while (outputs.Count > 0)
                             {
-                                outputs.Add(pstack);
+                                ItemStack dstack = outputs[0];
+                                outputs.RemoveAt(0);
+                                if (dstack == null) continue;
+
+                                SlideshowItemstackTextComponent comp = new SlideshowItemstackTextComponent(capi, dstack, outputs, 40, EnumFloat.Inline, (cs) => openDetailPageFor(getPageCodeForStack(capi, cs)));
+                                comp.PaddingLeft = firstPadding;
+                                firstPadding = 0;
+                                components.Add(comp);
                             }
+
+                            components.Add(new RichTextComponent(capi, "\n", CairoFont.WhiteSmallText()));
                         }
-                        else
+
+                        break;
+                    }
+                case BlockIngotMold:
+                    {
+                        foreach (var val in allStacks)
                         {
-                            var rstack = jprops.ReturnStack.ResolvedItemStack.Clone();
+                            if (val.Collectible is not ItemIngot) continue;
+                            if (capi.World.GetItem("metalbit-" + val.Collectible.LastCodePart()) is not Item bitObj) continue;
+                            if (!getCanContainerSmelt(capi, containers, fuels, new(bitObj))) continue;
+                            outputs.Add(val);
+                        }
+
+                        if (outputs.Count > 0)
+                        {
+                            AddHeading(components, capi, "handbook-processorfor-metalmolding-title", ref haveText);
+
+                            int firstPadding = TinyPadding;
+                            while (outputs.Count > 0)
+                            {
+                                ItemStack dstack = outputs[0];
+                                outputs.RemoveAt(0);
+                                if (dstack == null) continue;
+
+                                SlideshowItemstackTextComponent comp = new SlideshowItemstackTextComponent(capi, dstack, outputs, 40, EnumFloat.Inline, (cs) => openDetailPageFor(getPageCodeForStack(capi, cs)));
+                                comp.PaddingLeft = firstPadding;
+                                firstPadding = 0;
+                                components.Add(comp);
+                            }
+
+                            components.Add(new RichTextComponent(capi, "\n", CairoFont.WhiteSmallText()));
+                        }
+
+                        break;
+                    }
+                case BlockFruitPress:
+                    {
+                        foreach (var val in allStacks)
+                        {
+                            if (getjuiceableProps(val) is not JuiceableProperties jprops) continue;
+                            var litresLeft = val.Attributes?.GetDouble("juiceableLitresLeft") ?? 0;
+                            var jstack = jprops.LiquidStack.ResolvedItemStack.Clone();
                             if (jprops.LitresPerItem != null)
                             {
-                                rstack.StackSize /= (int)(1 / jprops.LitresPerItem);
+                                jstack.StackSize = (int)(100 * jprops.LitresPerItem);
+                            }
+                            if (litresLeft > 0)
+                            {
+                                jstack.StackSize = (int)(100 * litresLeft);
                             }
 
-                            if (!val.Equals(capi.World, jstack, GlobalConstants.IgnoredStackAttributes) && !outputs.Any(s => s.Equals(capi.World, rstack, GlobalConstants.IgnoredStackAttributes)))
+                            if (!val.Equals(capi.World, jstack, GlobalConstants.IgnoredStackAttributes) && !outputs.Any(s => s.Equals(capi.World, jstack, GlobalConstants.IgnoredStackAttributes)))
                             {
-                                outputs.Add(rstack);
+                                outputs.Add(jstack);
                             }
 
-                            var pstack = jprops.PressedStack.ResolvedItemStack.Clone();
-                            pstack.Attributes.SetDouble("juiceableLitresLeft", 1);
-
-                            if (!val.Equals(capi.World, pstack, GlobalConstants.IgnoredStackAttributes) && !outputs.Any(s => s.Equals(capi.World, pstack, GlobalConstants.IgnoredStackAttributes)))
+                            if (jprops.ReturnStack?.ResolvedItemStack == null)
                             {
-                                outputs.Add(pstack);
+                                if (val.Equals(capi.World, jprops.PressedStack.ResolvedItemStack, GlobalConstants.IgnoredStackAttributes)) continue;
+                                var pstack = jprops.PressedStack.ResolvedItemStack.Clone();
+                                if (!val.Equals(capi.World, jstack, GlobalConstants.IgnoredStackAttributes) && !outputs.Any(s => s.Equals(capi.World, pstack, GlobalConstants.IgnoredStackAttributes)))
+                                {
+                                    outputs.Add(pstack);
+                                }
+                            }
+                            else
+                            {
+                                var rstack = jprops.ReturnStack.ResolvedItemStack.Clone();
+                                if (jprops.LitresPerItem != null)
+                                {
+                                    rstack.StackSize /= (int)(1 / jprops.LitresPerItem);
+                                }
+
+                                if (!val.Equals(capi.World, jstack, GlobalConstants.IgnoredStackAttributes) && !outputs.Any(s => s.Equals(capi.World, rstack, GlobalConstants.IgnoredStackAttributes)))
+                                {
+                                    outputs.Add(rstack);
+                                }
+
+                                var pstack = jprops.PressedStack.ResolvedItemStack.Clone();
+                                pstack.Attributes.SetDouble("juiceableLitresLeft", 1);
+
+                                if (!val.Equals(capi.World, pstack, GlobalConstants.IgnoredStackAttributes) && !outputs.Any(s => s.Equals(capi.World, pstack, GlobalConstants.IgnoredStackAttributes)))
+                                {
+                                    outputs.Add(pstack);
+                                }
                             }
                         }
-                    }
 
-                    if (outputs.Count > 0)
-                    {
-                        AddHeading(components, capi, "handbook-processorfor-juicing-title", ref haveText);
-
-                        int firstPadding = TinyPadding;
-                        while (outputs.Count > 0)
+                        if (outputs.Count > 0)
                         {
-                            ItemStack dstack = outputs[0];
-                            outputs.RemoveAt(0);
-                            if (dstack == null) continue;
+                            AddHeading(components, capi, "handbook-processorfor-juicing-title", ref haveText);
 
-                            SlideshowItemstackTextComponent comp = new SlideshowItemstackTextComponent(capi, dstack, outputs, 40, EnumFloat.Inline, (cs) => openDetailPageFor(getPageCodeForStack(capi, cs)));
-                            comp.PaddingLeft = firstPadding;
-                            firstPadding = 0;
-                            components.Add(comp);
+                            int firstPadding = TinyPadding;
+                            while (outputs.Count > 0)
+                            {
+                                ItemStack dstack = outputs[0];
+                                outputs.RemoveAt(0);
+                                if (dstack == null) continue;
+
+                                SlideshowItemstackTextComponent comp = new SlideshowItemstackTextComponent(capi, dstack, outputs, 40, EnumFloat.Inline, (cs) => openDetailPageFor(getPageCodeForStack(capi, cs)));
+                                comp.PaddingLeft = firstPadding;
+                                firstPadding = 0;
+                                components.Add(comp);
+                            }
+
+                            components.Add(new RichTextComponent(capi, "\n", CairoFont.WhiteSmallText()));
                         }
 
-                        components.Add(new RichTextComponent(capi, "\n", CairoFont.WhiteSmallText()));
+                        break;
                     }
-
-                    break;
-                }
                 case BlockAnvil anvil:
-                {
-                    foreach (var val in capi.GetSmithingRecipes())
                     {
-                        if (outputs.Any(s => s.Equals(capi.World, val.Output.ResolvedItemStack, GlobalConstants.IgnoredStackAttributes))) continue;
-                        var workable = val.Ingredient.ResolvedItemStack.Collectible.GetCollectibleInterface<IAnvilWorkable>();
-                        if (workable?.GetRequiredAnvilTier(val.Ingredient.ResolvedItemStack) > anvil.MetalTier) continue;
-
-                        outputs.Add(val.Output.ResolvedItemStack);
-                    }
-
-                    if (outputs.Count > 0)
-                    {
-                        AddHeading(components, capi, "handbook-processorfor-smithing-title", ref haveText);
-
-                        int firstPadding = TinyPadding;
-                        while (outputs.Count > 0)
+                        foreach (var val in capi.GetSmithingRecipes())
                         {
-                            ItemStack dstack = outputs[0];
-                            outputs.RemoveAt(0);
-                            if (dstack == null) continue;
+                            if (outputs.Any(s => s.Equals(capi.World, val.Output.ResolvedItemStack, GlobalConstants.IgnoredStackAttributes))) continue;
+                            var workable = val.Ingredient.ResolvedItemStack.Collectible.GetCollectibleInterface<IAnvilWorkable>();
+                            if (workable?.GetRequiredAnvilTier(val.Ingredient.ResolvedItemStack) > anvil.MetalTier) continue;
 
-                            SlideshowItemstackTextComponent comp = new SlideshowItemstackTextComponent(capi, dstack, outputs, 40, EnumFloat.Inline, (cs) => openDetailPageFor(getPageCodeForStack(capi, cs)));
-                            comp.PaddingLeft = firstPadding;
-                            firstPadding = 0;
-                            components.Add(comp);
+                            outputs.Add(val.Output.ResolvedItemStack);
                         }
 
-                        components.Add(new RichTextComponent(capi, "\n", CairoFont.WhiteSmallText()));
-                    }
+                        if (outputs.Count > 0)
+                        {
+                            AddHeading(components, capi, "handbook-processorfor-smithing-title", ref haveText);
 
-                    break;
-                }
+                            int firstPadding = TinyPadding;
+                            while (outputs.Count > 0)
+                            {
+                                ItemStack dstack = outputs[0];
+                                outputs.RemoveAt(0);
+                                if (dstack == null) continue;
+
+                                SlideshowItemstackTextComponent comp = new SlideshowItemstackTextComponent(capi, dstack, outputs, 40, EnumFloat.Inline, (cs) => openDetailPageFor(getPageCodeForStack(capi, cs)));
+                                comp.PaddingLeft = firstPadding;
+                                firstPadding = 0;
+                                components.Add(comp);
+                            }
+
+                            components.Add(new RichTextComponent(capi, "\n", CairoFont.WhiteSmallText()));
+                        }
+
+                        break;
+                    }
                 case BlockQuern:
                     foreach (var val in allStacks)
                     {
@@ -1337,11 +1337,9 @@ namespace Vintagestory.GameContent
                 pierecipes.RemoveAt(0);
                 if (recipe == null) continue;
 
-                ItemStack mealBlock = new(capi.World.BlockAccessor.GetBlock("pie-perfect"));
-                mealBlock.Attributes.SetInt("pieSize", 4);
-                mealBlock.Attributes.SetString("topCrustType", BlockPie.TopCrustTypes[capi.World.Rand.Next(BlockPie.TopCrustTypes.Length)].Code);
-                mealBlock.Attributes.SetInt("bakeLevel", 2);
-                MealstackTextComponent comp = new(capi, mealBlock, recipe, 40, EnumFloat.Inline, (cs) => openDetailPageFor("handbook-mealrecipe-" + recipe.Code + "-pie"), 6, true, stack);
+                ItemStack mealStack = new(capi.World.BlockAccessor.GetBlock("pie-perfect"));
+                MealstackTextComponent comp = new(capi, mealStack, recipe, 40, EnumFloat.Inline, (cs) => openDetailPageFor("handbook-mealrecipe-" + recipe.Code + "-pie"), 6, true, stack);
+
                 components.Add(comp);
             }
             capi.World.FrameProfiler.Mark("handbook-recipematch-addcomponents");
@@ -2641,7 +2639,7 @@ namespace Vintagestory.GameContent
             var dummySlot = new DummySlot();
 
             var allowedDresstypes = stack.ItemAttributes?["allowedDresstypes"].AsArray<string>();
-            string[] placementSurfaces = [..stack.Block?.GetBehavior<BlockBehaviorDisplay>()?.PlacementSurfaces.Select(ps => ps.DisplayCategory) ?? []];
+            string[] placementSurfaces = [.. stack.Block?.GetBehavior<BlockBehaviorDisplay>()?.PlacementSurfaces.Select(ps => ps.DisplayCategory) ?? []];
             foreach (var val in allStacks)
             {
                 if ((placementSurfaces.Length > 0 && placementSurfaces.Any(key => BlockBehaviorDisplay.GetDisplayableAttributes(new DummySlot(val), key) != null)) ||
@@ -2714,9 +2712,6 @@ namespace Vintagestory.GameContent
                             if (recipe == null) continue;
 
                             ItemStack mealBlock = dstack.Clone();
-                            mealBlock.Attributes.SetInt("pieSize", 4);
-                            mealBlock.Attributes.SetString("topCrustType", BlockPie.TopCrustTypes[capi.World.Rand.Next(BlockPie.TopCrustTypes.Length)].Code);
-                            mealBlock.Attributes.SetInt("bakeLevel", 2);
                             MealstackTextComponent mealComp = new MealstackTextComponent(capi, mealBlock, recipe, 40, EnumFloat.Inline, (cs) => openDetailPageFor("handbook-mealrecipe-" + recipe.Code + "-pie"), 6, true);
                             components.Add(mealComp);
                         }

--- a/Systems/Handbook/Gui/GuiHandbookMealRecipePage.cs
+++ b/Systems/Handbook/Gui/GuiHandbookMealRecipePage.cs
@@ -89,7 +89,6 @@ namespace Vintagestory.GameContent
             {
                 dummySlot = new(new(capi.World.BlockAccessor.GetBlock("pie-perfect")), unspoilableInventory);
                 dummySlot.Itemstack!.Attributes.SetInt("pieSize", 4);
-                dummySlot.Itemstack.Attributes.SetString("topCrustType", BlockPie.TopCrustTypes[capi.World.Rand.Next(BlockPie.TopCrustTypes.Length)].Code);
                 dummySlot.Itemstack.Attributes.SetInt("bakeLevel", 2);
             }
             else
@@ -143,10 +142,16 @@ namespace Vintagestory.GameContent
             if ((secondsVisible -= dt) <= 0)
             {
                 secondsVisible = 1;
-                if (isPie) dummySlot.Itemstack?.Attributes.SetString("topCrustType", BlockPie.TopCrustTypes[capi.World.Rand.Next(BlockPie.TopCrustTypes.Length)].Code);
-                else dummySlot.Itemstack = new(BlockMeal.RandomMealBowl(capi));
+                if (!isPie) dummySlot.Itemstack = new(BlockMeal.RandomMealBowl(capi));
                 var cachedValidStacks = ObjectCacheUtil.TryGet<Dictionary<CookingRecipeIngredient, HashSet<ItemStack?>>?>(capi, "valstacksbying-" + Recipe.Code);
-                mealBlock?.SetContents(Recipe.Code, dummySlot.Itemstack!, isPie ? BlockPie.GenerateRandomPie(capi, ref cachedValidStacks, Recipe) : Recipe.GenerateRandomMeal(capi, ref cachedValidStacks, ObjectCacheUtil.TryGet<ItemStack[]>(capi, "handbookallstacks"), slots), 1);
+                mealBlock?.SetContents(Recipe.Code, dummySlot.Itemstack!, isPie ? BlockPie.GenerateRandomPie(capi, ref cachedValidStacks, Recipe) : Recipe.GenerateRandomMeal(capi, ref cachedValidStacks, ObjectCacheUtil.TryGet<ItemStack[]>(capi, "handbookallstacks") ?? [], slots), 1);
+
+                if ((mealBlock as BlockPie)?.GetContents(capi.World, dummySlot.Itemstack) is ItemStack?[] cStacks
+                    && InPieProperties.ReadFrom(cStacks[5]) is InPieProperties toppingProps
+                    && toppingProps.PartType == EnumPiePartType.Crust)
+                {
+                    dummySlot.Itemstack?.Attributes.SetString("topCrustType", BlockPie.TopCrustTypes[capi.World.Rand.Next(BlockPie.TopCrustTypes.Length)].Code);
+                }
             }
 
             if (Texture == null || scissorBounds == null)

--- a/Systems/Handbook/Gui/GuiHandbookMealRecipePage.cs
+++ b/Systems/Handbook/Gui/GuiHandbookMealRecipePage.cs
@@ -9,8 +9,6 @@ using Vintagestory.API.Config;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Util;
 
-#nullable enable
-
 namespace Vintagestory.GameContent
 {
     class IngredientMinMax

--- a/Systems/Handbook/Gui/GuiHandbookMealRecipePage.cs
+++ b/Systems/Handbook/Gui/GuiHandbookMealRecipePage.cs
@@ -144,10 +144,10 @@ namespace Vintagestory.GameContent
                 secondsVisible = 1;
                 if (!isPie) dummySlot.Itemstack = new(BlockMeal.RandomMealBowl(capi));
                 var cachedValidStacks = ObjectCacheUtil.TryGet<Dictionary<CookingRecipeIngredient, HashSet<ItemStack?>>?>(capi, "valstacksbying-" + Recipe.Code);
-                mealBlock?.SetContents(Recipe.Code, dummySlot.Itemstack!, isPie ? BlockPie.GenerateRandomPie(capi, ref cachedValidStacks, Recipe) : Recipe.GenerateRandomMeal(capi, ref cachedValidStacks, ObjectCacheUtil.TryGet<ItemStack[]>(capi, "handbookallstacks") ?? [], slots), 1);
+                mealBlock?.SetContents(Recipe.Code, dummySlot.Itemstack!, isPie ? BlockPie.GenerateRandomPie(capi, ref cachedValidStacks, Recipe) : Recipe.GenerateRandomMeal(capi, ref cachedValidStacks, ObjectCacheUtil.TryGet<ItemStack[]>(capi, "handbookallstacks") ?? [], slots));
 
                 if ((mealBlock as BlockPie)?.GetContents(capi.World, dummySlot.Itemstack) is ItemStack?[] cStacks
-                    && InPieProperties.ReadFrom(cStacks[5]) is InPieProperties toppingProps
+                    && InPieProperties.ReadFrom(cStacks.ElementAtOrDefault(5)) is InPieProperties toppingProps
                     && toppingProps.PartType == EnumPiePartType.Crust)
                 {
                     dummySlot.Itemstack?.Attributes.SetString("topCrustType", BlockPie.TopCrustTypes[capi.World.Rand.Next(BlockPie.TopCrustTypes.Length)].Code);

--- a/Systems/Handbook/Gui/GuiHandbookMealRecipePage.cs
+++ b/Systems/Handbook/Gui/GuiHandbookMealRecipePage.cs
@@ -9,6 +9,8 @@ using Vintagestory.API.Config;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Util;
 
+#nullable enable
+
 namespace Vintagestory.GameContent
 {
     class IngredientMinMax

--- a/Systems/Handbook/Gui/GuiHandbookMealRecipePage.cs
+++ b/Systems/Handbook/Gui/GuiHandbookMealRecipePage.cs
@@ -89,7 +89,6 @@ namespace Vintagestory.GameContent
             {
                 dummySlot = new(new(capi.World.BlockAccessor.GetBlock("pie-perfect")), unspoilableInventory);
                 dummySlot.Itemstack!.Attributes.SetInt("pieSize", 4);
-                dummySlot.Itemstack.Attributes.SetString("topCrustType", BlockPie.TopCrustTypes[capi.World.Rand.Next(BlockPie.TopCrustTypes.Length)].Code);
                 dummySlot.Itemstack.Attributes.SetInt("bakeLevel", 2);
             }
             else
@@ -143,10 +142,16 @@ namespace Vintagestory.GameContent
             if ((secondsVisible -= dt) <= 0)
             {
                 secondsVisible = 1;
-                if (isPie) dummySlot.Itemstack?.Attributes.SetString("topCrustType", BlockPie.TopCrustTypes[capi.World.Rand.Next(BlockPie.TopCrustTypes.Length)].Code);
-                else dummySlot.Itemstack = new(BlockMeal.RandomMealBowl(capi));
+                if (!isPie) dummySlot.Itemstack = new(BlockMeal.RandomMealBowl(capi));
                 var cachedValidStacks = ObjectCacheUtil.TryGet<Dictionary<CookingRecipeIngredient, HashSet<ItemStack?>>?>(capi, "valstacksbying-" + Recipe.Code);
-                mealBlock?.SetContents(Recipe.Code, dummySlot.Itemstack!, isPie ? BlockPie.GenerateRandomPie(capi, ref cachedValidStacks, Recipe) : Recipe.GenerateRandomMeal(capi, ref cachedValidStacks, ObjectCacheUtil.TryGet<ItemStack[]>(capi, "handbookallstacks"), slots), 1);
+                mealBlock?.SetContents(Recipe.Code, dummySlot.Itemstack!, isPie ? BlockPie.GenerateRandomPie(capi, ref cachedValidStacks, Recipe) : Recipe.GenerateRandomMeal(capi, ref cachedValidStacks, ObjectCacheUtil.TryGet<ItemStack[]>(capi, "handbookallstacks") ?? [], slots));
+
+                if ((mealBlock as BlockPie)?.GetContents(capi.World, dummySlot.Itemstack) is ItemStack?[] cStacks
+                    && InPieProperties.ReadFrom(cStacks.ElementAtOrDefault(5)) is InPieProperties toppingProps
+                    && toppingProps.PartType == EnumPiePartType.Crust)
+                {
+                    dummySlot.Itemstack?.Attributes.SetString("topCrustType", BlockPie.TopCrustTypes[capi.World.Rand.Next(BlockPie.TopCrustTypes.Length)].Code);
+                }
             }
 
             if (Texture == null || scissorBounds == null)

--- a/Systems/Handbook/Gui/MealstackTextComponent.cs
+++ b/Systems/Handbook/Gui/MealstackTextComponent.cs
@@ -1,5 +1,6 @@
 using Cairo;
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using Vintagestory.API.Common;
 using Vintagestory.API.Config;
@@ -60,7 +61,20 @@ namespace Vintagestory.API.Client
             {
                 if (isPie) dummySlot.Itemstack.Attributes.SetString("topCrustType", BlockPie.TopCrustTypes[capi.World.Rand.Next(BlockPie.TopCrustTypes.Length)].Code);
                 var cachedValidStacks = ObjectCacheUtil.TryGet<Dictionary<CookingRecipeIngredient, HashSet<ItemStack?>>?>(capi, "valstacksbying-" + recipe.Code);
-                meal.SetContents(recipe.Code!, dummySlot.Itemstack, isPie ? BlockPie.GenerateRandomPie(capi, ref cachedValidStacks, recipe, ingredient) : recipe.GenerateRandomMeal(capi, ref cachedValidStacks, ObjectCacheUtil.TryGet<ItemStack[]>(capi, "handbookallstacks"), slots, ingredient), 1);
+                meal.SetContents(recipe.Code!, dummySlot.Itemstack, isPie ? BlockPie.GenerateRandomPie(capi, ref cachedValidStacks, recipe, ingredient) : recipe.GenerateRandomMeal(capi, ref cachedValidStacks, ObjectCacheUtil.TryGet<ItemStack[]>(capi, "handbookallstacks") ?? [], slots, ingredient), 1);
+
+                if (dummySlot.Itemstack.Collectible is BlockPie)
+                {
+                    dummySlot.Itemstack.Attributes.SetInt("pieSize", 4);
+                    dummySlot.Itemstack.Attributes.SetInt("bakeLevel", 2);
+
+                    ItemStack?[] cStacks = meal.GetContents(capi.World, dummySlot.Itemstack);
+                    if (InPieProperties.ReadFrom(cStacks[5]) is InPieProperties toppingProps
+                        && toppingProps.PartType == EnumPiePartType.Crust)
+                    {
+                        dummySlot.Itemstack.Attributes.SetString("topCrustType", BlockPie.TopCrustTypes[capi.World.Rand.Next(BlockPie.TopCrustTypes.Length)].Code);
+                    }
+                }
             }
 
             this.ingredient = ingredient;
@@ -96,9 +110,9 @@ namespace Vintagestory.API.Client
             {
                 ctx.SetSourceRGBA(1, 1, 1, 0.2);
                 ctx.Rectangle(
-                    BoundsPerLine[0].X, 
+                    BoundsPerLine[0].X,
                     BoundsPerLine[0].Y,  /* - BoundsPerLine[0].Ascent / 2 */ /* why /2??? */ /* why this ascent at all???? wtf? */
-                    BoundsPerLine[0].Width, 
+                    BoundsPerLine[0].Width,
                     BoundsPerLine[0].Height
                 );
                 ctx.Fill();
@@ -112,24 +126,30 @@ namespace Vintagestory.API.Client
             LineRectangled bounds = BoundsPerLine[0];
             bool mouseover = bounds.PointInside(relx, rely);
 
-            IBlockMealContainer? mealBlock = dummySlot.Itemstack?.Collectible as IBlockMealContainer;
-            if (mealBlock == null) return;
+            if (dummySlot.Itemstack?.Collectible is not IBlockMealContainer mealBlock) return;
 
             if (!mouseover && (secondsVisible -= deltaTime) <= 0)
             {
                 secondsVisible = 1;
-                if (RandomBowlBlock)
+                if (RandomBowlBlock && !isPie)
                 {
-                    if (isPie) dummySlot.Itemstack?.Attributes.SetString("topCrustType", BlockPie.TopCrustTypes[capi.World.Rand.Next(BlockPie.TopCrustTypes.Length)].Code);
-                    else dummySlot.Itemstack = new(BlockMeal.RandomMealBowl(capi));
+                    dummySlot.Itemstack = new(BlockMeal.RandomMealBowl(capi));
                 }
+
                 var cachedValidStacks = ObjectCacheUtil.TryGet<Dictionary<CookingRecipeIngredient, HashSet<ItemStack?>>?>(capi, "valstacksbying-" + recipe.Code);
-                mealBlock.SetContents(recipe.Code!, dummySlot.Itemstack!, isPie ? BlockPie.GenerateRandomPie(capi, ref cachedValidStacks, recipe, ingredient) : recipe.GenerateRandomMeal(capi, ref cachedValidStacks, ObjectCacheUtil.TryGet<ItemStack[]>(capi, "handbookallstacks"), slots, ingredient), 1);
+                mealBlock.SetContents(recipe.Code!, dummySlot.Itemstack!, isPie ? BlockPie.GenerateRandomPie(capi, ref cachedValidStacks, recipe, ingredient) : recipe.GenerateRandomMeal(capi, ref cachedValidStacks, ObjectCacheUtil.TryGet<ItemStack[]>(capi, "handbookallstacks") ?? [], slots, ingredient), 1);
+                if (isPie
+                    && mealBlock.GetContents(capi.World, dummySlot.Itemstack!) is ItemStack?[] cStacks
+                    && InPieProperties.ReadFrom(cStacks[5]) is InPieProperties toppingProps
+                    && toppingProps.PartType == EnumPiePartType.Crust)
+                {
+                    dummySlot.Itemstack!.Attributes.SetString("topCrustType", BlockPie.TopCrustTypes[capi.World.Rand.Next(BlockPie.TopCrustTypes.Length)].Code);
+                }
             }
 
             ElementBounds scibounds = ElementBounds.FixedSize((int)(bounds.Width / RuntimeEnv.GUIScale), (int)(bounds.Height / RuntimeEnv.GUIScale));
             scibounds.ParentBounds = capi.Gui.WindowBounds;
-            
+
             scibounds.CalcWorldBounds();
             scibounds.absFixedX = renderX + bounds.X + renderOffset.X;
             scibounds.absFixedY = renderY + bounds.Y + renderOffset.Y /*- BoundsPerLine[0].Ascent / 2 - why???? */;
@@ -138,10 +158,10 @@ namespace Vintagestory.API.Client
 
             api.Render.PushScissor(scibounds, true);
 
-            api.Render.RenderItemstackToGui(dummySlot, 
-                renderX + bounds.X + bounds.Width * 0.5f + renderOffset.X + offX, 
-                renderY + bounds.Y + bounds.Height * 0.5f + renderOffset.Y + offY /*- BoundsPerLine[0].Ascent / 2 - why?????*/, 
-                100 + renderOffset.Z, (float)GuiElement.scaled(unscaledSize) * renderSize, 
+            api.Render.RenderItemstackToGui(dummySlot,
+                renderX + bounds.X + bounds.Width * 0.5f + renderOffset.X + offX,
+                renderY + bounds.Y + bounds.Height * 0.5f + renderOffset.Y + offY /*- BoundsPerLine[0].Ascent / 2 - why?????*/,
+                100 + renderOffset.Z, (float)GuiElement.scaled(unscaledSize) * renderSize,
                 ColorUtil.WhiteArgb, true, false, ShowStackSize
             );
 

--- a/Systems/Handbook/Gui/MealstackTextComponent.cs
+++ b/Systems/Handbook/Gui/MealstackTextComponent.cs
@@ -61,7 +61,7 @@ namespace Vintagestory.API.Client
             {
                 if (isPie) dummySlot.Itemstack.Attributes.SetString("topCrustType", BlockPie.TopCrustTypes[capi.World.Rand.Next(BlockPie.TopCrustTypes.Length)].Code);
                 var cachedValidStacks = ObjectCacheUtil.TryGet<Dictionary<CookingRecipeIngredient, HashSet<ItemStack?>>?>(capi, "valstacksbying-" + recipe.Code);
-                meal.SetContents(recipe.Code!, dummySlot.Itemstack, isPie ? BlockPie.GenerateRandomPie(capi, ref cachedValidStacks, recipe, ingredient) : recipe.GenerateRandomMeal(capi, ref cachedValidStacks, ObjectCacheUtil.TryGet<ItemStack[]>(capi, "handbookallstacks") ?? [], slots, ingredient), 1);
+                meal.SetContents(recipe.Code!, dummySlot.Itemstack, isPie ? BlockPie.GenerateRandomPie(capi, ref cachedValidStacks, recipe, ingredient) : recipe.GenerateRandomMeal(capi, ref cachedValidStacks, ObjectCacheUtil.TryGet<ItemStack[]>(capi, "handbookallstacks") ?? [], slots, ingredient));
 
                 if (dummySlot.Itemstack.Collectible is BlockPie)
                 {
@@ -69,7 +69,7 @@ namespace Vintagestory.API.Client
                     dummySlot.Itemstack.Attributes.SetInt("bakeLevel", 2);
 
                     ItemStack?[] cStacks = meal.GetContents(capi.World, dummySlot.Itemstack);
-                    if (InPieProperties.ReadFrom(cStacks[5]) is InPieProperties toppingProps
+                    if (InPieProperties.ReadFrom(cStacks.ElementAtOrDefault(5)) is InPieProperties toppingProps
                         && toppingProps.PartType == EnumPiePartType.Crust)
                     {
                         dummySlot.Itemstack.Attributes.SetString("topCrustType", BlockPie.TopCrustTypes[capi.World.Rand.Next(BlockPie.TopCrustTypes.Length)].Code);
@@ -137,10 +137,10 @@ namespace Vintagestory.API.Client
                 }
 
                 var cachedValidStacks = ObjectCacheUtil.TryGet<Dictionary<CookingRecipeIngredient, HashSet<ItemStack?>>?>(capi, "valstacksbying-" + recipe.Code);
-                mealBlock.SetContents(recipe.Code!, dummySlot.Itemstack!, isPie ? BlockPie.GenerateRandomPie(capi, ref cachedValidStacks, recipe, ingredient) : recipe.GenerateRandomMeal(capi, ref cachedValidStacks, ObjectCacheUtil.TryGet<ItemStack[]>(capi, "handbookallstacks") ?? [], slots, ingredient), 1);
+                mealBlock.SetContents(recipe.Code!, dummySlot.Itemstack!, isPie ? BlockPie.GenerateRandomPie(capi, ref cachedValidStacks, recipe, ingredient) : recipe.GenerateRandomMeal(capi, ref cachedValidStacks, ObjectCacheUtil.TryGet<ItemStack[]>(capi, "handbookallstacks") ?? [], slots, ingredient));
                 if (isPie
                     && mealBlock.GetContents(capi.World, dummySlot.Itemstack!) is ItemStack?[] cStacks
-                    && InPieProperties.ReadFrom(cStacks[5]) is InPieProperties toppingProps
+                    && InPieProperties.ReadFrom(cStacks.ElementAtOrDefault(5)) is InPieProperties toppingProps
                     && toppingProps.PartType == EnumPiePartType.Crust)
                 {
                     dummySlot.Itemstack!.Attributes.SetString("topCrustType", BlockPie.TopCrustTypes[capi.World.Rand.Next(BlockPie.TopCrustTypes.Length)].Code);

--- a/Systems/Handbook/Gui/MealstackTextComponent.cs
+++ b/Systems/Handbook/Gui/MealstackTextComponent.cs
@@ -1,5 +1,6 @@
 using Cairo;
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using Vintagestory.API.Common;
 using Vintagestory.API.Config;
@@ -60,7 +61,20 @@ namespace Vintagestory.API.Client
             {
                 if (isPie) dummySlot.Itemstack.Attributes.SetString("topCrustType", BlockPie.TopCrustTypes[capi.World.Rand.Next(BlockPie.TopCrustTypes.Length)].Code);
                 var cachedValidStacks = ObjectCacheUtil.TryGet<Dictionary<CookingRecipeIngredient, HashSet<ItemStack?>>?>(capi, "valstacksbying-" + recipe.Code);
-                meal.SetContents(recipe.Code!, dummySlot.Itemstack, isPie ? BlockPie.GenerateRandomPie(capi, ref cachedValidStacks, recipe, ingredient) : recipe.GenerateRandomMeal(capi, ref cachedValidStacks, ObjectCacheUtil.TryGet<ItemStack[]>(capi, "handbookallstacks"), slots, ingredient), 1);
+                meal.SetContents(recipe.Code!, dummySlot.Itemstack, isPie ? BlockPie.GenerateRandomPie(capi, ref cachedValidStacks, recipe, ingredient) : recipe.GenerateRandomMeal(capi, ref cachedValidStacks, ObjectCacheUtil.TryGet<ItemStack[]>(capi, "handbookallstacks") ?? [], slots, ingredient));
+
+                if (dummySlot.Itemstack.Collectible is BlockPie)
+                {
+                    dummySlot.Itemstack.Attributes.SetInt("pieSize", 4);
+                    dummySlot.Itemstack.Attributes.SetInt("bakeLevel", 2);
+
+                    ItemStack?[] cStacks = meal.GetContents(capi.World, dummySlot.Itemstack);
+                    if (InPieProperties.ReadFrom(cStacks.ElementAtOrDefault(5)) is InPieProperties toppingProps
+                        && toppingProps.PartType == EnumPiePartType.Crust)
+                    {
+                        dummySlot.Itemstack.Attributes.SetString("topCrustType", BlockPie.TopCrustTypes[capi.World.Rand.Next(BlockPie.TopCrustTypes.Length)].Code);
+                    }
+                }
             }
 
             this.ingredient = ingredient;
@@ -96,9 +110,9 @@ namespace Vintagestory.API.Client
             {
                 ctx.SetSourceRGBA(1, 1, 1, 0.2);
                 ctx.Rectangle(
-                    BoundsPerLine[0].X, 
+                    BoundsPerLine[0].X,
                     BoundsPerLine[0].Y,  /* - BoundsPerLine[0].Ascent / 2 */ /* why /2??? */ /* why this ascent at all???? wtf? */
-                    BoundsPerLine[0].Width, 
+                    BoundsPerLine[0].Width,
                     BoundsPerLine[0].Height
                 );
                 ctx.Fill();
@@ -112,24 +126,30 @@ namespace Vintagestory.API.Client
             LineRectangled bounds = BoundsPerLine[0];
             bool mouseover = bounds.PointInside(relx, rely);
 
-            IBlockMealContainer? mealBlock = dummySlot.Itemstack?.Collectible as IBlockMealContainer;
-            if (mealBlock == null) return;
+            if (dummySlot.Itemstack?.Collectible is not IBlockMealContainer mealBlock) return;
 
             if (!mouseover && (secondsVisible -= deltaTime) <= 0)
             {
                 secondsVisible = 1;
-                if (RandomBowlBlock)
+                if (RandomBowlBlock && !isPie)
                 {
-                    if (isPie) dummySlot.Itemstack?.Attributes.SetString("topCrustType", BlockPie.TopCrustTypes[capi.World.Rand.Next(BlockPie.TopCrustTypes.Length)].Code);
-                    else dummySlot.Itemstack = new(BlockMeal.RandomMealBowl(capi));
+                    dummySlot.Itemstack = new(BlockMeal.RandomMealBowl(capi));
                 }
+
                 var cachedValidStacks = ObjectCacheUtil.TryGet<Dictionary<CookingRecipeIngredient, HashSet<ItemStack?>>?>(capi, "valstacksbying-" + recipe.Code);
-                mealBlock.SetContents(recipe.Code!, dummySlot.Itemstack!, isPie ? BlockPie.GenerateRandomPie(capi, ref cachedValidStacks, recipe, ingredient) : recipe.GenerateRandomMeal(capi, ref cachedValidStacks, ObjectCacheUtil.TryGet<ItemStack[]>(capi, "handbookallstacks"), slots, ingredient), 1);
+                mealBlock.SetContents(recipe.Code!, dummySlot.Itemstack!, isPie ? BlockPie.GenerateRandomPie(capi, ref cachedValidStacks, recipe, ingredient) : recipe.GenerateRandomMeal(capi, ref cachedValidStacks, ObjectCacheUtil.TryGet<ItemStack[]>(capi, "handbookallstacks") ?? [], slots, ingredient));
+                if (isPie
+                    && mealBlock.GetContents(capi.World, dummySlot.Itemstack!) is ItemStack?[] cStacks
+                    && InPieProperties.ReadFrom(cStacks.ElementAtOrDefault(5)) is InPieProperties toppingProps
+                    && toppingProps.PartType == EnumPiePartType.Crust)
+                {
+                    dummySlot.Itemstack!.Attributes.SetString("topCrustType", BlockPie.TopCrustTypes[capi.World.Rand.Next(BlockPie.TopCrustTypes.Length)].Code);
+                }
             }
 
             ElementBounds scibounds = ElementBounds.FixedSize((int)(bounds.Width / RuntimeEnv.GUIScale), (int)(bounds.Height / RuntimeEnv.GUIScale));
             scibounds.ParentBounds = capi.Gui.WindowBounds;
-            
+
             scibounds.CalcWorldBounds();
             scibounds.absFixedX = renderX + bounds.X + renderOffset.X;
             scibounds.absFixedY = renderY + bounds.Y + renderOffset.Y /*- BoundsPerLine[0].Ascent / 2 - why???? */;
@@ -138,10 +158,10 @@ namespace Vintagestory.API.Client
 
             api.Render.PushScissor(scibounds, true);
 
-            api.Render.RenderItemstackToGui(dummySlot, 
-                renderX + bounds.X + bounds.Width * 0.5f + renderOffset.X + offX, 
-                renderY + bounds.Y + bounds.Height * 0.5f + renderOffset.Y + offY /*- BoundsPerLine[0].Ascent / 2 - why?????*/, 
-                100 + renderOffset.Z, (float)GuiElement.scaled(unscaledSize) * renderSize, 
+            api.Render.RenderItemstackToGui(dummySlot,
+                renderX + bounds.X + bounds.Width * 0.5f + renderOffset.X + offX,
+                renderY + bounds.Y + bounds.Height * 0.5f + renderOffset.Y + offY /*- BoundsPerLine[0].Ascent / 2 - why?????*/,
+                100 + renderOffset.Z, (float)GuiElement.scaled(unscaledSize) * renderSize,
                 ColorUtil.WhiteArgb, true, false, ShowStackSize
             );
 

--- a/Systems/Handbook/SurvivalHandbook.cs
+++ b/Systems/Handbook/SurvivalHandbook.cs
@@ -164,14 +164,14 @@ namespace Vintagestory.GameContent
         {
             ObjectCacheUtil.GetOrCreate(capi, "valstacksbying-" + recipe.Code, () =>
             {
-                Dictionary<CookingRecipeIngredient, HashSet<ItemStack>> valStacksByIng = [];
+                Dictionary<CookingRecipeIngredient, HashSet<ItemStack?>> valStacksByIng = [];
 
-                foreach (var ingredient in recipe.Ingredients)
+                foreach (var ingredient in recipe.Ingredients ?? [])
                 {
-                    HashSet<ItemStack> ingredientStacks = [];
+                    HashSet<ItemStack?> ingredientStacks = [];
 
                     ingredient.Resolve(capi.World, "handbook meal recipes");
-                    foreach (var astack in ObjectCacheUtil.TryGet<ItemStack[]>(capi, "handbookallstacks"))
+                    foreach (ItemStack astack in ObjectCacheUtil.TryGet<ItemStack[]>(capi, "handbookallstacks") ?? [])
                     {
                         if (ingredient.GetMatchingStack(astack) is not CookingRecipeStack vstack) continue;
 

--- a/Systems/Handbook/SurvivalHandbook.cs
+++ b/Systems/Handbook/SurvivalHandbook.cs
@@ -164,14 +164,14 @@ namespace Vintagestory.GameContent
         {
             ObjectCacheUtil.GetOrCreate(capi, "valstacksbying-" + recipe.Code, () =>
             {
-                Dictionary<CookingRecipeIngredient, HashSet<ItemStack>> valStacksByIng = [];
+                Dictionary<CookingRecipeIngredient, HashSet<ItemStack?>> valStacksByIng = [];
 
-                foreach (var ingredient in recipe.Ingredients)
+                foreach (var ingredient in recipe.Ingredients ?? [])
                 {
-                    HashSet<ItemStack> ingredientStacks = [];
+                    HashSet<ItemStack?> ingredientStacks = [];
 
                     ingredient.Resolve(capi.World, "handbook meal recipes");
-                    foreach (var astack in ObjectCacheUtil.TryGet<ItemStack[]>(capi, "handbookallstacks"))
+                    foreach (ItemStack astack in ObjectCacheUtil.TryGet<ItemStack[]>(capi, "handbookallstacks") ?? [])
                     {
                         if (ingredient.GetMatchingStack(astack) is not CookingRecipeStack vstack) continue;
 
@@ -180,7 +180,16 @@ namespace Vintagestory.GameContent
 
                         if (BlockLiquidContainerBase.GetContainableProps(stack) is WaterTightContainableProps props)
                         {
-                            stack.StackSize *= (int)(props.ItemsPerLitre * ingredient.PortionSizeLitres);
+                            // Don't use *= in case the multiplier isn't an int because of nonstandard items per litre.
+                            // e.g. 30 * 150 * 0.01 = 45
+                            //      30 *= (int)(150 * 0.1) would still be 30 because the multiplier is 1.5 -> 1
+
+                            // Use ceil to make sure recipe matching works. Truncation breaks it.
+                            // e.g. 1 * 104 * 0.2 = 20.8 -> 21
+                            // Only 20 means CookingRecipe.Match will fail because it always truncates
+                            // and we will never have 104 items, only 100.
+
+                            //stack.StackSize = (int)Math.Ceiling(stack.StackSize * props.ItemsPerLitre * ingredient.PortionSizeLitres);
                         }
 
                         ingredientStacks.Add(stack);

--- a/Systems/Liquid/BlockLiquidContainerBase.cs
+++ b/Systems/Liquid/BlockLiquidContainerBase.cs
@@ -864,7 +864,7 @@ namespace Vintagestory.GameContent
             nutriProps.Intoxication *= litres;
             nutriProps.Psychedelic *= litres;
 
-            nutriProps.EatenStack = new JsonItemStack { ResolvedItemstack = itemstack.Clone() };
+            nutriProps.EatenStack = new JsonItemStack { ResolvedItemstack = itemstack.Clone(), Code = itemstack.Collectible.Code };
             nutriProps.EatenStack.ResolvedItemstack.StackSize = 1;
             (nutriProps.EatenStack.ResolvedItemstack.Collectible as BlockLiquidContainerBase)?.SetContent(nutriProps.EatenStack.ResolvedItemstack, null);
 

--- a/Systems/Liquid/BlockLiquidContainerBase.cs
+++ b/Systems/Liquid/BlockLiquidContainerBase.cs
@@ -309,20 +309,14 @@ namespace Vintagestory.GameContent
         }
 
 
-
+        public static WaterTightContainableProps? GetContainableProps(CollectibleObject? obj)
+        {
+            return obj?.Attributes?["waterTightContainerProps"].AsObject<WaterTightContainableProps?>(null, obj.Code.Domain);
+        }
 
         public static WaterTightContainableProps? GetContainableProps(ItemStack? stack)
         {
-            try
-            {
-                JsonObject? obj = stack?.ItemAttributes?["waterTightContainerProps"];
-                if (obj != null && obj.Exists) return obj.AsObject<WaterTightContainableProps>(null, stack!.Collectible.Code.Domain);
-                return null;
-            }
-            catch (Exception)
-            {
-                return null;
-            }
+            return GetContainableProps(stack?.Collectible);
         }
 
         /// <summary>

--- a/Systems/Liquid/BlockLiquidContainerBase.cs
+++ b/Systems/Liquid/BlockLiquidContainerBase.cs
@@ -125,7 +125,8 @@ namespace Vintagestory.GameContent
             if (Attributes?["capacityLitres"].Exists == true)
             {
                 capacityLitresFromAttributes = Attributes["capacityLitres"].AsInt(10);
-            } else
+            }
+            else
             {
                 var props = Attributes?["liquidContainerProps"]?.AsObject<LiquidTopOpenContainerProps>(null, Code.Domain);
                 if (props != null)
@@ -137,7 +138,8 @@ namespace Vintagestory.GameContent
             if (Attributes?["drinkPortionSize"].Exists == true)
             {
                 drinkPortionSizeFromAttributes = Attributes["drinkPortionSize"].AsInt(1);
-            } else
+            }
+            else
             {
                 var props = Attributes?["liquidContainerProps"]?.AsObject<LiquidTopOpenContainerProps>(null, Code.Domain);
                 if (props != null)
@@ -162,7 +164,7 @@ namespace Vintagestory.GameContent
                 foreach (CollectibleObject obj in api.World.Collectibles)
                 {
                     if (obj is BlockLiquidContainerBase blc && blc.IsTopOpened && blc.AllowHeldLiquidTransfer)
-                    liquidContainerStacks.Add(new ItemStack(obj));
+                        liquidContainerStacks.Add(new ItemStack(obj));
                 }
 
                 var lcstacks = liquidContainerStacks.ToArray();
@@ -331,7 +333,7 @@ namespace Vintagestory.GameContent
             if (becontainer == null) return null;
 
             int slotid = GetContainerSlotId(pos);
-            if (slotid >=becontainer.Inventory.Count) return null;
+            if (slotid >= becontainer.Inventory.Count) return null;
 
             ItemStack? stack = becontainer.Inventory[slotid]?.Itemstack;
             if (stack == null) return null;
@@ -836,7 +838,8 @@ namespace Vintagestory.GameContent
 
             if (nutriProps.Health != 0)
             {
-                byEntity.ReceiveDamage(new DamageSource {
+                byEntity.ReceiveDamage(new DamageSource
+                {
                     Source = EnumDamageSource.Internal,
                     Type = nutriProps.Health > 0 ? EnumDamageType.Heal : EnumDamageType.Poison
                 }, Math.Abs(nutriProps.Health));
@@ -1036,7 +1039,7 @@ namespace Vintagestory.GameContent
             }
 
 
-            int moved = SplitStackAndPerformAction(byEntity, containerSlot, (stack) => { SetContent(stack, null); return contentStack.StackSize; } );
+            int moved = SplitStackAndPerformAction(byEntity, containerSlot, (stack) => { SetContent(stack, null); return contentStack.StackSize; });
 
             DoLiquidMovedEffects(byPlayer, contentStack, moved, EnumLiquidDirection.Pour);
             return true;

--- a/Systems/Liquid/BlockLiquidContainerBase.cs
+++ b/Systems/Liquid/BlockLiquidContainerBase.cs
@@ -125,7 +125,8 @@ namespace Vintagestory.GameContent
             if (Attributes?["capacityLitres"].Exists == true)
             {
                 capacityLitresFromAttributes = Attributes["capacityLitres"].AsInt(10);
-            } else
+            }
+            else
             {
                 var props = Attributes?["liquidContainerProps"]?.AsObject<LiquidTopOpenContainerProps>(null, Code.Domain);
                 if (props != null)
@@ -137,7 +138,8 @@ namespace Vintagestory.GameContent
             if (Attributes?["drinkPortionSize"].Exists == true)
             {
                 drinkPortionSizeFromAttributes = Attributes["drinkPortionSize"].AsInt(1);
-            } else
+            }
+            else
             {
                 var props = Attributes?["liquidContainerProps"]?.AsObject<LiquidTopOpenContainerProps>(null, Code.Domain);
                 if (props != null)
@@ -162,7 +164,7 @@ namespace Vintagestory.GameContent
                 foreach (CollectibleObject obj in api.World.Collectibles)
                 {
                     if (obj is BlockLiquidContainerBase blc && blc.IsTopOpened && blc.AllowHeldLiquidTransfer)
-                    liquidContainerStacks.Add(new ItemStack(obj));
+                        liquidContainerStacks.Add(new ItemStack(obj));
                 }
 
                 var lcstacks = liquidContainerStacks.ToArray();
@@ -309,20 +311,14 @@ namespace Vintagestory.GameContent
         }
 
 
-
+        public static WaterTightContainableProps? GetContainableProps(CollectibleObject? obj)
+        {
+            return obj?.Attributes?["waterTightContainerProps"].AsObject<WaterTightContainableProps?>(null, obj.Code.Domain);
+        }
 
         public static WaterTightContainableProps? GetContainableProps(ItemStack? stack)
         {
-            try
-            {
-                JsonObject? obj = stack?.ItemAttributes?["waterTightContainerProps"];
-                if (obj != null && obj.Exists) return obj.AsObject<WaterTightContainableProps>(null, stack!.Collectible.Code.Domain);
-                return null;
-            }
-            catch (Exception)
-            {
-                return null;
-            }
+            return GetContainableProps(stack?.Collectible);
         }
 
         /// <summary>
@@ -337,7 +333,7 @@ namespace Vintagestory.GameContent
             if (becontainer == null) return null;
 
             int slotid = GetContainerSlotId(pos);
-            if (slotid >=becontainer.Inventory.Count) return null;
+            if (slotid >= becontainer.Inventory.Count) return null;
 
             ItemStack? stack = becontainer.Inventory[slotid]?.Itemstack;
             if (stack == null) return null;
@@ -842,7 +838,8 @@ namespace Vintagestory.GameContent
 
             if (nutriProps.Health != 0)
             {
-                byEntity.ReceiveDamage(new DamageSource {
+                byEntity.ReceiveDamage(new DamageSource
+                {
                     Source = EnumDamageSource.Internal,
                     Type = nutriProps.Health > 0 ? EnumDamageType.Heal : EnumDamageType.Poison
                 }, Math.Abs(nutriProps.Health));
@@ -867,7 +864,7 @@ namespace Vintagestory.GameContent
             nutriProps.Intoxication *= litres;
             nutriProps.Psychedelic *= litres;
 
-            nutriProps.EatenStack = new JsonItemStack { ResolvedItemstack = itemstack.Clone() };
+            nutriProps.EatenStack = new JsonItemStack { ResolvedItemstack = itemstack.Clone(), Code = itemstack.Collectible.Code };
             nutriProps.EatenStack.ResolvedItemstack.StackSize = 1;
             (nutriProps.EatenStack.ResolvedItemstack.Collectible as BlockLiquidContainerBase)?.SetContent(nutriProps.EatenStack.ResolvedItemstack, null);
 
@@ -1043,7 +1040,7 @@ namespace Vintagestory.GameContent
             }
 
 
-            int moved = SplitStackAndPerformAction(byEntity, containerSlot, (stack) => { SetContent(stack, null); return contentStack.StackSize; } );
+            int moved = SplitStackAndPerformAction(byEntity, containerSlot, (stack) => { SetContent(stack, null); return contentStack.StackSize; });
 
             DoLiquidMovedEffects(byPlayer, contentStack, moved, EnumLiquidDirection.Pour);
             return true;

--- a/Systems/Liquid/WaterTightContainableProps.cs
+++ b/Systems/Liquid/WaterTightContainableProps.cs
@@ -17,6 +17,9 @@ namespace Vintagestory.GameContent
         public float LiquidMaxYTranslate;
     }
 
+    /// <summary>
+    /// <!--<jsonalias>waterTightContainerProps</jsonalias>-->
+    /// </summary>
     public class WaterTightContainableProps
     {
         public bool Containable;

--- a/Systems/Liquid/WaterTightContainableProps.cs
+++ b/Systems/Liquid/WaterTightContainableProps.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Vintagestory.API;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 
@@ -6,6 +7,8 @@ using Vintagestory.API.Common;
 
 namespace Vintagestory.GameContent
 {
+    /// <!--<jsonalias>liquidContainerProps</jsonalias>-->
+    [DocumentAsJson]
     public class LiquidTopOpenContainerProps
     {
         public float CapacityLitres = 10f;
@@ -17,6 +20,7 @@ namespace Vintagestory.GameContent
         public float LiquidMaxYTranslate;
     }
 
+    [DocumentAsJson]
     public class WaterTightContainableProps
     {
         public bool Containable;


### PR DESCRIPTION
For future reference, I've created a branch that will remain in the original multi-commit form here: https://github.com/Lazula/vssurvivalmod/tree/improve-pie-archive

## Pie

### Major changes

* API Feature: Add InPieProperties.ReadFrom instead of using manual attribute checking everywhere. Added detailed documentation.
* API Feature: Move from using ingredient food categories in pies to a fully mixing code-based system that automatically prepends the category as a mixing code if it isn't in the list. Fixes a lot of code annoyances and allows modders to prioritize certain mixing codes over the food category codes in JSON. Previous behavior is unchanged for old JSON content.
* API Feature: If not provided, the default food category for pie ingredients is checked in all nutrition properties first. `NoNutrition` can be provided explicitly to prevent the nutritional food category from being used as a code. For example, a fruit can be marked as `NoNutrition`, but have a `protein` mixing code to indicate it only goes in meat pies. If no nutrition properties can be found and no food category is provided, the ingredient is marked as `NoNutrition` to prevent it from being used in pies and an error will be logged.
* API Feature: Add unique pie toppings. Toppings are limited by mixing codes like fillings. Dough can always be used as a topping and is not affected by mixing codes. Individual toppings can have unique shapes.
* API Feature: Add support for liquid pie ingredients.
* API Feature: Pie ingredients can have custom amounts.
* API Tweak: Add significantly more error logging for pies for players and modders.

### Minor changes

* Tweak: Remove duplicate pickup world interaction help from pies.
* Tweak: Prevent picking up pies while holding shift.
* Tweak: Pie ingredient freshness is now used instead of always making a completely fresh pie.
* Tweak: Add creative mode support to pies to avoid using up items.
* API Tweak: Ensure that GenerateRandomPie uses all applicable mixing codes if possible to prevent displaying pies with smaller code ranges than intended, e.g. selecting only vegetables when trying to display a pot pie.
* API Tweak: Limit ingredients shown in pie filling WorldInteraction to ones that can actually be added using CanAddIngredient.
* API Tweak: Extract CanAddIngredient out of TryAddIngredientFrom for the public API and out-parameterize the error information. Unique error codes have been added for each failure condition.
* API Tweak: Call UpdateAndGetTransitionStatesNative directly in pie code to skip all meal content-spoiling code instead of manually resetting content freshness each tick.
* API Feature: Ingredients in pies that do not have InPieProperties will be reported once per invalid item.

## Meals

* Fixed: If the inventory is full when eating a stackable meal such as pie, put the stack into the inventory first so that the partial meal is dropped instead. Fixes anegostudios/VintageStory-Issues#4493.
* Tweak: Show total satiety in meal nutrition facts.
* Fixed: Remove duplicate temperature display in cooked container held item info..
* Tweak: Serve meals from held crocks into crocks on shelves or the ground. Allows players to place partially full crocks in front of full crocks without holding shift. Fixes anegostudios/Vintagestory-Issues#9031.
* Tweak: Allow meals to be eaten while holding shift. Fixes anegostudios/VintageStory-Issues#8081.
* Tweak: Delete servings smaller than 1% to prevent strange-looking small numbers. Fixes anegostudios/VintageStory-Issues#3140.

## Bug fixes

* Fixed: Taking a slice of pie from a block did not cost tool durability.
* Fixed: Crash when rendering a pie with invalid size or no ingredients.
* Fixed: Pies displayed the wrong number of slices if the quantityServings attribute did not exist.
* Fixed: Table stacks were missing from the dough item interaction, showing an empty item stack instead.
* API Fixed: Picking up a raw pie while holding a pie it can stack with showed a non-filling error even though the action succeeded.
* API Fixed: Adding a part type to pie ingredients is now required.
* API Fixed: Off-by-one error caused pie mixing code check to ignore the most recent ingredient.
* API Fixed: Use pieSize attribute to determine number of slices if servings attribute does not exist.
* API Fixed: JsonItemStack instantiation in BlockLiquidContainerBase.GetNutritionProperties missing the Code member.