### PR TITLE
Remove duplicate pickup WorldInteraction from pies

### DIFF
--- a/Block/BlockPie.cs
+++ b/Block/BlockPie.cs
@@ -296,7 +296,7 @@ namespace Vintagestory.GameContent
 
             if (!foodCatEquals && mixCodes.Any())
             {
-                return Lang.Get("pie-mixed-" + mixCodes.First() + "-" +state);
+                return Lang.Get("pie-mixed-" + mixCodes.First() + "-" + state);
             }
 
             return Lang.Get("pie-mixed-" + FillingFoodCategory(cStacks[1]).ToString().ToLowerInvariant() + "-" + state);
@@ -554,8 +554,8 @@ namespace Vintagestory.GameContent
 
         public override WorldInteraction[] GetPlacedBlockInteractionHelp(IWorldAccessor world, BlockSelection selection, IPlayer forPlayer)
         {
-            var baseinteractions = base.GetPlacedBlockInteractionHelp(world, selection, forPlayer);
-            baseinteractions = baseinteractions.RemoveAt(1);
+            WorldInteraction[] baseinteractions = [.. base.GetPlacedBlockInteractionHelp(world, selection, forPlayer)
+                .Where(bi => bi.ActionLangCode != "blockhelp-meal-eat" && bi.ActionLangCode != "blockhelp-meal-pickup")];
 
             var allinteractions = interactions.Append(baseinteractions);
             return allinteractions;


### PR DESCRIPTION
Removes the default meal RMB pickup WI in favor of the empty hand + RMB WI from BehaviorRightClickPickup.

#### Comparison

<img width="2560" height="1440" alt="2026-06-23_06-56-27" src="https://github.com/user-attachments/assets/ff7ffa63-4d2c-4e4d-b7ac-3f0916e70dea" />

<img width="2560" height="1440" alt="2026-06-23_06-54-55" src="https://github.com/user-attachments/assets/0c3a5d8c-c958-433f-a184-222a40fdedf6" />
