### PR TITLE
Fix: mixed pie fill texture location caching fix

### DIFF
--- a/Systems/Cooking/MealMeshCache.cs
+++ b/Systems/Cooking/MealMeshCache.cs
@@ -262,12 +262,18 @@ namespace Vintagestory.GameContent
             if (singleFilling) return pieProps[1]?.Texture;
 
             if (!singleFoodCat && mixingCodes.Length > 0)
-            {
-                if (pieMixingCodeFillingTextures.TryGetValue(mixingCodes[0].GetHashCode(), out var loc))
+            {   
+                key = mixingCodes[0].GetHashCode();
+                if (pieMixingCodeFillingTextures.TryGetValue(key, out var loc))
                 {
                     return loc;
                 }
-                else pieMixingCodeFillingTextures.Add(mixingCodes[0].GetHashCode(), new("block/food/pie/fill-mixed" + mixingCodes[0]));
+                else
+                {
+                    loc = new AssetLocation("block/food/pie/fill-mixed" + mixingCodes[0]);
+                    pieMixingCodeFillingTextures.Add(key, loc);
+                    return loc;
+                } 
             }
 
             return pieMixedCategoryFillingTextures[(int)fillingCat];


### PR DESCRIPTION
The game caches the texture paths for pie fillings with mixing codes at runtime, but on a cache miss during world loading (first instance of the pie with particular mixing code), instead of caching the value AND returning it, the game is just caching it and passing through to the region that determined the texture based on the filling nutrition category of the pie instance (whatever you put in first and initialized the pie).

This fix corrects the caching logic so that on cache miss - the texture path that was set in the cache is returned.

Fixes [#9459](https://github.com/anegostudios/VintageStory-Issues/issues/9459)

Harmony patch mod version of the fix:
[*Mod*](https://mods.vintagestory.at/piefixes)
[*Mod patch code*](https://codeberg.org/at375/PieFixes/src/commit/e3464cf1cb5eba1d98af74409c0b0c04d86e1d2c/PieFixes/Patches/MealMeshCacheFix.cs)