### PR TITLE
Update GetHeldItemInfo for forge burn properties

### DIFF
--- a/Item/ItemCoal.cs
+++ b/Item/ItemCoal.cs
@@ -18,9 +18,9 @@ namespace Vintagestory.GameContent
             var inforgeprops = Attributes["inForge"];
 
             var tpd = inforgeprops["tempGainDeg"].AsInt();
-            if (tpd != 0) dsc.AppendLine(Lang.Get("coal-forgetemp-mod", tpd));
+            dsc.AppendLine(Lang.Get("coal-forgetemp-mod", 700 + tpd));
             var dm = inforgeprops["durationMul"].AsFloat();
-            if (dm != 1) dsc.AppendLine(Lang.Get("coal-forgedur-mod", dm));
+            dsc.AppendLine(Lang.Get("coal-forgedur-mod", 2f * dm));
         }
     }
 }


### PR DESCRIPTION
Update the tooltips for ItemCoal so that they specify the actual forge temperatures and durations, rather than the modifiers/multipliers. The base forge times and temperatures are not currently specified _anywhere_ in the handbook, and referring only to modifiers makes it very difficult to compare fuels or determine which one is needed for a particular purpose.

Implementing this change also requires updating two lang entries:
```
"coal-forgetemp-mod": "Forge burn temperature: {0} °C",
"coal-forgedur-mod": "Forge burn duration: {0:F1} game hours",
```

For clarity and consistency, I also suggest changing these two lang entries:
```
"Burn temperature: {0}°C": "Firepit burn temperature: {0} °C",
"Burn duration: {0}s": "Firepit burn duration: {0} real seconds",
```