### PR TITLE
Rework clay oven interaction

### DIFF
--- a/Block/BlockClayOven.cs
+++ b/Block/BlockClayOven.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;
@@ -50,11 +51,11 @@ namespace Vintagestory.GameContent
         {
             base.OnLoaded(api);
 
-            if (api.Side != EnumAppSide.Client) return;
+            PlacedPriorityInteract = true;
 
-            ICoreClientAPI capi = api as ICoreClientAPI;
+            if (api is not ICoreClientAPI capi) return;
 
-            if (capi != null) interactions = ObjectCacheUtil.GetOrCreate(api, "ovenInteractions", () =>
+            interactions = ObjectCacheUtil.GetOrCreate(api, "ovenInteractions", () =>
             {
                 List<ItemStack> bakeableStacklist = [];
                 List<ItemStack> fuelStacklist = [];
@@ -90,40 +91,42 @@ namespace Vintagestory.GameContent
                 }
 
                 return new WorldInteraction[] {
-                    new WorldInteraction()
+                    new ()
                     {
-                        ActionLangCode = "blockhelp-oven-bakeable",
-                        HotKeyCode = null,
+                        ActionLangCode = "blockhelp-oven-take",
                         MouseButton = EnumMouseButton.Right,
-                        Itemstacks = bakeableStacklist.ToArray(),
-                        GetMatchingStacks = (wi, bs, es) => {
-                            if (wi.Itemstacks.Length == 0) return null;
-                            BlockEntityOven beo = api.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityOven;
-                            return beo != null ? beo.CanAdd(wi.Itemstacks) : null;
+                        ShouldApply = (wi, bs, es) => {
+                            return api.World.BlockAccessor.GetBlockEntity<BlockEntityOven>(bs.Position) is { } beo && !beo.ovenInv.Empty && !beo.IsBurning;
                         }
                     },
-                    new WorldInteraction()
+                    new (){
+                        ActionLangCode = "blockhelp-oven-bakeable",
+                        HotKeyCode = "shift",
+                        MouseButton = EnumMouseButton.Right,
+                        Itemstacks = [.. bakeableStacklist],
+                        GetMatchingStacks = (wi, bs, es) => {
+                            return wi.Itemstacks.Where(stack => api.World.BlockAccessor.GetBlockEntity<BlockEntityOven>(bs.Position)?.CanAddBakeable(stack) == true).ToArray();
+                        }
+                    },
+                    new ()
                     {
                         ActionLangCode = "blockhelp-oven-fuel",
-                        HotKeyCode = null,
+                        HotKeyCode = "shift",
                         MouseButton = EnumMouseButton.Right,
-                        Itemstacks = fuelStacklist.ToArray(),
+                        Itemstacks = [.. fuelStacklist],
                         GetMatchingStacks = (wi, bs, es) => {
-                            //if (wi.Itemstacks.Length == 0) return null;
-                            BlockEntityOven beo = api.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityOven;
-                            return beo != null ? beo.CanAddAsFuel(fuelStacklist.ToArray()) : null;
+                            return wi.Itemstacks.Where(stack => api.World.BlockAccessor.GetBlockEntity<BlockEntityOven>(bs.Position)?.CanAddFuel(stack) == true).ToArray();
                         }
                     },
-                    new WorldInteraction()
+                    new ()
                     {
                         ActionLangCode = "blockhelp-oven-ignite",
                         MouseButton = EnumMouseButton.Right,
                         HotKeyCode = "shift",
-                        Itemstacks = canIgniteStacks.ToArray(),
+                        Itemstacks = [.. canIgniteStacks],
                         GetMatchingStacks = (wi, bs, es) => {
                             if (wi.Itemstacks.Length == 0) return null;
-                            BlockEntityOven beo = api.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityOven;
-                            return beo != null && beo.CanIgnite() ? wi.Itemstacks : null;
+                            return api.World.BlockAccessor.GetBlockEntity<BlockEntityOven>(bs.Position) is { } beo && beo.CanIgnite() ? wi.Itemstacks : null;
                         }
                     }
                 };
@@ -153,9 +156,7 @@ namespace Vintagestory.GameContent
 
         public EnumIgniteState OnTryIgniteBlock(EntityAgent byEntity, BlockPos pos, float secondsIgniting)
         {
-            BlockEntityOven beo = byEntity.World.BlockAccessor.GetBlockEntity(pos) as BlockEntityOven;
-            if (beo == null || !beo.CanIgnite()) return EnumIgniteState.NotIgnitablePreventDefault;
-
+            if (byEntity.World.BlockAccessor.GetBlockEntity(pos) is not BlockEntityOven beo || !beo.CanIgnite()) return EnumIgniteState.NotIgnitablePreventDefault;
             return secondsIgniting > 4 ? EnumIgniteState.IgniteNow : EnumIgniteState.Ignitable;
         }
 

--- a/Block/BlockClayOven.cs
+++ b/Block/BlockClayOven.cs
@@ -51,7 +51,7 @@ namespace Vintagestory.GameContent
             base.OnLoaded(api);
 
             if (api.Side != EnumAppSide.Client) return;
-            
+
             ICoreClientAPI capi = api as ICoreClientAPI;
 
             if (capi != null) interactions = ObjectCacheUtil.GetOrCreate(api, "ovenInteractions", () =>
@@ -128,7 +128,7 @@ namespace Vintagestory.GameContent
                     }
                 };
             });
-            
+
             InitializeParticles();
         }
 

--- a/Block/BlockClayOven.cs
+++ b/Block/BlockClayOven.cs
@@ -5,7 +5,7 @@ using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Util;
 
