### PR TITLE
Apply the actual broken blocks count as damage to shears and scythes

### DIFF
--- a/Item/ItemScythe.cs
+++ b/Item/ItemScythe.cs
@@ -143,14 +143,14 @@ namespace Vintagestory.GameContent
         }
 
 
-        protected override void breakMultiBlock(BlockPos pos, IPlayer plr)
+        protected override bool breakMultiBlock(BlockPos pos, IPlayer plr)
         {
             if (trimMode)
             {
                 var block = api.World.BlockAccessor.GetBlock(pos);
                 var trimmedBlock = api.World.GetBlock(block.CodeWithVariant("tallgrass", "eaten"));
                 bool blockIsTallgrass = block.Variant.ContainsKey("tallgrass");
-                if (blockIsTallgrass && block == trimmedBlock) return;
+                if (blockIsTallgrass && block == trimmedBlock) return false;
 
                 if (blockIsTallgrass && trimmedBlock != null)
                 {
@@ -161,11 +161,11 @@ namespace Vintagestory.GameContent
                     var be = api.World.BlockAccessor.GetBlockEntity(pos) as BlockEntityTransient;
                     if (be != null) be.ConvertToOverride = block.Code.ToShortString();
 
-                    return;
+                    return true;
                 }
             }
 
-            base.breakMultiBlock(pos, plr);
+            return base.breakMultiBlock(pos, plr);
         }
 
 

--- a/Item/ItemShears.cs
+++ b/Item/ItemShears.cs
@@ -65,7 +65,10 @@ namespace Vintagestory.GameContent
             IPlayer plr = world.PlayerByUid((byEntity as EntityPlayer).PlayerUID);
 
             //base.OnBlockBrokenWith(world, byEntity, itemslot, blockSel, dropQuantityMultiplier);
-            breakMultiBlock(blockSel.Position, plr);
+            if (breakMultiBlock(blockSel.Position, plr))
+            {
+                DamageItem(world, byEntity, itemslot);
+            }
 
             if (!CanMultiBreak(block)) return true;
 
@@ -80,10 +83,10 @@ namespace Vintagestory.GameContent
             {
                 if (!plr.Entity.World.Claims.TryAccess(plr, val.Key, EnumBlockAccessFlags.BuildOrBreak)) continue;
 
-                breakMultiBlock(val.Key, plr);
-
-                DamageItem(world, byEntity, itemslot);
-
+                if (breakMultiBlock(val.Key, plr))
+                {
+                    DamageItem(world, byEntity, itemslot);
+                }
                 q++;
                 if (q >= MultiBreakQuantity || itemslot.Itemstack == null) break;
             }
@@ -91,10 +94,11 @@ namespace Vintagestory.GameContent
             return true;
         }
 
-        protected virtual void breakMultiBlock(BlockPos pos, IPlayer plr)
+        protected virtual bool breakMultiBlock(BlockPos pos, IPlayer plr)
         {
             api.World.BlockAccessor.BreakBlock(pos, plr);
             api.World.BlockAccessor.MarkBlockDirty(pos);
+            return true;
         }
 
 


### PR DESCRIPTION
Fixes https://github.com/anegostudios/VintageStory-Issues/issues/3863, the bug was also applying to shears cause the block breaking logic for those is customized.

To fix the issue, I added two things:
- Applying tool damage even for the first block broken before the blocks around get looped through
- Changed the breakMultiBlock function to be a boolean return type so the function can feedback if the block was actually broken or filtered out

Known issues:
- The scythe still makes the scything sound even if it's doing nothing... Maybe consider adding a different check than the "block was actually broken" to apply in sound and breaking.