### PR TITLE
Drop partially eaten meal instead of full meals if inventory is full

### DIFF
--- a/Systems/Cooking/BlockMeal.cs
+++ b/Systems/Cooking/BlockMeal.cs
@@ -325,22 +325,29 @@ namespace Vintagestory.GameContent
             }
             else
             {
+                BlockMeal? sourceMeal = foodSourceStack.Collectible as BlockMeal;
                 if (slot.Empty || slot.StackSize == 1)
                 {
-                    (foodSourceStack.Collectible as BlockMeal)?.SetQuantityServings(byEntity.World, foodSourceStack, servingsLeft);
+                    sourceMeal?.SetQuantityServings(byEntity.World, foodSourceStack, servingsLeft);
                     slot.Itemstack = foodSourceStack;
                 }
                 else
                 {
-                    ItemStack? splitStack = slot.TakeOut(1);
-                    (foodSourceStack.Collectible as BlockMeal)?.SetQuantityServings(byEntity.World, splitStack, servingsLeft);
+                    // Pull out the eaten stack first
+                    ItemStack partiallyEatenStack = slot.TakeOut(1);
+                    sourceMeal?.SetQuantityServings(byEntity.World, partiallyEatenStack, servingsLeft);
 
-                    ItemStack originalStack = slot.Itemstack;
-                    slot.Itemstack = splitStack;
+                    // Then pull out the remaining full meals and replace them with the partially eaten meal
+                    ItemStack fullMealsStack = slot.TakeOutWhole();
+                    slot.Itemstack = partiallyEatenStack;
 
-                    if (!player.InventoryManager.TryGiveItemstack(originalStack, true))
+                    if (!player.InventoryManager.TryGiveItemstack(fullMealsStack, true))
                     {
-                        byEntity.World.SpawnItemEntity(originalStack, byEntity.Pos.XYZ);
+                        // If the player doesn't have an empty slot, make sure we give them
+                        // the stack of full meals instead of dropping everything except
+                        // the partially eaten one.
+                        slot.Itemstack = fullMealsStack;
+                        byEntity.World.SpawnItemEntity(partiallyEatenStack, byEntity.Pos.XYZ);
                     }
                 }
             }


### PR DESCRIPTION
Swapped the order of stack insertion. Closes https://github.com/anegostudios/VintageStory-Issues/issues/4493.

<img width="2560" height="1440" alt="2026-06-25_02-46-09" src="https://github.com/user-attachments/assets/61a91c8f-32a1-4ea9-90d3-b4fa62a8043b" />

<img width="2560" height="1440" alt="2026-06-25_02-46-15" src="https://github.com/user-attachments/assets/68979f15-41b8-45bc-9f5d-f35704f18a3e" />

<img width="2560" height="1440" alt="2026-06-25_02-50-31" src="https://github.com/user-attachments/assets/d66cd589-963b-4cb3-86be-c869a08a0069" />
