### PR TITLE
Normalize ignite world interaction generation, fix boiler nullable capi

### DIFF
--- a/Block/BlockBloomery.cs
+++ b/Block/BlockBloomery.cs
@@ -16,16 +16,15 @@ namespace Vintagestory.GameContent
         {
             base.OnLoaded(api);
 
-            if (api.Side != EnumAppSide.Client) return;
-            ICoreClientAPI capi = api as ICoreClientAPI;
+            if (api is not ICoreClientAPI capi) return;
 
-            interactions = ObjectCacheUtil.GetOrCreate(api, "bloomeryBlockInteractions", () =>
+            interactions = ObjectCacheUtil.GetOrCreate(capi, "bloomeryBlockInteractions", () =>
             {
                 List<ItemStack> heatableStacklist = new List<ItemStack>();
                 List<ItemStack> fuelStacklist = new List<ItemStack>();
-                List<ItemStack> canIgniteStacks = BlockBehaviorCanIgnite.CanIgniteStacks(api, false);
+                List<ItemStack> canIgniteStacks = BlockBehaviorCanIgnite.CanIgniteStacks(capi, false);
 
-                foreach (CollectibleObject obj in api.World.Collectibles)
+                foreach (CollectibleObject obj in capi.World.Collectibles)
                 {
                     if (obj.CombustibleProps == null) continue;
                     if (obj.CombustibleProps.SmeltedStack != null && obj.CombustibleProps.MeltingPoint < 1500)
@@ -75,8 +74,8 @@ namespace Vintagestory.GameContent
                         MouseButton = EnumMouseButton.Right,
                         Itemstacks = canIgniteStacks.ToArray(),
                         GetMatchingStacks = (wi, bs, es) => {
-                            BlockEntityBloomery beb = api.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityBloomery;
-                            if (beb!= null && beb.CanIgnite() == true && !beb.IsBurning && api.World.BlockAccessor.GetBlock(bs.Position.UpCopy()).Code.Path.Contains("bloomerychimney"))
+                            BlockEntityBloomery beb = capi.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityBloomery;
+                            if (beb!= null && beb.CanIgnite() == true && !beb.IsBurning && capi.World.BlockAccessor.GetBlock(bs.Position.UpCopy()).Code.Path.Contains("bloomerychimney"))
                             {
                                 return wi.Itemstacks;
                             }

--- a/Block/BlockBoiler.cs
+++ b/Block/BlockBoiler.cs
@@ -23,14 +23,16 @@ namespace Vintagestory.GameContent
             partCollBoxes = (Cuboidf[])CollisionBoxes.Clone();
             partCollBoxes[0].Y1 = 7/16f;
 
-            boilerinteractions = ObjectCacheUtil.GetOrCreate(api, "boilerInteractions", () =>
+            if (api is not ICoreClientAPI capi) return;
+
+            boilerinteractions = ObjectCacheUtil.GetOrCreate(capi, "boilerInteractions", () =>
             {
-                List<ItemStack> canIgniteStacks = BlockBehaviorCanIgnite.CanIgniteStacks(api, true);
+                List<ItemStack> canIgniteStacks = BlockBehaviorCanIgnite.CanIgniteStacks(capi, true);
 
                 List<ItemStack> tinderStacks = new List<ItemStack>();
                 List<ItemStack> firewoodStacks = new List<ItemStack>();
 
-                foreach (CollectibleObject obj in api.World.Items)
+                foreach (CollectibleObject obj in capi.World.Items)
                 {
                     if (obj is ItemDryGrass)
                     {
@@ -52,7 +54,7 @@ namespace Vintagestory.GameContent
                         HotKeyCode = "shift",
                         Itemstacks = canIgniteStacks.ToArray(),
                         GetMatchingStacks = (wi, bs, es) => {
-                            BlockEntityBoiler bef = api.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityBoiler;
+                            BlockEntityBoiler bef = capi.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityBoiler;
                             if (bef != null && !bef.IsBurning && bef.fuelHours > 0 && bef.firepitStage >= 5)
                             {
                                 return wi.Itemstacks;
@@ -67,7 +69,7 @@ namespace Vintagestory.GameContent
                         Itemstacks = tinderStacks.ToArray(),
                         GetMatchingStacks = (wi, bs, es) =>
                         {
-                            BlockEntityBoiler bef = api.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityBoiler;
+                            BlockEntityBoiler bef = capi.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityBoiler;
                             if (bef != null && bef.firepitStage == 0) return wi.Itemstacks;
                             return null;
                         }
@@ -79,13 +81,14 @@ namespace Vintagestory.GameContent
                         Itemstacks = firewoodStacks.ToArray(),
                         GetMatchingStacks = (wi, bs, es) =>
                         {
-                            BlockEntityBoiler bef = api.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityBoiler;
+                            BlockEntityBoiler bef = capi.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityBoiler;
                             if (bef != null && bef.firepitStage > 0 && bef.fuelHours <= 6f) return wi.Itemstacks;
                             return null;
                         }
                     }
                 };
             });
+
         }
 
         public override ItemStack OnPickBlock(IWorldAccessor world, BlockPos pos)

--- a/Block/BlockBomb.cs
+++ b/Block/BlockBomb.cs
@@ -16,12 +16,11 @@ namespace Vintagestory.GameContent
         {
             base.OnLoaded(api);
 
-            if (api.Side != EnumAppSide.Client) return;
-            ICoreClientAPI capi = api as ICoreClientAPI;
+            if (api is not ICoreClientAPI capi) return;
 
-            interactions = ObjectCacheUtil.GetOrCreate(api, "bombInteractions", () =>
+            interactions = ObjectCacheUtil.GetOrCreate(capi, "bombInteractions", () =>
             {
-                List<ItemStack> canIgniteStacks = BlockBehaviorCanIgnite.CanIgniteStacks(api, false);
+                List<ItemStack> canIgniteStacks = BlockBehaviorCanIgnite.CanIgniteStacks(capi, false);
 
                 return new WorldInteraction[] {
                     new WorldInteraction()
@@ -30,7 +29,7 @@ namespace Vintagestory.GameContent
                         ActionLangCode = "blockhelp-bomb-ignite",
                         Itemstacks = canIgniteStacks.ToArray(),
                         GetMatchingStacks = (wi, bs, es) => {
-                            BlockEntityBomb bebomb = api.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityBomb;
+                            BlockEntityBomb bebomb = capi.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityBomb;
                             return bebomb == null || bebomb.IsLit ? null : wi.Itemstacks;
                         }
                     }

--- a/Block/BlockCharcoalPit.cs
+++ b/Block/BlockCharcoalPit.cs
@@ -14,9 +14,11 @@ namespace Vintagestory.GameContent
         {
             base.OnLoaded(api);
 
-            interactions = ObjectCacheUtil.GetOrCreate(api, "charcoalpitInteractions", () =>
+            if (api is not ICoreClientAPI capi) return;
+            
+            interactions = ObjectCacheUtil.GetOrCreate(capi, "charcoalpitInteractions", () =>
             {
-                List<ItemStack> canIgniteStacks = BlockBehaviorCanIgnite.CanIgniteStacks(api, true);
+                List<ItemStack> canIgniteStacks = BlockBehaviorCanIgnite.CanIgniteStacks(capi, true);
 
                 return new WorldInteraction[]
                 {
@@ -27,7 +29,7 @@ namespace Vintagestory.GameContent
                         HotKeyCode = "shift",
                         Itemstacks = canIgniteStacks.ToArray(),
                         GetMatchingStacks = (wi, bs, es) => {
-                            BlockEntityCharcoalPit? becp = api.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityCharcoalPit;
+                            BlockEntityCharcoalPit? becp = capi.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityCharcoalPit;
                             if (becp?.Lit == false)
                             {
                                 return wi.Itemstacks;

--- a/Block/BlockClayOven.cs
+++ b/Block/BlockClayOven.cs
@@ -50,17 +50,15 @@ namespace Vintagestory.GameContent
         {
             base.OnLoaded(api);
 
-            if (api.Side != EnumAppSide.Client) return;
-            
-            ICoreClientAPI capi = api as ICoreClientAPI;
+            if (api is not ICoreClientAPI capi) return;
 
-            if (capi != null) interactions = ObjectCacheUtil.GetOrCreate(api, "ovenInteractions", () =>
+            interactions = ObjectCacheUtil.GetOrCreate(capi, "ovenInteractions", () =>
             {
                 List<ItemStack> bakeableStacklist = [];
                 List<ItemStack> fuelStacklist = [];
-                List<ItemStack> canIgniteStacks = BlockBehaviorCanIgnite.CanIgniteStacks(api, true);
+                List<ItemStack> canIgniteStacks = BlockBehaviorCanIgnite.CanIgniteStacks(capi, true);
 
-                foreach (CollectibleObject obj in api.World.Collectibles)
+                foreach (CollectibleObject obj in capi.World.Collectibles)
                 {
                     // we test firewood first because LazyWarlock's mod adds a wood baking recipe, which we don't want to be treated as a bakeable item here
                     if (obj.Attributes?.IsTrue("isClayOvenFuel") == true)
@@ -83,8 +81,8 @@ namespace Vintagestory.GameContent
                     stack.Attributes.SetString("topCrustType", "square");
                     stack.Attributes.SetInt("bakeLevel", 0);
 
-                    ItemStack doughStack = new(api.World.GetItem("dough-spelt"), 2);
-                    ItemStack fillingStack = new(api.World.GetItem("fruit-redapple"), 2);
+                    ItemStack doughStack = new(capi.World.GetItem("dough-spelt"), 2);
+                    ItemStack fillingStack = new(capi.World.GetItem("fruit-redapple"), 2);
                     pieBlock.SetContents(stack, [doughStack, fillingStack, fillingStack, fillingStack, fillingStack, doughStack]);
                     stack.Attributes.SetFloat("quantityServings", 1);
                 }
@@ -98,7 +96,7 @@ namespace Vintagestory.GameContent
                         Itemstacks = bakeableStacklist.ToArray(),
                         GetMatchingStacks = (wi, bs, es) => {
                             if (wi.Itemstacks.Length == 0) return null;
-                            BlockEntityOven beo = api.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityOven;
+                            BlockEntityOven beo = capi.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityOven;
                             return beo != null ? beo.CanAdd(wi.Itemstacks) : null;
                         }
                     },
@@ -110,7 +108,7 @@ namespace Vintagestory.GameContent
                         Itemstacks = fuelStacklist.ToArray(),
                         GetMatchingStacks = (wi, bs, es) => {
                             //if (wi.Itemstacks.Length == 0) return null;
-                            BlockEntityOven beo = api.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityOven;
+                            BlockEntityOven beo = capi.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityOven;
                             return beo != null ? beo.CanAddAsFuel(fuelStacklist.ToArray()) : null;
                         }
                     },
@@ -122,7 +120,7 @@ namespace Vintagestory.GameContent
                         Itemstacks = canIgniteStacks.ToArray(),
                         GetMatchingStacks = (wi, bs, es) => {
                             if (wi.Itemstacks.Length == 0) return null;
-                            BlockEntityOven beo = api.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityOven;
+                            BlockEntityOven beo = capi.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityOven;
                             return beo != null && beo.CanIgnite() ? wi.Itemstacks : null;
                         }
                     }

--- a/Block/BlockCoalPile.cs
+++ b/Block/BlockCoalPile.cs
@@ -42,12 +42,11 @@ namespace Vintagestory.GameContent
         {
             base.OnLoaded(api);
 
-            if (api.Side != EnumAppSide.Client) return;
-            ICoreClientAPI capi = api as ICoreClientAPI;
+            if (api is not ICoreClientAPI capi) return;
 
-            interactions = ObjectCacheUtil.GetOrCreate(api, "coalBlockInteractions", () =>
+            interactions = ObjectCacheUtil.GetOrCreate(capi, "coalBlockInteractions", () =>
             {
-                List<ItemStack> canIgniteStacks = BlockBehaviorCanIgnite.CanIgniteStacks(api, false);
+                List<ItemStack> canIgniteStacks = BlockBehaviorCanIgnite.CanIgniteStacks(capi, false);
 
                 return new WorldInteraction[] {
                     new WorldInteraction()
@@ -55,7 +54,7 @@ namespace Vintagestory.GameContent
                         ActionLangCode = "blockhelp-coalpile-addcoal",
                         MouseButton = EnumMouseButton.Right,
                         HotKeyCode = "shift",
-                        Itemstacks = new ItemStack[] { new ItemStack(api.World.GetItem(new AssetLocation("charcoal")), 2) }
+                        Itemstacks = new ItemStack[] { new ItemStack(capi.World.GetItem(new AssetLocation("charcoal")), 2) }
                     },
                     new WorldInteraction()
                     {
@@ -70,7 +69,7 @@ namespace Vintagestory.GameContent
                         MouseButton = EnumMouseButton.Right,
                         Itemstacks = canIgniteStacks.ToArray(),
                         GetMatchingStacks = (wi, bs, es) => {
-                            BlockEntityForge bef = api.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityForge;
+                            BlockEntityForge bef = capi.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityForge;
                             if (bef!= null && bef.CanIgnite && !bef.IsBurning)
                             {
                                 return wi.Itemstacks;

--- a/Block/BlockFirepit.cs
+++ b/Block/BlockFirepit.cs
@@ -105,10 +105,11 @@ namespace Vintagestory.GameContent
                 }
             }
 
+            if (capi is null) return;
 
-            interactions = ObjectCacheUtil.GetOrCreate(api, "firepitInteractions-"+Stage, () =>
+            interactions = ObjectCacheUtil.GetOrCreate(capi, "firepitInteractions-"+Stage, () =>
             {
-                List<ItemStack> canIgniteStacks = BlockBehaviorCanIgnite.CanIgniteStacks(api, true);
+                List<ItemStack> canIgniteStacks = BlockBehaviorCanIgnite.CanIgniteStacks(capi, true);
 
                 return new WorldInteraction[]
                 {
@@ -127,7 +128,7 @@ namespace Vintagestory.GameContent
                         MouseButton = EnumMouseButton.Right,
                         Itemstacks = canIgniteStacks.ToArray(),
                         GetMatchingStacks = (wi, bs, es) => {
-                            BlockEntityFirepit bef = api.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityFirepit;
+                            BlockEntityFirepit bef = capi.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityFirepit;
                             if (bef?.fuelSlot != null && !bef.fuelSlot.Empty && !bef.IsBurning)
                             {
                                 return wi.Itemstacks;

--- a/Block/BlockForge.cs
+++ b/Block/BlockForge.cs
@@ -22,15 +22,14 @@ namespace Vintagestory.GameContent
         {
             base.OnLoaded(api);
 
-            if (api.Side != EnumAppSide.Client) return;
-            ICoreClientAPI capi = api as ICoreClientAPI;
+            if (api is not ICoreClientAPI capi) return;
 
-            interactions = ObjectCacheUtil.GetOrCreate(api, "forgeBlockInteractions", () =>
+            interactions = ObjectCacheUtil.GetOrCreate(capi, "forgeBlockInteractions", () =>
             {
                 List<ItemStack> heatableStacklist = new List<ItemStack>();
-                List<ItemStack> canIgniteStacks = BlockBehaviorCanIgnite.CanIgniteStacks(api, false);
+                List<ItemStack> canIgniteStacks = BlockBehaviorCanIgnite.CanIgniteStacks(capi, false);
 
-                foreach (CollectibleObject obj in api.World.Collectibles)
+                foreach (CollectibleObject obj in capi.World.Collectibles)
                 {
                     string firstCodePart = obj.FirstCodePart();
 
@@ -58,10 +57,10 @@ namespace Vintagestory.GameContent
                         Itemstacks = heatableStacklist.ToArray(),
                         GetMatchingStacks = (wi, bs, es) =>
                         {
-                            BlockEntityForge bef = api.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityForge;
+                            BlockEntityForge bef = capi.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityForge;
                             if (bef!= null && bef.WorkItemStack != null)
                             {
-                                return wi.Itemstacks.Where(stack => stack.Equals(api.World, bef.WorkItemStack, GlobalConstants.IgnoredStackAttributes)).ToArray();
+                                return wi.Itemstacks.Where(stack => stack.Equals(capi.World, bef.WorkItemStack, GlobalConstants.IgnoredStackAttributes)).ToArray();
                             }
                             return wi.Itemstacks;
                         }
@@ -74,7 +73,7 @@ namespace Vintagestory.GameContent
                         Itemstacks = heatableStacklist.ToArray(),
                         GetMatchingStacks = (wi, bs, es) =>
                         {
-                            BlockEntityForge bef = api.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityForge;
+                            BlockEntityForge bef = capi.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityForge;
                             if (bef!= null && bef.WorkItemStack != null)
                             {
                                 return new ItemStack[] { bef.WorkItemStack };
@@ -90,7 +89,7 @@ namespace Vintagestory.GameContent
                         Itemstacks = coalStacklist.ToArray(),
                         GetMatchingStacks = (wi, bs, es) =>
                         {
-                            BlockEntityForge bef = api.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityForge;
+                            BlockEntityForge bef = capi.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityForge;
                             if (bef!= null && bef.FuelLevel < 5/16f)
                             {
                                 return wi.Itemstacks;
@@ -105,7 +104,7 @@ namespace Vintagestory.GameContent
                         MouseButton = EnumMouseButton.Right,
                         Itemstacks = canIgniteStacks.ToArray(),
                         GetMatchingStacks = (wi, bs, es) => {
-                            BlockEntityForge bef = api.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityForge;
+                            BlockEntityForge bef = capi.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityForge;
                             if (bef!= null && bef.CanIgnite && !bef.IsBurning)
                             {
                                 return wi.Itemstacks;

--- a/Block/BlockPitkiln.cs
+++ b/Block/BlockPitkiln.cs
@@ -56,24 +56,26 @@ namespace Vintagestory.GameContent
 
             Dictionary<string, BuildStageMaterial[]> resolvedMats = new Dictionary<string, BuildStageMaterial[]>();
 
-            List<ItemStack> canIgniteStacks = BlockBehaviorCanIgnite.CanIgniteStacks(api, true);
-            ingiteInteraction = new WorldInteraction[] { new WorldInteraction()
-            {
-                ActionLangCode = "blockhelp-firepit-ignite",
-                MouseButton = EnumMouseButton.Right,
-                HotKeyCode = "shift",
-                Itemstacks = canIgniteStacks.ToArray(),
-                GetMatchingStacks = (wi, bs, es) =>
+            if (api is ICoreClientAPI capi) {
+                List<ItemStack> canIgniteStacks = BlockBehaviorCanIgnite.CanIgniteStacks(capi, true);
+                ingiteInteraction = new WorldInteraction[] { new WorldInteraction()
                 {
-                    BlockEntityPitKiln beg = api.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityPitKiln;
-                    if (beg?.Lit != true && beg?.CanIgnite == true)
+                    ActionLangCode = "blockhelp-firepit-ignite",
+                    MouseButton = EnumMouseButton.Right,
+                    HotKeyCode = "shift",
+                    Itemstacks = canIgniteStacks.ToArray(),
+                    GetMatchingStacks = (wi, bs, es) =>
                     {
-                        return wi.Itemstacks;
+                        BlockEntityPitKiln beg = capi.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityPitKiln;
+                        if (beg?.Lit != true && beg?.CanIgnite == true)
+                        {
+                            return wi.Itemstacks;
+                        }
+                        return null;
                     }
-                    return null;
                 }
+                };
             }
-            };
 
 
 

--- a/Block/BlockTorch.cs
+++ b/Block/BlockTorch.cs
@@ -59,23 +59,25 @@ namespace Vintagestory.GameContent
 
             if (IsExtinct)
             {
-                interactions = ObjectCacheUtil.GetOrCreate(api, "torchInteractions" + FirstCodePart(), () =>
-                {
-                    List<ItemStack> canIgniteStacks = BlockBehaviorCanIgnite.CanIgniteStacks(api, true);
+                if (api is ICoreClientAPI capi) {
+                    interactions = ObjectCacheUtil.GetOrCreate(capi, "torchInteractions" + FirstCodePart(), () =>
+                    {
+                        List<ItemStack> canIgniteStacks = BlockBehaviorCanIgnite.CanIgniteStacks(capi, true);
 
-                    return new WorldInteraction[]
-                    {
-                    new WorldInteraction()
-                    {
-                        ActionLangCode = "blockhelp-firepit-ignite",
-                        MouseButton = EnumMouseButton.Right,
-                        Itemstacks = canIgniteStacks.ToArray(),
-                        GetMatchingStacks = (wi, bs, es) => {
-                            return wi.Itemstacks;
+                        return new WorldInteraction[]
+                        {
+                        new WorldInteraction()
+                        {
+                            ActionLangCode = "blockhelp-firepit-ignite",
+                            MouseButton = EnumMouseButton.Right,
+                            Itemstacks = canIgniteStacks.ToArray(),
+                            GetMatchingStacks = (wi, bs, es) => {
+                                return wi.Itemstacks;
+                            }
                         }
-                    }
-                    };
-                });
+                        };
+                    });
+                }
             }
         }
 

--- a/Lore/ResoArchives/BlockBehaviorJonasGasifier.cs
+++ b/Lore/ResoArchives/BlockBehaviorJonasGasifier.cs
@@ -30,14 +30,13 @@ namespace Vintagestory.GameContent
         {
             base.OnLoaded(api);
 
-            if (api.Side != EnumAppSide.Client) return;
-            ICoreClientAPI capi = api as ICoreClientAPI;
+            if (api is not ICoreClientAPI capi) return;
 
-            BlockForge forgeBlock = api.World.GetBlock(new AssetLocation("forge")) as BlockForge;
+            BlockForge forgeBlock = capi.World.GetBlock(new AssetLocation("forge")) as BlockForge;
 
-            interactions = ObjectCacheUtil.GetOrCreate(api, "gasifierBlockInteractions", () =>
+            interactions = ObjectCacheUtil.GetOrCreate(capi, "gasifierBlockInteractions", () =>
             {
-                List<ItemStack> canIgniteStacks = BlockBehaviorCanIgnite.CanIgniteStacks(api, false);
+                List<ItemStack> canIgniteStacks = BlockBehaviorCanIgnite.CanIgniteStacks(capi, false);
 
                 return new WorldInteraction[] {
                     new WorldInteraction()
@@ -54,7 +53,7 @@ namespace Vintagestory.GameContent
                         MouseButton = EnumMouseButton.Right,
                         Itemstacks = canIgniteStacks.ToArray(),
                         GetMatchingStacks = (wi, bs, es) => {
-                            var bef = api.World.BlockAccessor.GetBlockEntity(bs.Position)?.GetBehavior<BEBehaviorJonasGasifier>();
+                            var bef = capi.World.BlockAccessor.GetBlockEntity(bs.Position)?.GetBehavior<BEBehaviorJonasGasifier>();
                             if (bef!= null && bef.HasFuel && !bef.Lit)
                             {
                                 return wi.Itemstacks;


### PR DESCRIPTION
This PR fixes some world interaction generations trying to create the interactions in the server side, leading to null capi being passed around which didn't create issues since the part that used the capi was not activelly reachable for torch and firestarter, as those didn't have defined creative stacks. 
Adding ignitable items or changing existing items to have creative stacks akin to lantern would produce NPEs.
Additionally, i've taken the liberty of modifying the interaction generator code to use exclusively capi to avoid the repeat of this, as well as normalized the approach to branch execution: check against capi being null, or checks against api being castable to capi. Returns if the block is the last in the OnLoaded and IF blocks if it's indented and as such has worse visibility.
<img width="965" height="762" alt="image" src="https://github.com/user-attachments/assets/57c7ba41-03f4-460b-81db-ff4c079a616f" />