-#nullable disable
+#nullable enable
 
 namespace Vintagestory.GameContent
 {
@@ -43,9 +43,9 @@ namespace Vintagestory.GameContent
 
 
 
-        WorldInteraction[] interactions;
-        AdvancedParticleProperties[] particles;
-        Vec3f[] basePos;
+        WorldInteraction[]? interactions;
+        AdvancedParticleProperties[]? particles;
+        Vec3f[]? basePos;
 
         public override void OnLoaded(ICoreAPI api)
         {
@@ -99,15 +99,6 @@ namespace Vintagestory.GameContent
                             return api.World.BlockAccessor.GetBlockEntity<BlockEntityOven>(bs.Position) is { } beo && !beo.ovenInv.Empty && !beo.IsBurning;
                         }
                     },
-                    new (){
-                        ActionLangCode = "blockhelp-oven-bakeable",
-                        HotKeyCode = "shift",
-                        MouseButton = EnumMouseButton.Right,
-                        Itemstacks = [.. bakeableStacklist],
-                        GetMatchingStacks = (wi, bs, es) => {
-                            return wi.Itemstacks.Where(stack => api.World.BlockAccessor.GetBlockEntity<BlockEntityOven>(bs.Position)?.CanAddBakeable(stack) == true).ToArray();
-                        }
-                    },
                     new ()
                     {
                         ActionLangCode = "blockhelp-oven-fuel",
@@ -116,6 +107,15 @@ namespace Vintagestory.GameContent
                         Itemstacks = [.. fuelStacklist],
                         GetMatchingStacks = (wi, bs, es) => {
                             return wi.Itemstacks.Where(stack => api.World.BlockAccessor.GetBlockEntity<BlockEntityOven>(bs.Position)?.CanAddFuel(stack) == true).ToArray();
+                        }
+                    },
+                    new (){
+                        ActionLangCode = "blockhelp-oven-bakeable",
+                        HotKeyCode = "shift",
+                        MouseButton = EnumMouseButton.Right,
+                        Itemstacks = [.. bakeableStacklist],
+                        GetMatchingStacks = (wi, bs, es) => {
+                            return wi.Itemstacks.Where(stack => api.World.BlockAccessor.GetBlockEntity<BlockEntityOven>(bs.Position)?.CanAddBakeable(stack) == true).ToArray();
                         }
                     },
                     new ()
@@ -149,8 +149,8 @@ namespace Vintagestory.GameContent
 
         EnumIgniteState IIgnitable.OnTryIgniteStack(EntityAgent byEntity, BlockPos pos, ItemSlot slot, float secondsIgniting)
         {
-            BlockEntityOven beo = byEntity.World.BlockAccessor.GetBlockEntity(pos) as BlockEntityOven;
-            if (beo.IsBurning) return secondsIgniting > 2 ? EnumIgniteState.IgniteNow : EnumIgniteState.Ignitable;
+            BlockEntityOven? beo = byEntity.World.BlockAccessor.GetBlockEntity(pos) as BlockEntityOven;
+            if (beo?.IsBurning ?? false) return secondsIgniting > 2 ? EnumIgniteState.IgniteNow : EnumIgniteState.Ignitable;
             return EnumIgniteState.NotIgnitable;
         }
 
@@ -164,8 +164,7 @@ namespace Vintagestory.GameContent
         {
             handling = EnumHandling.PreventDefault;
 
-            BlockEntityOven beo = byEntity.World.BlockAccessor.GetBlockEntity(pos) as BlockEntityOven;
-            beo?.TryIgnite();
+            (byEntity.World.BlockAccessor.GetBlockEntity(pos) as BlockEntityOven)?.TryIgnite();
         }
 
         public override WorldInteraction[] GetPlacedBlockInteractionHelp(IWorldAccessor world, BlockSelection selection, IPlayer forPlayer)
@@ -183,8 +182,8 @@ namespace Vintagestory.GameContent
 
         public override void OnAsyncClientParticleTick(IAsyncParticleManager manager, BlockPos pos, float windAffectednessAtPos, float secondsTicking)
         {
-            BlockEntityOven beo = manager.BlockAccess.GetBlockEntity(pos) as BlockEntityOven;
-            if (beo != null && beo.IsBurning) beo.RenderParticleTick(manager, pos, windAffectednessAtPos, secondsTicking, particles);
+            if (manager.BlockAccess.GetBlockEntity(pos) is BlockEntityOven beo && beo.IsBurning)
+                beo.RenderParticleTick(manager, pos, windAffectednessAtPos, secondsTicking, particles!);
 
             base.OnAsyncClientParticleTick(manager, pos, windAffectednessAtPos, secondsTicking);
         }

--- a/Systems/Cooking/Clayoven/BEClayOven.cs
+++ b/Systems/Cooking/Clayoven/BEClayOven.cs
@@ -70,7 +70,6 @@ namespace Vintagestory.GameContent
         /// Data about the level of browning/baking reached for the baked items
         /// </summary>
         private readonly OvenItemData[] bakingData;
-        private ItemStack lastRemoved = null;
         /// <summary>
         /// For rendering: degrees of rotation of contents depending on block variant - 0 is east
         /// </summary>
@@ -85,15 +84,12 @@ namespace Vintagestory.GameContent
         /// </summary>
         internal InventoryOven ovenInv;
 
