### PR TITLE
Tweak: Show total satiety in meal nutrition facts

### DIFF
--- a/Systems/Cooking/BlockMeal.cs
+++ b/Systems/Cooking/BlockMeal.cs
@@ -680,6 +680,7 @@ namespace Vintagestory.GameContent
             }
 
             StringBuilder sb = new StringBuilder();
+            sb.AppendLine(Lang.Get("When eaten: {0} sat", Math.Round(totalSaturation.Values.Sum())));
             sb.AppendLine(Lang.Get("Nutrition Facts"));
 
             foreach (var val in totalSaturation)


### PR DESCRIPTION
Show the total satiety above the nutrition facts listing to prevent lots of mental math.

<img width="2560" height="1440" alt="2026-06-23_08-03-48" src="https://github.com/user-attachments/assets/813baa13-9462-4c04-bbab-63bec5713e91" />
<img width="2560" height="1440" alt="2026-06-23_08-04-00" src="https://github.com/user-attachments/assets/1bf3dd3f-b843-4601-aaf6-02485bca65f7" />
