### PR TITLE
Fix: mixed pies name derivation

### DIFF
--- a/Block/BlockPie.cs
+++ b/Block/BlockPie.cs
@@ -275,8 +275,8 @@ namespace Vintagestory.GameContent
                 if (cStacks[i] == null) continue;
 
                 equal &= cstack.Equals(api.World, cStacks[i], GlobalConstants.IgnoredStackAttributes);
-                foodCatEquals &= cStacks[i] == null || foodCats[i] == foodCat;
-                mixCodes = cstack.ItemAttributes["inPieProperties"].AsObject<InPieProperties>()?.MixingCodes.Intersect(mixCodes) ?? [];
+                foodCatEquals &= foodCats[i] == foodCat;
+                mixCodes = cStacks[i].ItemAttributes["inPieProperties"].AsObject<InPieProperties>()?.MixingCodes.Intersect(mixCodes) ?? [];
 
                 cstack = cStacks[i];
                 foodCat = foodCats[i];


### PR DESCRIPTION
When a pie contains fillings from different food categories whose item types share mixing codes, the game determines a common mixed name by intersecting the mixing code arrays of all present fillings.

The original code performed the intersection in a loop using the mixing codes of the previous filling (still held in the stale variable) instead of the current filling being processed. Because of this, whenever a new filling would change the common set – for example, going from three fillings with mixing codes `[x, y]` to a fourth with only `[y]` – that final ingredient’s codes were effectively ignored. When adding filling 4 - intersection would be performed of filling 3 and intersected set of fillings 1 and 2, leaving the mix unchanged at `[x, y]`. The game then picked the first element (`x`) for the pie name, producing an incorrect result.

Fix corrects the loop so that intersection is performed on the mixCodes set with already added filling and mixing codes of the current filling, so the mixCodes set is immediately accurate.

Fixes [#9461](https://github.com/anegostudios/VintageStory-Issues/issues/9461)

Harmony patch mod version of the fix:
[Mod](https://mods.vintagestory.at/piefixes)
[Mod patch code](https://codeberg.org/at375/PieFixes/src/commit/e3464cf1cb5eba1d98af74409c0b0c04d86e1d2c/PieFixes/Patches/BlockPie.cs)