-        EnumOvenContentMode OvenContentMode
+        public EnumOvenContentMode OvenContentMode
         {
             get
             {
-                var slot = ovenInv.FirstNonEmptySlot;
-                if (slot == null) return EnumOvenContentMode.Firewood;
-
-                BakingProperties bakingProps = BakingProperties.ReadFrom(slot.Itemstack);
-                if (bakingProps == null) return EnumOvenContentMode.Firewood;
+                if (ovenInv.FirstNonEmptySlot is not ItemSlot slot
+                    || BakingProperties.ReadFrom(slot.Itemstack) is not BakingProperties bakingProps) return EnumOvenContentMode.Firewood;
 
                 return bakingProps.LargeItem ? EnumOvenContentMode.SingleCenter : EnumOvenContentMode.Quadrants;
             }
@@ -113,21 +109,18 @@ namespace Vintagestory.GameContent
 
         public override string InventoryClassName => "oven";
 
-        public ItemSlot FuelSlot { get { return ovenInv[0]; } }
+        public ItemSlot FuelSlot => ovenInv[0];
 
-        public bool HasFuel => FuelSlot.Itemstack?.Collectible?.Attributes?.IsTrue("isClayOvenFuel") == true;
+        public bool HasFuel => FuelSlot.Itemstack?.ItemAttributes?.IsTrue("isClayOvenFuel") == true;
 
-        public bool IsBurning { get { return burning; } }
+        public bool IsBurning => burning;
 
         public bool HasBakeables
         {
             get
             {
-                for (int i = 0; i < bakeableCapacity; i++)
-                {
-                    if (!ovenInv[i].Empty && (i != 0 || !HasFuel)) return true;
-                }
-                return false;
+                if (HasFuel && FuelSlot.Itemstack?.ItemAttributes?.KeyExists("combustibleProperties") == true) return false;
+                return ovenInv.Take(4).Any(slot => !slot.Empty);
             }
         }
 
@@ -144,21 +137,14 @@ namespace Vintagestory.GameContent
 
         private void SetRotation()
         {
-            switch (Block.Variant["side"])
+            this.rotationDeg = Block.Variant["side"] switch
             {
-                case "south":
-                    this.rotationDeg = 270;
-                    break;
-                case "west":
-                    this.rotationDeg = 180;
-                    break;
-                case "east":
-                    this.rotationDeg = 0;
-                    break;
-                default:
-                    this.rotationDeg = 90;
-                    break;
-            }
+                "south" => 270,
+                "west" => 180,
+                "east" => 0,
+                _ => 90,
+            };
+
         }
 
 
