### PR TITLE
Patch/firewood

### DIFF
--- a/Item/ItemFirewood.cs
+++ b/Item/ItemFirewood.cs
@@ -10,16 +10,17 @@ namespace Vintagestory.GameContent
         
         public override void OnHeldInteractStart(ItemSlot slot, EntityAgent byEntity, BlockSelection blockSel, EntitySelection entitySel, bool firstEvent, ref EnumHandHandling handling)
         {
-            if (blockSel == null || byEntity?.World == null || !byEntity.Controls.ShiftKey) return;
-
-            BlockPos onBlockPos = blockSel.Position;
-            Block block = byEntity.World.BlockAccessor.GetBlock(onBlockPos);
-
-            if (block is BlockFirepit || block is BlockPitkiln || block is BlockClayOven)
+            if (blockSel != null && byEntity?.World != null && byEntity.Controls.ShiftKey)
             {
-                // Prevent placing firewoodpiles when trying to construct firepits
-                return;
-            } 
+                BlockPos onBlockPos = blockSel.Position;
+                Block block = byEntity.World.BlockAccessor.GetBlock(onBlockPos);
+
+                if (block is BlockFirepit || block is BlockPitkiln || block is BlockClayOven)
+                {
+                    // Prevent placing firewoodpiles when trying to construct firepits
+                    return;
+                }
+            }
 
             base.OnHeldInteractStart(slot, byEntity, blockSel, entitySel, firstEvent, ref handling);
         }

--- a/Item/ItemFirewood.cs
+++ b/Item/ItemFirewood.cs
@@ -6,8 +6,7 @@ using Vintagestory.API.MathTools;
 namespace Vintagestory.GameContent
 {
     public class ItemFirewood : Item
-    {
-        
+    {    
         public override void OnHeldInteractStart(ItemSlot slot, EntityAgent byEntity, BlockSelection blockSel, EntitySelection entitySel, bool firstEvent, ref EnumHandHandling handling)
         {
             if (blockSel != null && byEntity?.World != null && byEntity.Controls.ShiftKey)
@@ -21,12 +20,7 @@ namespace Vintagestory.GameContent
                     return;
                 }
             }
-
             base.OnHeldInteractStart(slot, byEntity, blockSel, entitySel, firstEvent, ref handling);
         }
-
-
-
-
     }
 }


### PR DESCRIPTION
This fixes a small logic bug where the base method (and subsequent behaviors) were not being called when the shift key was not pressed. 

I also removed a bunch of whitespace but I can drop that commit if desired. 

If you are worried some behaviors might be relying on the null checks  - I can add an early return, just excluding the shift key press check. 