### PR TITLE
Insert servings into placed crocks instead of taking them out

### DIFF
--- a/Block/BlockCookedContainerBase.cs
+++ b/Block/BlockCookedContainerBase.cs
@@ -419,7 +419,17 @@ namespace Vintagestory.GameContent
                 }
                 else
                 {
-                    served = ServeIntoStack(targetSlot, slot, api.World);
+                    // Try to put meals into other crocks instead of taking them out.
+                    // Makes interacting with shelves nicer since you can put a semi-full
+                    // crock in front of a full one.
+                    if (targetSlot.Itemstack.Block is BlockCrock)
+                    {
+                        served = ServeIntoStack(slot, targetSlot, api.World);
+                    }
+                    else
+                    {
+                        served = ServeIntoStack(targetSlot, slot, api.World);
+                    }
                 }
 
                 slot.MarkDirty();

--- a/Block/BlockCrock.cs
+++ b/Block/BlockCrock.cs
@@ -326,7 +326,15 @@ namespace Vintagestory.GameContent
                 {
                     if (quantityServings > 0)
                     {
-                        ServeIntoStack(gsslot, slot, byEntity.World);
+                        // Try to put meals into other crocks instead of taking them out.
+                        if (gsslot.Itemstack.Block is BlockCrock)
+                        {
+                            ServeIntoStack(slot, gsslot, byEntity.World);
+                        }
+                        else
+                        {
+                            ServeIntoStack(gsslot, slot, byEntity.World);
+                        }
                         gsslot.MarkDirty();
                         begs.MarkMeshesDirty();
                         begs.MarkDirty(true);


### PR DESCRIPTION
Makes interacting with shelves and ground storage nicer. You can now fill up a placed crock and put a partially filled one in front without holding shift.

Vanilla:

Held full crock is placed in front of partially-full crock and takes meals when not full.

<img width="2560" height="1440" alt="2026-06-25_03-00-10" src="https://github.com/user-attachments/assets/e9868bf0-80df-457f-9027-c1de64a6d6f0" />
<img width="2560" height="1440" alt="2026-06-25_03-05-33" src="https://github.com/user-attachments/assets/06a838aa-4977-4d89-9268-ce61a12fedaf" />

Right clicking a partially full ground stored crock with a full crock does nothing.

<img width="2560" height="1440" alt="2026-06-25_03-11-58" src="https://github.com/user-attachments/assets/47b0b338-2a98-4412-a267-5e9b96e3df9d" />
<img width="2560" height="1440" alt="2026-06-25_03-12-10" src="https://github.com/user-attachments/assets/fe7a6a43-ec3c-4c02-ac88-2b062d868518" />


Tweaked:

Held partially full crock is placed in front of full crock without holding shift.

<img width="2560" height="1440" alt="2026-06-25_03-09-49" src="https://github.com/user-attachments/assets/5dbc34f7-d563-4fec-8d07-f16fa049118a" />
<img width="2560" height="1440" alt="2026-06-25_03-09-53" src="https://github.com/user-attachments/assets/9ed62b44-6f16-4d16-a1dd-14f6ec21f3ef" />

Right clicking a partially full ground stored crock with a full crock fills the one on the ground.

<img width="2560" height="1440" alt="2026-06-25_03-14-26" src="https://github.com/user-attachments/assets/e76d9325-ee17-45fe-9ea5-44d5f8fa9397" />
<img width="2560" height="1440" alt="2026-06-25_03-14-30" src="https://github.com/user-attachments/assets/25f9fa89-dfe2-4000-aad8-abf2c7b01a96" />

Closes https://github.com/anegostudios/VintageStory-Issues/issues/9031