### PR TITLE
Fix taking a slice from a pie block not costing tool durability

### DIFF
--- a/BlockEntity/BEPie.cs
+++ b/BlockEntity/BEPie.cs
@@ -177,6 +177,7 @@ namespace Vintagestory.GameContent
                 {
                     if (Api.Side == EnumAppSide.Server && TakeSlice() is { } slicestack)
                     {
+                        hotbarSlot?.Itemstack?.Collectible.DamageItem(byPlayer.Entity.World, byPlayer.Entity, hotbarSlot);
                         if (!byPlayer.InventoryManager.TryGiveItemstack(slicestack))
                         {
                             Api.World.SpawnItemEntity(slicestack, Pos);


### PR DESCRIPTION
Using the crafting grid already does this.

<img width="2560" height="1440" alt="2026-06-23_07-02-51" src="https://github.com/user-attachments/assets/9a6e5cb1-bc81-4bd6-bb95-40c9e97fa768" />

<img width="2560" height="1440" alt="2026-06-23_07-02-59" src="https://github.com/user-attachments/assets/aadc9b48-6aa4-4416-8275-0b25639c3382" />
