### PR TITLE
Fix missing JsonItemStack.Code in BlockLiquidContainerBase.GetNutritionProperties

### DIFF
--- a/Systems/Liquid/BlockLiquidContainerBase.cs
+++ b/Systems/Liquid/BlockLiquidContainerBase.cs
@@ -867,7 +867,7 @@ namespace Vintagestory.GameContent
             nutriProps.Intoxication *= litres;
             nutriProps.Psychedelic *= litres;
 
-            nutriProps.EatenStack = new JsonItemStack { ResolvedItemstack = itemstack.Clone() };
+            nutriProps.EatenStack = new JsonItemStack { ResolvedItemstack = itemstack.Clone(), Code = itemstack.Collectible.Code };
             nutriProps.EatenStack.ResolvedItemstack.StackSize = 1;
             (nutriProps.EatenStack.ResolvedItemstack.Collectible as BlockLiquidContainerBase)?.SetContent(nutriProps.EatenStack.ResolvedItemstack, null);
 


### PR DESCRIPTION
The code must exist when `FoodNutritionProperties.EatenStack` is cloned, or it crashes.