@@ -168,82 +154,69 @@ namespace Vintagestory.GameContent
         {
             ItemSlot slot = byPlayer.InventoryManager.ActiveHotbarSlot;
 
-            if (slot.Empty)
+            if (!byPlayer.Entity.Controls.ShiftKey)
             {
                 if (TryTake(byPlayer))
                 {
                     byPlayer.InventoryManager.BroadcastHotbarSlot();
                     return true;
                 }
+
                 return false;
             }
-            else
+
+            if (slot.Itemstack?.Collectible is not CollectibleObject co) return false;
+            AssetLocation stackName = co.Code;
+            CombustibleProperties? combustibleProperties = co.GetCombustibleProperties(Api.World, slot.Itemstack, null);
+
+            string? errCode;
+            string? errMessage;
+
+            if (co.Attributes?.IsTrue("isClayOvenFuel") == true)
             {
-                CollectibleObject colObj = slot.Itemstack.Collectible;
-                CombustibleProperties combustibleProperties = colObj.GetCombustibleProperties(Api.World, slot.Itemstack, null);
-
-                if (colObj.Attributes?.IsTrue("isClayOvenFuel") == true)
+                if (TryAddFuel(slot, out errCode, out errMessage))
                 {
-                    if (TryAddFuel(slot))
-                    {
-                        SoundAttributes? sound = slot.Itemstack?.Block?.Sounds?.Place;
-                        Api.World.PlaySoundAt(sound ?? GlobalConstants.DefaultBuildSound, byPlayer.Entity, byPlayer);
-                        byPlayer.InventoryManager.BroadcastHotbarSlot();
-                        (byPlayer as IClientPlayer)?.TriggerFpAnimation(EnumHandInteract.HeldItemInteract);
-                        return true;
-                    }
-
-                    return false;
-
-                }
-                else if (colObj.Attributes?["bakingProperties"] != null || combustibleProperties?.SmeltingType == EnumSmeltType.Bake && combustibleProperties.MeltingPoint < maxBakingTemperatureAccepted)  //Can't meaningfully bake anything requiring heat over 260 in the basic clay oven
-                {
-                    if (slot.Itemstack.Equals(Api.World, lastRemoved, GlobalConstants.IgnoredStackAttributes) && !ovenInv[0].Empty)
-                    {
-                        if (TryTake(byPlayer))
-                        {
-                            byPlayer.InventoryManager.BroadcastHotbarSlot();
-                            return true;
-                        }
-                    }
-                    else
-                    {
-                        var stackName = slot.Itemstack?.Collectible.Code;
-                        if (TryPut(slot))
-                        {
-                            SoundAttributes? sound = slot.Itemstack?.Block?.Sounds?.Place;
-                            Api.World.PlaySoundAt(sound ?? new SoundAttributes(new AssetLocation("sounds/player/buildhigh"), true) { Range = 16 }, byPlayer.Entity, byPlayer);
-                            byPlayer.InventoryManager.BroadcastHotbarSlot();
-                            Api.World.Logger.Audit("{0} Put 1x{1} into Clay oven at {2}.",
-                                byPlayer.PlayerName,
-                                stackName,
-                                Pos
-                            );
-                            return true;
-                        }
-                        else
-                        {
-                            if (slot.Itemstack.Block?.GetBehavior<BlockBehaviorCanIgnite>() == null)
-                            {
-                                if (Api is not ICoreClientAPI capi) return true;
-
-                                bool bakeable = BakingProperties.ReadFrom(slot.Itemstack) != null && slot.Itemstack.Attributes.GetBool("bakeable", true);
-                                if (slot.Empty || !bakeable) capi.TriggerIngameError(this, "notbakeable", Lang.Get("This item is not bakeable."));
-                                else if (!slot.Empty) capi.TriggerIngameError(this, "notbakeable", Lang.Get(burning ? "Wait until the fire is out" : "Oven is full"));
-
-                                return true;
-                            }
-                        }
-                    }
-
-                    return false;
-                }
-                else if (TryTake(byPlayer))
-                //TryTake with non-empty hotbar slot, filling available empty slots in player inventory
-                {
+                    SoundAttributes? sound = slot.Itemstack?.Block?.Sounds?.Place;
+                    Api.World.PlaySoundAt(sound ?? GlobalConstants.DefaultBuildSound, byPlayer.Entity, byPlayer);
                     byPlayer.InventoryManager.BroadcastHotbarSlot();
+                    Api.World.Logger.Audit("{0} Put 1x{1} into Clay oven at {2}.",
+                        byPlayer.PlayerName,
+                        stackName,
+                        Pos
+                    );
+                    (byPlayer as IClientPlayer)?.TriggerFpAnimation(EnumHandInteract.HeldItemInteract);
+
                     return true;
                 }
+
+                (Api as ICoreClientAPI)?.TriggerIngameError(this, errCode, errMessage);
+
+                return false;
+            }
+
+
+            // Can't meaningfully bake anything requiring heat over 260 in the basic clay oven
+            if (co?.Attributes?.KeyExists("bakingProperties") == true || combustibleProperties?.SmeltingType == EnumSmeltType.Bake && combustibleProperties.MeltingPoint < maxBakingTemperatureAccepted)
+            {
+
+                if (TryPut(slot, out errCode, out errMessage))
+                {
+                    SoundAttributes? sound = slot.Itemstack?.Block?.Sounds?.Place;
+                    Api.World.PlaySoundAt(sound ?? new SoundAttributes(new AssetLocation("sounds/player/buildhigh"), true) { Range = 16 }, byPlayer.Entity, byPlayer);
+                    byPlayer.InventoryManager.BroadcastHotbarSlot();
+                    Api.World.Logger.Audit("{0} Put 1x{1} into Clay oven at {2}.",
+                        byPlayer.PlayerName,
+                        stackName,
+                        Pos
+                    );
+                    (byPlayer as IClientPlayer)?.TriggerFpAnimation(EnumHandInteract.HeldItemInteract);
+                }
+                else if (slot.Itemstack.Block?.GetBehavior<BlockBehaviorCanIgnite>() == null)
+                {
+                    (Api as ICoreClientAPI)?.TriggerIngameError(this, errCode, errMessage);
+                }
+
+                return true;
             }
 
             return false;
@@ -251,123 +224,216 @@ namespace Vintagestory.GameContent
 
         protected virtual bool TryAddFuel(ItemSlot slot)
         {
-            if (IsBurning || HasBakeables) return false;
+            return TryAddFuel(slot, out _, out _);
+        }
 
-            if (FuelSlot.Empty || FuelSlot.Itemstack.StackSize < fuelitemCapacity)
+        protected virtual bool TryAddFuel(ItemSlot slot, out string? errCode, out string? errMessage)
+        {
+            errCode = null;
+            errMessage = null;
+
+            if (!CanAddFuel(slot.Itemstack, out errCode, out errMessage)) return false;
+
+            int moved = slot.TryPutInto(Api.World, FuelSlot);
+
+            if (moved > 0)
             {
-                int moved = slot.TryPutInto(Api.World, FuelSlot);
-
-                if (moved > 0)
-                {
-                    updateMesh(0);
-                    MarkDirty();
-                    lastRemoved = null;
-                }
-
-                return moved > 0;
+                updateMesh(0);
+                MarkDirty();
             }
 
-            return false;
+            return moved > 0;
         }
 
         protected virtual bool TryPut(ItemSlot slot)
         {
-            if (IsBurning || HasFuel) return false;
+            return TryPut(slot, out _, out _);
+        }
 
-            BakingProperties bakingProps = BakingProperties.ReadFrom(slot.Itemstack);
-            if (bakingProps == null) return false;
+        protected virtual bool TryPut(ItemSlot slot, out string? errCode, out string? errMessage)
+        {
+            // CanAddBakeable checks for large item requirements
+            if (!CanAddBakeable(slot.Itemstack, out errCode, out errMessage)) return false;
 
-            if (slot.Itemstack.Attributes.GetBool("bakeable", true) == false) return false;
+            int empty = Array.FindIndex(ovenInv.Take(4).ToArray(), slot => slot.Empty);
+            if (empty == -1) return false;
 
-            if (bakingProps.LargeItem && !ovenInv.Empty)
+            int moved = slot.TryPutInto(Api.World, ovenInv[empty]);
+
+            if (moved > 0)
             {
-                return false;
+                // We store the baked level data into the BlockEntity itself, for continuity and to avoid adding unwanted attributes to the ItemStacks (which e.g. could cause them not to stack)
+                bakingData[empty] = new OvenItemData(ovenInv[empty].Itemstack);
+                updateMesh(empty);
+
+                MarkDirty();
             }
 
-            for (int index = 0; index < bakeableCapacity; index++)
-            {
-                if (ovenInv[index].Empty)
-                {
-                    int moved = slot.TryPutInto(Api.World, ovenInv[index]);
-
-                    if (moved > 0)
-                    {
-                        // We store the baked level data into the BlockEntity itself, for continuity and to avoid adding unwanted attributes to the ItemStacks (which e.g. could cause them not to stack)
-                        bakingData[index] = new OvenItemData(ovenInv[index].Itemstack);
-                        updateMesh(index);
-
-                        MarkDirty();
-                        lastRemoved = null;
-                    }
-
-                    return moved > 0;
-                }
-                else if (index == 0)
-                {
-                    // Disallow other items from being inserted if slot 0 holds a large item (a pie)
-                    BakingProperties props = BakingProperties.ReadFrom(ovenInv[0].Itemstack);
-                    if (props != null && props.LargeItem) return false;
-                }
-            }
-            return false;
+            return moved > 0;
         }
 
         protected virtual bool TryTake(IPlayer byPlayer)
         {
-            if (IsBurning) return false;    // We cannot remove fuel once it is lit
+            // We cannot remove fuel once it is lit
+            if (IsBurning) return false;
 
             for (int index = bakeableCapacity; index >= 0; index--)
             {
-                if (!ovenInv[index].Empty)
+                if (ovenInv[index].Empty) continue;
+
+                ItemStack stack = ovenInv[index].TakeOut(1);
+                if (byPlayer.InventoryManager.TryGiveItemstack(stack))
                 {
-                    ItemStack stack = ovenInv[index].TakeOut(1);
-                    lastRemoved = stack == null ? null : stack.Clone();
-                    if (byPlayer.InventoryManager.TryGiveItemstack(stack))
-                    {
-                        SoundAttributes? sound = stack.Block?.Sounds?.Place;
-                        Api.World.PlaySoundAt(sound ?? new SoundAttributes(new AssetLocation("sounds/player/throw"), true) { Range = 16 }, byPlayer.Entity, byPlayer);
-                    }
-
-                    if (stack.StackSize > 0)
-                    {
-                        Api.World.SpawnItemEntity(stack, Pos);
-                    }
-                    Api.World.Logger.Audit("{0} Took 1x{1} from Clay oven at {2}.",
-                        byPlayer.PlayerName,
-                        stack.Collectible.Code,
-                        Pos
-                    );
-
-                    bakingData[index].CurHeightMul = 1; // Reset risenLevel to avoid brief render of unwanted size on next item inserted, if server/client not perfectly in sync - note this only really works if the newly inserted item can be assumed to have risenLevel of 0 i.e. dough
-                    updateMesh(index);
-                    MarkDirty();
-                    return true;
+                    SoundAttributes? sound = stack.Block?.Sounds?.Place;
+                    Api.World.PlaySoundAt(sound ?? new SoundAttributes(new AssetLocation("sounds/player/throw"), true) { Range = 16 }, byPlayer.Entity, byPlayer);
                 }
 
+                if (stack.StackSize > 0)
+                {
+                    Api.World.SpawnItemEntity(stack, Pos);
+                }
+
+                Api.World.Logger.Audit("{0} Took 1x{1} from Clay oven at {2}.",
+                    byPlayer.PlayerName,
+                    stack.Collectible.Code,
+                    Pos
+                );
+
+                bakingData[index].CurHeightMul = 1; // Reset risenLevel to avoid brief render of unwanted size on next item inserted, if server/client not perfectly in sync - note this only really works if the newly inserted item can be assumed to have risenLevel of 0 i.e. dough
+                updateMesh(index);
+                MarkDirty();
+                return true;
             }
+
             return false;
         }
 
-        public virtual ItemStack[] CanAdd(ItemStack[] itemstacks)
+        public bool CanAddBakeable(ItemStack stack)
         {
-            if (IsBurning) return null;
-            if (!FuelSlot.Empty) return null;
-            if (ovenTemperature <= EnvironmentTemperature() + 25) return null;   // Don't invite player to insert bakeable items in a cold oven - 25 degrees allows some hysteresis if SEASONS causes changes in enviro temperature
-            for (int i = 0; i < bakeableCapacity; i++)
-            {
-                if (ovenInv[i].Empty) return itemstacks;
-            }
-            return null;
+            return CanAddBakeable(stack, out _, out _);
         }
 
-        public virtual ItemStack[] CanAddAsFuel(ItemStack[] itemstacks)
+        /// <summary>
+        /// Whether or not the oven can currently accept a given bakeable item.
+        /// </summary>
+        /// <returns>True if either the oven is empty or there is enough space to accept the given item. Oven must not be burning or contain fuel.</returns>
+        public virtual bool CanAddBakeable(ItemStack stack, out string? errCode, out string? errMessage)
         {
-            if (IsBurning) return null;
-            for (int i = 0; i < bakeableCapacity; i++)
+            errCode = null;
+            errMessage = null;
+
+            if (IsBurning)
             {
-                if (!ovenInv[i].Empty) return null;
+                errCode = "fuelburning";
+                errMessage = Lang.Get("Wait until the fire is out");
+                return false;
             }
-            return (FuelSlot.StackSize < fuelitemCapacity) ? itemstacks : null;
+
+            if (HasFuel)
+            {
+                errCode = "fuelpresent";
+                errMessage = Lang.Get("ovenerror-notfuel");
+                return false;
+            }
+
+            // Don't invite player to insert bakeable items in a cold oven - 25 degrees allows some hysteresis if SEASONS causes changes in enviro temperature
+            if (ovenTemperature <= EnvironmentTemperature() + 25)
+            {
+                errCode = "toocold";
+                errMessage = Lang.Get("ovenerror-toocold");
+                return false;
+            }
+
+
+            if (ovenInv[0].Empty) return true;
+
+
+            if (stack.ItemAttributes?.KeyExists("bakingProperties") == false)
+            {
+                errCode = "notbakeable";
+                errMessage = Lang.Get("This item is not bakeable.");
+                return false;
+            }
+
+            // Large items take up all slots
+            if (BakingProperties.ReadFrom(ovenInv[0].Itemstack)?.LargeItem ?? false)
+            {
+                errCode = "ovenfull";
+                errMessage = Lang.Get("Oven is full");
+                return false;
+            }
+
+            if (ovenInv.Take(4).All(slot => !slot.Empty))
+            {
+                errCode = "ovenfull";
+                errMessage = Lang.Get("Oven is full");
+                return false;
+            }
+
+            // Handle held large item separately if not all slots are full
+            if (BakingProperties.ReadFrom(stack)?.LargeItem ?? false && !ovenInv[0].Empty)
+            {
+                errCode = "notenoughspace";
+                errMessage = Lang.Get("ovenerror-notenoughspace");
+                return false;
+            }
+
+            return true;
+        }
+
+        public bool CanAddFuel(ItemStack stack)
+        {
+            return CanAddFuel(stack, out _, out _);
+        }
+
+        /// <summary>
+        /// Whether or not the oven can currently accept a given fuel item.
+        /// </summary>
+        /// <returns>True if either the oven is empty or the fuel slot is of the same type and has space. Oven must not be burning or contain bakeables.</returns>
+        public virtual bool CanAddFuel(ItemStack stack, out string? errCode, out string? errMessage)
+        {
+            errCode = null;
+            errMessage = null;
+
+            if (FuelSlot.Empty) return true;
+
+            if (IsBurning)
+            {
+                errCode = "fuelburning";
+                errMessage = Lang.Get("Wait until the fire is out");
+                return false;
+            }
+
+            if (stack.ItemAttributes?.IsTrue("isClayOvenFuel") == false)
+            {
+                errCode = "notfuel";
+                errMessage = Lang.Get("ovenerror-notfuel");
+                return false;
+            }
+
+            if (HasFuel && FuelSlot.StackSize < fuelitemCapacity && !FuelSlot.Itemstack.Satisfies(stack))
+            {
+                errCode = "nonmatchingfuel";
+                errMessage = Lang.Get("ovenerror-nonmatchingfuel");
+                return false;
+            }
+
+            // Bakeables are already present
+            if (!FuelSlot.Empty && !HasFuel)
+            {
+                errCode = "notbakeable";
+                errMessage = Lang.Get("This item is not bakeable.");
+                return false;
+            }
+
+            if (FuelSlot.StackSize >= fuelitemCapacity)
+            {
+                errCode = "ovenfull";
+                errMessage = Lang.Get("Oven is full");
+                return false;
+            }
+
+            return true;
         }
 
         public bool TryIgnite()
@@ -836,7 +902,7 @@ namespace Vintagestory.GameContent
                 if (mesh != null) return mesh;
 
                 var stack = slot.Itemstack;
-                string shapeLoc = FuelSlot?.Itemstack?.Collectible?.Attributes?["ovenFuelShape"].AsString() ?? Block.Attributes["ovenFuelShape"].AsString();
+                string shapeLoc = FuelSlot?.Itemstack?.ItemAttributes?["ovenFuelShape"].AsString() ?? Block.Attributes["ovenFuelShape"].AsString();
 
                 var loc = AssetLocation.Create(shapeLoc, Block.Code.Domain).WithPathPrefixOnce("shapes/").WithPathAppendixOnce(".json");
                 nowTesselatingShape = Shape.TryGet(capi, loc);

--- a/Systems/Cooking/Clayoven/BEClayOven.cs
+++ b/Systems/Cooking/Clayoven/BEClayOven.cs
@@ -7,7 +7,7 @@ using Vintagestory.API.Config;
 using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
 
-#nullable disable
+#nullable enable
 
 namespace Vintagestory.GameContent
 {
@@ -74,10 +74,10 @@ namespace Vintagestory.GameContent
         /// For rendering: degrees of rotation of contents depending on block variant - 0 is east
         /// </summary>
         private int rotationDeg;
-        Random prng;
+        Random? prng = null;
         private int syncCount;
 
-        ILoadedSound ambientSound;
+        ILoadedSound? ambientSound;
 
         /// <summary>
         /// Slots 0-3: Baking items. Slot 0: Fuel  Note: Slot 0 doubles up for both uses, as an oven cannot hold both fuel and baking items at the same time!
@@ -131,7 +131,7 @@ namespace Vintagestory.GameContent
             ovenInv.LateInitialize(InventoryClassName + "-" + Pos, api);
 
             RegisterGameTickListener(OnBurnTick, 100);
-            this.prng = new Random((int)(this.Pos.GetHashCode()));
+            this.prng ??= new Random((int)(this.Pos.GetHashCode()));
             this.SetRotation();
         }
 
@@ -317,7 +317,7 @@ namespace Vintagestory.GameContent
         /// Whether or not the oven can currently accept a given bakeable item.
         /// </summary>
         /// <returns>True if either the oven is empty or there is enough space to accept the given item. Oven must not be burning or contain fuel.</returns>
-        public virtual bool CanAddBakeable(ItemStack stack, out string? errCode, out string? errMessage)
+        public virtual bool CanAddBakeable(ItemStack? stack, out string? errCode, out string? errMessage)
         {
             errCode = null;
             errMessage = null;
@@ -348,7 +348,7 @@ namespace Vintagestory.GameContent
             if (ovenInv[0].Empty) return true;
 
 
-            if (stack.ItemAttributes?.KeyExists("bakingProperties") == false)
+            if (stack?.ItemAttributes?.KeyExists("bakingProperties") == false)
             {
                 errCode = "notbakeable";
                 errMessage = Lang.Get("This item is not bakeable.");
@@ -381,7 +381,7 @@ namespace Vintagestory.GameContent
             return true;
         }
 
-        public bool CanAddFuel(ItemStack stack)
+        public bool CanAddFuel(ItemStack? stack)
         {
             return CanAddFuel(stack, out _, out _);
         }
@@ -390,7 +390,7 @@ namespace Vintagestory.GameContent
         /// Whether or not the oven can currently accept a given fuel item.
         /// </summary>
         /// <returns>True if either the oven is empty or the fuel slot is of the same type and has space. Oven must not be burning or contain bakeables.</returns>
-        public virtual bool CanAddFuel(ItemStack stack, out string? errCode, out string? errMessage)
+        public virtual bool CanAddFuel(ItemStack? stack, out string? errCode, out string? errMessage)
         {
             errCode = null;
             errMessage = null;
@@ -404,7 +404,7 @@ namespace Vintagestory.GameContent
                 return false;
             }
 
-            if (stack.ItemAttributes?.IsTrue("isClayOvenFuel") == false)
+            if (stack?.ItemAttributes?.IsTrue("isClayOvenFuel") == false)
             {
                 errCode = "notfuel";
                 errMessage = Lang.Get("ovenerror-notfuel");
@@ -481,18 +481,18 @@ namespace Vintagestory.GameContent
                 {
                     fuelBurnTime = 0;
                     burning = false;
-                    CombustibleProperties props = FuelSlot.Itemstack?.Collectible.GetCombustibleProperties(Api.World, FuelSlot.Itemstack, null);
-                    if (props?.SmeltedStack == null)
-                    {
-                        FuelSlot.Itemstack = null;
-                        for (int i = 0; i < bakeableCapacity; i++) bakingData[i].CurHeightMul = 1;
-                    }
-                    else
+                    CombustibleProperties? props = FuelSlot.Itemstack?.Collectible.GetCombustibleProperties(Api.World, FuelSlot.Itemstack, null);
+                    if (props?.SmeltedStack?.ResolvedItemstack?.Clone() is ItemStack smeltedStack)
                     {
                         // Allows for wood ash inserted by mods (for example, LazyWarlock's Tweaks)
                         int count = FuelSlot.StackSize;
-                        FuelSlot.Itemstack = props.SmeltedStack.ResolvedItemstack.Clone();
+                        FuelSlot.Itemstack = smeltedStack;
                         FuelSlot.Itemstack.StackSize = count * props.SmeltedRatio;
+                    }
+                    else
+                    {
+                        FuelSlot.Itemstack = null;
+                        for (int i = 0; i < bakeableCapacity; i++) bakingData[i].CurHeightMul = 1;
                     }
                     MarkDirty(true);
                 }
@@ -526,8 +526,7 @@ namespace Vintagestory.GameContent
         {
             for (int slotIndex = 0; slotIndex < bakeableCapacity; slotIndex++)
             {
-                ItemStack stack = ovenInv[slotIndex].Itemstack;
-                if (stack != null)
+                if (ovenInv[slotIndex].Itemstack is ItemStack stack && !stack.ItemAttributes.KeyExists("combustibleProperties"))
                 {
                     float nowTemp = HeatStack(stack, dt, slotIndex);
                     // Begin baking - or at least rising - when hot enough
@@ -607,41 +606,36 @@ namespace Vintagestory.GameContent
             if (currentLevel > levelTo)
             {
                 float nowTemp = bakeData.temp;
-                string resultCode = bakeProps?.ResultCode;
 
-                if (resultCode != null)
+                if (bakeProps?.ResultCode is string resultCode)
                 {
-                    ItemStack resultStack = null;
-                    if (slot.Itemstack.Class == EnumItemClass.Block)
+                    ItemStack? resultStack = null;
+                    if (slot.Itemstack?.Class == EnumItemClass.Block)
                     {
-                        Block block = Api.World.GetBlock(new AssetLocation(resultCode));
-                        if (block != null)
-                        {
-                            resultStack = new ItemStack(block);
-                        }
+                        if (Api.World.GetBlock(new AssetLocation(resultCode)) is Block block) resultStack = new ItemStack(block);
                     }
                     else
                     {
-                        Item item = Api.World.GetItem(new AssetLocation(resultCode));
-                        if (item != null) resultStack = new ItemStack(item);
+                        if (Api.World.GetItem(new AssetLocation(resultCode)) is Item item) resultStack = new ItemStack(item);
                     }
 
                     if (resultStack != null)
                     {
-                        TransitionableProperties[] tprops = resultStack.Collectible.GetTransitionableProperties(Api.World, slot.Itemstack, null);
-                        TransitionableProperties perishProps = tprops?.FirstOrDefault(p => p.Type == EnumTransitionType.Perish);
+                        TransitionableProperties?[] tprops = resultStack.Collectible.GetTransitionableProperties(Api.World, slot.Itemstack, null);
 
                         // Carry over freshness
-                        if (perishProps != null)
+                        if (tprops?.FirstOrDefault(p => p?.Type == EnumTransitionType.Perish) is TransitionableProperties perishProps)
                         {
                             CollectibleObject.CarryOverFreshness(Api, slot, resultStack, perishProps);
                         }
 
-                        ovenInv[slotIndex].Itemstack.Collectible.GetCollectibleInterface<IBakeableCallback>()?.OnBaked(ovenInv[slotIndex].Itemstack, resultStack);
+                        ovenInv[slotIndex].Itemstack?.Collectible.GetCollectibleInterface<IBakeableCallback>()?.OnBaked(ovenInv[slotIndex].Itemstack!, resultStack);
 
                         ovenInv[slotIndex].Itemstack = resultStack;
-                        bakingData[slotIndex] = new OvenItemData(resultStack);
-                        bakingData[slotIndex].temp = nowTemp;
+                        bakingData[slotIndex] = new OvenItemData(resultStack)
+                        {
+                            temp = nowTemp
+                        };
 
                         reDraw = true;
                     }
@@ -651,14 +645,16 @@ namespace Vintagestory.GameContent
                     // Allow the oven also to 'smelt' low-temperature bakeable items which do not have specific baking properties
 
                     ItemSlot result = new DummySlot(null);
-                    if (slot.Itemstack.Collectible.CanSmelt(Api.World, ovenInv, slot.Itemstack, null))
+                    if (slot.Itemstack?.Collectible.CanSmelt(Api.World, ovenInv, slot.Itemstack, null) ?? false)
                     {
                         slot.Itemstack.Collectible.DoSmelt(Api.World, ovenInv, ovenInv[slotIndex], result);
                         if (!result.Empty)
                         {
                             ovenInv[slotIndex].Itemstack = result.Itemstack;
-                            bakingData[slotIndex] = new OvenItemData(result.Itemstack);
-                            bakingData[slotIndex].temp = nowTemp;
+                            bakingData[slotIndex] = new OvenItemData(result.Itemstack)
+                            {
+                                temp = nowTemp
+                            };
                             reDraw = true;
                         }
                     }
@@ -770,8 +766,7 @@ namespace Vintagestory.GameContent
             {
                 if (!ovenInv[index].Empty)
                 {
-                    ItemStack stack = ovenInv[index].Itemstack;
-                    sb.Append(stack.GetName());
+                    sb.Append(ovenInv[index].Itemstack?.GetName());
                     sb.AppendLine(" (" + Lang.Get("{0}°C", (int)bakingData[index].temp) + ")");
                 }
             }
@@ -802,8 +797,8 @@ namespace Vintagestory.GameContent
             }
             else
             {
-                ambientSound.Stop();
-                ambientSound.Dispose();
+                ambientSound!.Stop();
+                ambientSound!.Dispose();
                 ambientSound = null;
             }
 
@@ -894,27 +889,26 @@ namespace Vintagestory.GameContent
             return (OvenContentMode == EnumOvenContentMode.Firewood ? slot.StackSize + "x" : "") + base.getMeshCacheKey(slot) + scaleY;
         }
 
-        protected override MeshData getOrCreateMesh(ItemSlot slot, int index)
+        protected override MeshData? getOrCreateMesh(ItemSlot slot, int index)
         {
             if (OvenContentMode == EnumOvenContentMode.Firewood)
             {
-                MeshData mesh = getMesh(slot);
-                if (mesh != null) return mesh;
+                if (getMesh(slot) is MeshData mesh) return mesh;
 
-                var stack = slot.Itemstack;
-                string shapeLoc = FuelSlot?.Itemstack?.ItemAttributes?["ovenFuelShape"].AsString() ?? Block.Attributes["ovenFuelShape"].AsString();
+                ItemStack? stack = slot.Itemstack;
+                string? shapeLoc = FuelSlot.Itemstack?.ItemAttributes["ovenFuelShape"].AsString() ?? Block.Attributes["ovenFuelShape"].AsString();
 
                 var loc = AssetLocation.Create(shapeLoc, Block.Code.Domain).WithPathPrefixOnce("shapes/").WithPathAppendixOnce(".json");
                 nowTesselatingShape = Shape.TryGet(capi, loc);
-                nowTesselatingObj = stack.Collectible;
+                nowTesselatingObj = stack?.Collectible;
 
                 if (nowTesselatingShape == null)
                 {
-                    capi.Logger.Error("Stacking model shape for collectible " + stack.Collectible.Code + " not found. Block will be invisible!");
+                    capi.Logger.Error("Stacking model shape for collectible " + stack?.Collectible.Code + " not found. Block will be invisible!");
                     return null;
                 }
 
-                capi.Tesselator.TesselateShape("ovenFuelShape", nowTesselatingShape, out mesh, this, null, 0, 0, 0, stack.StackSize);
+                capi.Tesselator.TesselateShape("ovenFuelShape", nowTesselatingShape, out mesh, this, null, 0, 0, 0, stack?.StackSize);
 
                 string key = getMeshCacheKey(slot);
                 MeshCache[key] = mesh;
@@ -936,13 +930,13 @@ namespace Vintagestory.GameContent
             for (int i = 0; i < particles.Length; i++)
             {
                 //reduced number of bright yellow flames - and reduces as the fuel burns
-                if (i >= 12 && prng.Next(0, 90) > this.fuelBurnTime) continue;
+                if (i >= 12 && prng!.Next(0, 90) > this.fuelBurnTime) continue;
 
                 //limit orange flames when fuel is almost burned
-                if (i >= 8 && i < 12 && prng.Next(0, 12) > this.fuelBurnTime) continue;
+                if (i >= 8 && i < 12 && prng!.Next(0, 12) > this.fuelBurnTime) continue;
 
                 //also randomise red flames
-                if (i >= 4 && i < 4 && prng.Next(0, 6) == 0) continue;
+                if (i >= 4 && i < 4 && prng!.Next(0, 6) == 0) continue;
 
                 //adjust flames to the number of logs, if less than 3 logs
                 if (i >= 4 && logsCount < 3)
@@ -985,8 +979,8 @@ namespace Vintagestory.GameContent
                 else
                 //set up flame positions with RNG (this way all three flame evolution particles will be in approx. same position)
                 {
-                    x[i] = prng.NextDouble() * 0.4f + 0.33f;   // the multiplier and offset gets the flame position aligned with the top surface of the logs
-                    z[i] = 0.26f + prng.Next(0, 3) * 0.2f + (float)prng.NextDouble() * 0.08f;
+                    x[i] = prng!.NextDouble() * 0.4f + 0.33f;   // the multiplier and offset gets the flame position aligned with the top surface of the logs
+                    z[i] = 0.26f + prng.Next(0, 3) * 0.2f + (float)prng!.NextDouble() * 0.08f;
                 }
 
                 manager.Spawn(bps);

--- a/Systems/Cooking/Clayoven/BEClayOven.cs
+++ b/Systems/Cooking/Clayoven/BEClayOven.cs
@@ -780,7 +780,7 @@ namespace Vintagestory.GameContent
                     break;
                 case EnumOvenContentMode.Quadrants:
                     // Top left
-                    offs[0] = new Vec3f(-2/16f, 1 / 16f, -2.5f / 16f);
+                    offs[0] = new Vec3f(-2 / 16f, 1 / 16f, -2.5f / 16f);
                     // Top right
                     offs[1] = new Vec3f(-2 / 16f, 1 / 16f, 2.5f / 16f);
                     // Bot left
@@ -789,7 +789,7 @@ namespace Vintagestory.GameContent
                     offs[3] = new Vec3f(3 / 16f, 1 / 16f, 2.5f / 16f);
                     break;
                 case EnumOvenContentMode.SingleCenter:
-                    offs[0] = new Vec3f(0, 1/16f, 0);
+                    offs[0] = new Vec3f(0, 1 / 16f, 0);
                     break;
             }
 


### PR DESCRIPTION
Make oven interactions more differentiated from each other to improve player frustrations with accidental inputs and make world interactions more detailed.

* Shift now toggles between all item taking and placing. Taking items no longer requires an empty hand.
* Add `CanAddFuel` and `CanAddBakeable` to provide more detailed error information to players and other classes based on several conditions.
* Make OvenContentMode public
* WorldInteraction changes based on what actions are actually possible. For example, the "place fuel" interaction is removed when bakeables are present, and when fuel is present the item stack will stop rotating and show only the type of fuel that is already in the oven.
* Enable nullable in BlockClayOven.cs and BEClayOven.cs