### PR TITLE
Fix dough held interaction not showing table stacks

### DIFF
--- a/Item/ItemDough.cs
+++ b/Item/ItemDough.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Config;
@@ -10,30 +11,28 @@ namespace Vintagestory.GameContent
 {
     public class ItemDough : Item
     {
-        static ItemStack[] tableStacks;
+        static WorldInteraction[] interactions = null;
 
         public override void OnLoaded(ICoreAPI api)
         {
-            if (tableStacks == null)
-            {
-                List<ItemStack> foundStacks = new List<ItemStack>();
-                api.World.Collectibles.ForEach(obj =>
+            base.OnLoaded(api);
+
+            if (api.World.Side != EnumAppSide.Client || interactions != null) return;
+
+            ItemStack[] tableStacks = [.. api.World.Collectibles
+                .Where(obj => (obj as Block)?.Attributes?.IsTrue("pieFormingSurface") == true)
+                .Select(obj => new ItemStack(obj))];
+
+            interactions = [
+                new ()
                 {
-                    if (obj is Block block && block.Attributes?.IsTrue("pieFormingSurface") == true)
-                    {
-                        foundStacks.Add(new ItemStack(obj));
-                    }
-                });
-
-                tableStacks = foundStacks.ToArray();
-            }
+                    ActionLangCode = "heldhelp-makepie",
+                    Itemstacks = tableStacks,
+                    HotKeyCode = "shift",
+                    MouseButton = EnumMouseButton.Right
+                }
+            ];
         }
-
-        public override void OnUnloaded(ICoreAPI api)
-        {
-            tableStacks = null;
-        }
-
 
         public override void OnHeldInteractStart(ItemSlot slot, EntityAgent byEntity, BlockSelection blockSel, EntitySelection entitySel, bool firstEvent, ref EnumHandHandling handling)
         {
@@ -45,11 +44,12 @@ namespace Vintagestory.GameContent
                     if (slot.StackSize >= 2)
                     {
                         BlockPie blockform = api.World.GetBlock(new AssetLocation("pie-raw")) as BlockPie;
-                        blockform.TryPlacePie(byEntity, blockSel);
-                    } else
+                        blockform?.TryPlacePie(byEntity, blockSel);
+                    }
+                    else
                     {
                         ICoreClientAPI capi = api as ICoreClientAPI;
-                        if (capi != null) capi.TriggerIngameError(this, "notpieable", Lang.Get("Need at least 2 dough"));
+                        capi?.TriggerIngameError(this, "notpieable", Lang.Get("Need at least 2 dough"));
                     }
 
                     handling = EnumHandHandling.PreventDefault;
@@ -62,15 +62,7 @@ namespace Vintagestory.GameContent
 
         public override WorldInteraction[] GetHeldInteractionHelp(ItemSlot inSlot)
         {
-            return new WorldInteraction[] {
-                new WorldInteraction()
-                {
-                    ActionLangCode = "heldhelp-makepie",
-                    Itemstacks = tableStacks,
-                    HotKeyCode = "shift",
-                    MouseButton = EnumMouseButton.Right,
-                }
-            }.Append(base.GetHeldInteractionHelp(inSlot));
+            return interactions.Append(base.GetHeldInteractionHelp(inSlot));
         }
     }
 }


### PR DESCRIPTION
Uses a `static WorldInteraction[]` instead of a `static ItemStack[]`

<img width="2560" height="1440" alt="2026-06-23_07-41-47" src="https://github.com/user-attachments/assets/d2ffe189-87fb-49d5-99aa-44eb4b4c49dc" />
<img width="2560" height="1440" alt="2026-06-23_07-43-51" src="https://github.com/user-attachments/assets/68c94661-7c7e-45c5-a120-ee946b393dc0" />
