### PR TITLE
Fixed: Meals showed temperature in held item info twice

### DIFF
--- a/Systems/Cooking/BlockCookedContainer.cs
+++ b/Systems/Cooking/BlockCookedContainer.cs
@@ -321,11 +321,6 @@ namespace Vintagestory.GameContent
         {
             if (inSlot.Itemstack is not ItemStack cookedContStack) return;
             base.GetHeldItemInfo(inSlot, dsc, world, withDebugInfo);
-            float temp = GetTemperature(world, cookedContStack);
-            if (temp > 20)
-            {
-                dsc.AppendLine(Lang.Get("Temperature: {0}°C", (int)temp));
-            }
 
             CookingRecipe? recipe = GetMealRecipe(world, cookedContStack);
             float servings = cookedContStack.Attributes.GetFloat("quantityServings");


### PR DESCRIPTION
Removed the temperature display from BlockCookedContainer. I tried removing it from BlockMeal instead, but that did nothing.

<img width="2560" height="1440" alt="2026-06-25_02-30-55" src="https://github.com/user-attachments/assets/e9ce056c-0baa-454e-8c8d-6abce3289bf8" />
<img width="2560" height="1440" alt="2026-06-25_02-29-22" src="https://github.com/user-attachments/assets/01278b94-b476-4d02-ae87-c4a02879d4c9" />
