### PR TITLE
Improved Spur Gears feature bounty.

### DIFF
--- a/Systems/MechanicalPower/Block/BlockAxle.cs
+++ b/Systems/MechanicalPower/Block/BlockAxle.cs
@@ -26,11 +26,14 @@ namespace Vintagestory.GameContent.Mechanics
             if (BlockSpurGear.WoodenAxleCheck(this) && world.BlockAccessor.GetBlock(blockSel.Position) is BlockSpurGear spurgear)
             {
                 if (spurgear.TryAddInsideAxle(world, blockSel.Position))
+                {
                     return true;
-
-                failureCode = "notreplaceable";
-
-                return false;
+                }
+                else
+                {
+                    failureCode = "notreplaceable";
+                    return false;
+                }
             }
 
             if (!CanPlaceBlock(world, byPlayer, blockSel, ref failureCode))

--- a/Systems/MechanicalPower/Block/BlockAxle.cs
+++ b/Systems/MechanicalPower/Block/BlockAxle.cs
@@ -22,6 +22,17 @@ namespace Vintagestory.GameContent.Mechanics
 
         public override bool TryPlaceBlock(IWorldAccessor world, IPlayer byPlayer, ItemStack itemstack, BlockSelection blockSel, ref string failureCode)
         {
+            // Only wooden axles can be placed inside spur gears.
+            if (BlockSpurGear.WoodenAxleCheck(this) && world.BlockAccessor.GetBlock(blockSel.Position) is BlockSpurGear spurgear)
+            {
+                if (spurgear.TryAddInsideAxle(world, blockSel.Position))
+                    return true;
+
+                failureCode = "notreplaceable";
+
+                return false;
+            }
+
             if (!CanPlaceBlock(world, byPlayer, blockSel, ref failureCode))
             {
                 return false;

--- a/Systems/MechanicalPower/Block/BlockSpurGear.cs
+++ b/Systems/MechanicalPower/Block/BlockSpurGear.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;
 
@@ -16,6 +17,7 @@ namespace Vintagestory.GameContent.Mechanics
         {
             Orientation = Variant["orientation"];
             Facing = BlockFacing.FromFirstLetter(Orientation[0]);
+
             base.OnLoaded(api);
         }
 
@@ -39,7 +41,69 @@ namespace Vintagestory.GameContent.Mechanics
         public bool HasExtraGear() => Orientation.Length == 2 && !HasInsideAxle();
         public bool IsOrientedTo(BlockFacing facing) => Orientation.Contains(facing.Code[0]);
 
-        public override bool HasMechPowerConnectorAt(IWorldAccessor world, BlockPos pos, BlockFacing face, BlockMPBase forBlock) => IsOrientedTo(face);
+        public BlockFacing[] GearsInThisBlock => HasExtraGear() ? Facings : [Facing];
+
+        /// <summary>
+        /// Null if not interlacing
+        /// </summary>
+        public BlockFacing GetInterlacingGearsFace(Block block, BlockFacing face)
+        {
+            if (block is not BlockSpurGear otherGear)
+                return null;
+
+            foreach (BlockFacing gearFace in GearsInThisBlock)
+            {
+                if (face.Axis != gearFace.Axis && otherGear.GearsInThisBlock.Contains(gearFace))
+                    return gearFace;
+            }
+
+            return null;
+        }
+
+        public bool CanConnectWith(Block block, BlockFacing face) => GetInterlacingGearsFace(block, face) != null;
+
+        /// <summary>
+        /// Count the directly adjacent gears, where their teeth interlace with this gear
+        /// </summary>
+        public static int CountInterlacedGears(IWorldAccessor world, BlockPos pos, BlockFacing gearFacing)
+        {
+            int count = 0;
+            foreach (BlockFacing face in BlockFacing.ALLFACES)
+            {
+                if (face.Axis == gearFacing.Axis)
+                    continue;
+
+                if (world.BlockAccessor.GetBlock(pos.AddCopy(face)) is BlockSpurGear neighbour && neighbour.GearsInThisBlock.Contains(gearFacing))
+                    count++;
+            }
+
+            return count;
+        }
+
+        public static bool WouldCreateFourWayJunction(IWorldAccessor world, BlockPos pos, BlockFacing newGearFacing)
+        {
+            if (CountInterlacedGears(world, pos, newGearFacing) >= 4)
+                return true; // Would be the 4 way junction
+
+            foreach (BlockFacing face in BlockFacing.ALLFACES)
+            {
+                if (face.Axis == newGearFacing.Axis)
+                    continue;
+
+                BlockPos neighbourPos = pos.AddCopy(face);
+                if (world.BlockAccessor.GetBlock(neighbourPos) is BlockSpurGear neighbour
+                    && neighbour.GearsInThisBlock.Contains(newGearFacing)
+                    && CountInterlacedGears(world, neighbourPos, newGearFacing) >= 3)
+                {
+                    return true; // Would make another gear the 4 way junction
+                }
+            }
+
+            return false;
+        }
+
+        public override bool HasMechPowerConnectorAt(IWorldAccessor world, BlockPos pos, BlockFacing face, BlockMPBase forBlock)
+            => IsOrientedTo(face) || CanConnectWith(forBlock, face);    // Side by side: powers any matching spur gear adjacent
 
         /// <summary>
         /// Only wooden axles can be placed inside spur gears.
@@ -105,6 +169,13 @@ namespace Vintagestory.GameContent.Mechanics
             Block toPlaceBlock = getGearBlock(world, existingGear.Facing, extraGearWillBeFacing);
             if (toPlaceBlock == null)
                 return false;
+
+            // 4 way junctions can create deadlocks
+            // Theres currently no handling for those deadlocks so for now we don't allow them to be created
+            if (WouldCreateFourWayJunction(world, gearPos, extraGearWillBeFacing))
+            {
+                return false;
+            }
 
             // The server will update the client with the new gear block's state
             if (world.Side == EnumAppSide.Client)
@@ -176,7 +247,6 @@ namespace Vintagestory.GameContent.Mechanics
             else if (world.BlockAccessor.GetBlock(blockSel.Position) is BlockSpurGear)
             {
                 // "Another block is in the way"
-                failureCode = "notreplaceable";
                 return false;
             }
 
@@ -204,6 +274,9 @@ namespace Vintagestory.GameContent.Mechanics
                     axleFoundButUnsupported = true;
                     continue;
                 }
+
+                if (WouldCreateFourWayJunction(world, blockSel.Position, face))
+                    continue;
 
                 targetFace = face;
                 break;

--- a/Systems/MechanicalPower/Block/BlockSpurGear.cs
+++ b/Systems/MechanicalPower/Block/BlockSpurGear.cs
@@ -112,7 +112,7 @@ namespace Vintagestory.GameContent.Mechanics
 
             (toPlaceBlock as BlockMPBase).ExchangeBlockAt(world, gearPos);
 
-            // Attach the new extra gear to its axle
+            // Connect the new extra gear to its axle
             IMechanicalPowerBlock neighbour = be?.Block as IMechanicalPowerBlock;
             neighbour?.DidConnectAt(world, axlePos, extraGearWillBeFacing.Opposite);
             WasPlaced(world, gearPos, extraGearWillBeFacing);
@@ -135,7 +135,7 @@ namespace Vintagestory.GameContent.Mechanics
 
             (toPlaceBlock as BlockMPBase).ExchangeBlockAt(world, pos);
 
-            // Attach the new inside axle to the opposite axle
+            // Connect the new inside axle to the opposite axle
             BlockPos oppositeAxlePos = pos.AddCopy(Facing.Opposite);
             IMechanicalPowerBlock neighbour = world.BlockAccessor.GetBlock(oppositeAxlePos) as IMechanicalPowerBlock;
             if (neighbour != null && neighbour.HasMechPowerConnectorAt(world, oppositeAxlePos, Facing, this))
@@ -149,7 +149,7 @@ namespace Vintagestory.GameContent.Mechanics
 
         public override bool OnBlockInteractStart(IWorldAccessor world, IPlayer byPlayer, BlockSelection blockSel)
         {
-            // Right clicking/placing a solo spur gear with a wooden axle puts it inside the spur gear' block
+            // Right clicking/placing a solo spur gear block with a wooden axle puts it inside the spur gear's block
             ItemSlot slot = byPlayer.InventoryManager.ActiveHotbarSlot;
             if (WoodenAxleCheck(slot?.Itemstack?.Block) && TryAddInsideAxle(world, blockSel.Position))
             {
@@ -168,7 +168,7 @@ namespace Vintagestory.GameContent.Mechanics
 
         public override bool TryPlaceBlock(IWorldAccessor world, IPlayer byPlayer, ItemStack itemstack, BlockSelection blockSel, ref string failureCode)
         {
-            // Right clicking/placing an adjacent axle to a solo spur gear with another spur gear puts it on that adjacent axle inside the spur gear' block
+            // Right clicking/placing an adjacent axle to a solo spur gear with another spur gear puts it on that adjacent axle inside the spur gear's block
             if (TryAddExtraGear(world, byPlayer, blockSel))
             {
                 return true;

--- a/Systems/MechanicalPower/Block/BlockSpurGear.cs
+++ b/Systems/MechanicalPower/Block/BlockSpurGear.cs
@@ -1,5 +1,4 @@
-using System;
-using System.Collections.Generic;
+using System.Linq;
 using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;
 
@@ -7,89 +6,255 @@ using Vintagestory.API.MathTools;
 
 namespace Vintagestory.GameContent.Mechanics
 {
+    // Based off of BlockAngledGears
     public class BlockSpurGear : BlockMPBase
     {
-        protected BlockFacing Orientation; 
+        public string Orientation;
+        public BlockFacing Facing;
 
         public override void OnLoaded(ICoreAPI api)
         {
+            Orientation = Variant["orientation"];
+            Facing = BlockFacing.FromFirstLetter(Orientation[0]);
             base.OnLoaded(api);
-            Orientation = BlockFacing.FromFirstLetter(Variant["orientation"]);
         }
 
-        public override bool HasMechPowerConnectorAt(IWorldAccessor world, BlockPos pos, BlockFacing face, BlockMPBase forBlock)
+        public BlockFacing[] Facings
         {
-            return face == Orientation || (forBlock == this && face != Orientation.Opposite);    // Side by side: powers any matching spur gear adjacent
+            get
+            {
+                string dirs = Orientation;
+                BlockFacing[] facings = new BlockFacing[dirs.Length];
+                for (int i = 0; i < dirs.Length; i++)
+                {
+                    facings[i] = BlockFacing.FromFirstLetter(dirs[i]);
+                }
+
+                return facings;
+            }
         }
 
-        public override ItemStack OnPickBlock(IWorldAccessor world, BlockPos pos)
+        public bool IsSoloGear() => Orientation.Length == 1;
+        public bool HasInsideAxle() => Orientation.Length == 2 && Orientation[1] == Facing.Opposite.Code[0];
+        public bool HasExtraGear() => Orientation.Length == 2 && !HasInsideAxle();
+        public bool IsOrientedTo(BlockFacing facing) => Orientation.Contains(facing.Code[0]);
+
+        public override bool HasMechPowerConnectorAt(IWorldAccessor world, BlockPos pos, BlockFacing face, BlockMPBase forBlock) => IsOrientedTo(face);
+
+        /// <summary>
+        /// Only wooden axles can be placed inside spur gears.
+        /// </summary>
+        public static bool WoodenAxleCheck(Block block) => block is BlockAxle && block.FirstCodePart() == "woodenaxle";
+
+        public override bool IsReplacableBy(Block block)
         {
-            return new ItemStack(world.GetBlock(CodeWithVariant("orientation", "s")));
+            // Either an extra spur or an axle can be potentially placed inside 
+            if (block is BlockSpurGear || WoodenAxleCheck(block))
+                return true;
+
+            return base.IsReplacableBy(block);
         }
 
+        public override ItemStack OnPickBlock(IWorldAccessor world, BlockPos pos) => new(world.GetBlock(CodeWithVariant("orientation", "s")));
+
+        public Block getGearBlock(IWorldAccessor world, BlockFacing facing, BlockFacing extraGearFacing = null)
+        {
+            if (extraGearFacing == null)
+                return world.GetBlock(new AssetLocation(FirstCodePart() + "-" + facing.Code[0]));
+
+            AssetLocation loc = new AssetLocation(FirstCodePart() + "-" + facing.Code[0] + extraGearFacing.Code[0]);
+            Block toPlaceBlock = world.GetBlock(loc);
+
+            if (toPlaceBlock is not BlockSpurGear)
+            {
+                loc = new AssetLocation(FirstCodePart() + "-" + extraGearFacing.Code[0] + facing.Code[0]);
+                toPlaceBlock = world.GetBlock(loc);
+            }
+
+            if (toPlaceBlock is not BlockSpurGear)
+                return null;
+            else
+                return toPlaceBlock;
+        }
+
+        public override void DidConnectAt(IWorldAccessor world, BlockPos pos, BlockFacing face) { }
+
+        protected bool TryAddExtraGear(IWorldAccessor world, IPlayer byPlayer, BlockSelection blockSel)
+        {
+            if (world.BlockAccessor.GetBlock(blockSel.Position) is not BlockSpurGear existingGear)
+                return false;
+
+            BlockPos gearPos = blockSel.Position;
+            BlockFacing extraGearWillBeFacing;
+            if (blockSel.DidOffset)
+                extraGearWillBeFacing = blockSel.Face.Opposite;
+            else
+                extraGearWillBeFacing = blockSel.Face;
+
+            if (!existingGear.IsSoloGear())
+                return false;
+            if (!extraGearWillBeFacing.IsAdjacent(existingGear.Facing))
+                return false;
+
+            BlockPos axlePos = gearPos.AddCopy(extraGearWillBeFacing);
+            BlockEntity be = world.BlockAccessor.GetBlockEntity(axlePos);
+            BEBehaviorMPAxle bempaxle = be?.GetBehavior<BEBehaviorMPAxle>();
+            if (bempaxle == null || !(bempaxle.Block as BlockMPBase).HasMechPowerConnectorAt(world, axlePos, extraGearWillBeFacing.Opposite, this))
+                return false;
+
+            Block toPlaceBlock = getGearBlock(world, existingGear.Facing, extraGearWillBeFacing);
+            if (toPlaceBlock == null)
+                return false;
+
+            // The server will update the client with the new gear block's state
+            if (world.Side == EnumAppSide.Client)
+                return true;
+
+            (toPlaceBlock as BlockMPBase).ExchangeBlockAt(world, gearPos);
+
+            // Attach the new extra gear to its axle
+            IMechanicalPowerBlock neighbour = be?.Block as IMechanicalPowerBlock;
+            neighbour?.DidConnectAt(world, axlePos, extraGearWillBeFacing.Opposite);
+            WasPlaced(world, gearPos, extraGearWillBeFacing);
+
+            return true;
+        }
+
+        public bool TryAddInsideAxle(IWorldAccessor world, BlockPos pos)
+        {
+            if (!IsSoloGear())
+                return false;
+
+            Block toPlaceBlock = getGearBlock(world, Facing, Facing.Opposite);
+            if (toPlaceBlock == null)
+                return false;
+
+            // The server will update the client with the new gear block's state
+            if (world.Side == EnumAppSide.Client)
+                return true;
+
+            (toPlaceBlock as BlockMPBase).ExchangeBlockAt(world, pos);
+
+            // Attach the new inside axle to the opposite axle
+            BlockPos oppositeAxlePos = pos.AddCopy(Facing.Opposite);
+            IMechanicalPowerBlock neighbour = world.BlockAccessor.GetBlock(oppositeAxlePos) as IMechanicalPowerBlock;
+            if (neighbour != null && neighbour.HasMechPowerConnectorAt(world, oppositeAxlePos, Facing, this))
+            {
+                neighbour.DidConnectAt(world, oppositeAxlePos, Facing);
+                WasPlaced(world, pos, Facing.Opposite);
+            }
+
+            return true;
+        }
+
+        public override bool OnBlockInteractStart(IWorldAccessor world, IPlayer byPlayer, BlockSelection blockSel)
+        {
+            // Right clicking/placing a solo spur gear with a wooden axle puts it inside the spur gear' block
+            ItemSlot slot = byPlayer.InventoryManager.ActiveHotbarSlot;
+            if (WoodenAxleCheck(slot?.Itemstack?.Block) && TryAddInsideAxle(world, blockSel.Position))
+            {
+                if (byPlayer.WorldData.CurrentGameMode != EnumGameMode.Creative)
+                {
+                    slot.TakeOut(1);
+                    slot.MarkDirty();
+                }
+
+                world.PlaySoundAt(Sounds.Place, blockSel.Position, 0.5f, byPlayer);
+                return true;
+            }
+
+            return base.OnBlockInteractStart(world, byPlayer, blockSel);
+        }
 
         public override bool TryPlaceBlock(IWorldAccessor world, IPlayer byPlayer, ItemStack itemstack, BlockSelection blockSel, ref string failureCode)
         {
+            // Right clicking/placing an adjacent axle to a solo spur gear with another spur gear puts it on that adjacent axle inside the spur gear' block
+            if (TryAddExtraGear(world, byPlayer, blockSel))
+            {
+                return true;
+            }
+            else if (world.BlockAccessor.GetBlock(blockSel.Position) is BlockSpurGear)
+            {
+                // "Another block is in the way"
+                failureCode = "notreplaceable";
+                return false;
+            }
+
             if (!CanPlaceBlock(world, byPlayer, blockSel, ref failureCode))
             {
                 return false;
             }
 
-            BlockFacing targetFace = blockSel.Face.Opposite;
-            BlockPos pos = blockSel.Position.AddCopy(targetFace);
-            BlockEntity be = world.BlockAccessor.GetBlockEntity(pos);
-            IMechanicalPowerBlock neighbour = be?.Block as IMechanicalPowerBlock;
-
-            BEBehaviorMPAxle bempaxle = be?.GetBehavior<BEBehaviorMPAxle>();
-            if (bempaxle == null || !(bempaxle.Block as BlockMPBase).HasMechPowerConnectorAt(world, pos, targetFace, this))
+            BlockFacing targetFace = null;
+            bool axleFoundButUnsupported = false;
+            // Try put the gear on the adjacent axle thats being looked at by prepending it
+            foreach (BlockFacing face in BlockFacing.ALLFACES.Prepend(blockSel.Face.Opposite))
             {
-                failureCode = "requiresaxle";
+                BlockPos pos = blockSel.Position.AddCopy(face);
+                BlockEntity be = world.BlockAccessor.GetBlockEntity(pos);
+                IMechanicalPowerBlock neighbour = be?.Block as IMechanicalPowerBlock;
+
+                BEBehaviorMPAxle bempaxle = be?.GetBehavior<BEBehaviorMPAxle>();
+                if (bempaxle == null || !(bempaxle.Block as BlockMPBase).HasMechPowerConnectorAt(world, pos, face.Opposite, this))
+                    continue;
+
+                // axlemusthavesupport condition, but pretty sure this is impossible right now
+                if (!BEBehaviorMPAxle.IsAttachedToBlock(world.BlockAccessor, neighbour as Block, pos))
+                {
+                    axleFoundButUnsupported = true;
+                    continue;
+                }
+
+                targetFace = face;
+                break;
+            }
+
+            if (targetFace == null)
+            {
+                if (axleFoundButUnsupported)
+                    failureCode = "axlemusthavesupport";
+                else
+                    failureCode = "requiresaxle";
+
                 return false;
             }
-            if (bempaxle != null && !BEBehaviorMPAxle.IsAttachedToBlock(world.BlockAccessor, neighbour as Block, pos))
-            {
-                failureCode = "axlemusthavesupport";
-                return false;
-            }
 
-            BlockSpurGear toPlaceBlock = world.GetBlock(CodeWithVariant("orientation", targetFace.Code[0] + "")) as BlockSpurGear;
+            Block toPlaceBlock = getGearBlock(world, targetFace);
             world.BlockAccessor.SetBlock(toPlaceBlock.BlockId, blockSel.Position);
 
-            var selfBeh = GetBEBehavior<BEBehaviorMPBase>(blockSel.Position);
-            var exits = selfBeh.GetMechPowerExits(new MechPowerPath() { OutFacing = targetFace });
+            BEBehaviorMPBase beSpurGear = GetBEBehavior<BEBehaviorMPBase>(blockSel.Position);
+            if (beSpurGear == null)
+                return true; // From BlockAngledGears: "fixes CTD when trying to place above block limit without an error message, to match other blocks"
+            MechPowerPath[] mechPowerExits = beSpurGear.GetMechPowerExits(new MechPowerPath() { OutFacing = targetFace });
 
-            List<BlockFacing> possiblyNetworklessCandidates = new List<BlockFacing>();
-            foreach (var exit in exits)
+            foreach (MechPowerPath mechPowerExit in mechPowerExits)
             {
-                var npos = blockSel.Position.AddCopy(exit.OutFacing);
-                var neibBlock = world.BlockAccessor.GetBlock(npos) as IMechanicalPowerBlock;
-                neibBlock?.DidConnectAt(world, blockSel.Position, exit.OutFacing.Opposite);
-                if (neibBlock != null)
+                BlockPos neighbourPos = blockSel.Position.AddCopy(mechPowerExit.OutFacing);
+                var neighbourBlock = world.BlockAccessor.GetBlock(neighbourPos) as IMechanicalPowerBlock;
+                neighbourBlock?.DidConnectAt(world, neighbourPos, mechPowerExit.OutFacing.Opposite);
+                if (neighbourBlock != null)
                 {
-                    if (!selfBeh.tryConnect(exit.OutFacing))
-                    {
-                        // We might be trying to connect to a side which is has no power node, which means it has no network.
-                        // We first need to connect to a network, before we can connect our neighbours, so lets try to connect these again
-                        possiblyNetworklessCandidates.Add(exit.OutFacing);
-                    }
+                    beSpurGear.tryConnect(mechPowerExit.OutFacing);
                 }
             }
-
-            // Looks like we managed to connect
-            if (selfBeh.Network != null)
-            {
-                foreach (var face in possiblyNetworklessCandidates) selfBeh.tryConnect(face);
-            }
-
 
             return true;
         }
 
-
         public override void OnNeighbourBlockChange(IWorldAccessor world, BlockPos pos, BlockPos neibpos)
         {
-            var nblock = world.BlockAccessor.GetBlock(pos.AddCopy(Orientation));
-            if (!(nblock is BlockMPBase) || nblock.SideIsSolid(world.BlockAccessor, pos, Orientation.Opposite.Index))
+            bool isSupported = false;
+            foreach (BlockFacing facing in Facings)
+            {
+                Block neighbourBlock = world.BlockAccessor.GetBlock(pos.AddCopy(facing));
+                if (neighbourBlock is BlockMPBase && !neighbourBlock.SideIsSolid(world.BlockAccessor, pos, facing.Opposite.Index))
+                {
+                    isSupported = true;
+                    break;
+                }
+            }
+
+            if (!isSupported)
             {
                 world.BlockAccessor.BreakBlock(pos, null);
                 return;
@@ -98,7 +263,44 @@ namespace Vintagestory.GameContent.Mechanics
             base.OnNeighbourBlockChange(world, pos, neibpos);
         }
 
+        public override AssetLocation GetRotatedBlockCode(int angle)
+        {
+            var last = LastCodePart();
+            string first;
+            string second = string.Empty;
+            if (last.Length > 1)
+            {
+                first = last.Substring(0, 1);
+                second = last.Substring(1);
+            }
+            else
+            {
+                first = last;
+            }
 
-        public override void DidConnectAt(IWorldAccessor world, BlockPos pos, BlockFacing face) { }
+            if (first != "u" && first != "d")
+            {
+                var beforeFacing = BlockFacing.FromFirstLetter(first);
+                int rotatedIndex = GameMath.Mod(beforeFacing.HorizontalAngleIndex - angle / 90, 4);
+                var nowFacing = BlockFacing.HORIZONTALS_ANGLEORDER[rotatedIndex];
+                first = nowFacing.Code.Substring(0, 1);
+            }
+
+            if (second != string.Empty && second != "u" && second != "d")
+            {
+                var beforeFacing = BlockFacing.FromFirstLetter(second);
+                int rotatedIndex = GameMath.Mod(beforeFacing.HorizontalAngleIndex - angle / 90, 4);
+                var nowFacing = BlockFacing.HORIZONTALS_ANGLEORDER[rotatedIndex];
+                second = nowFacing.Code.Substring(0, 1);
+            }
+            var newOrientation = CodeWithParts(first+second);
+
+            if (api.World.GetBlock(newOrientation) is not BlockSpurGear)
+            {
+                return CodeWithParts(second+first);
+            }
+
+            return newOrientation;
+        }
     }
 }

--- a/Systems/MechanicalPower/BlockEntityBehavior/BEBehaviorMPSpurGear.cs
+++ b/Systems/MechanicalPower/BlockEntityBehavior/BEBehaviorMPSpurGear.cs
@@ -40,7 +40,6 @@ namespace Vintagestory.GameContent.Mechanics
             string orientations = (Block as BlockSpurGear).Orientation;
 
             // This applies only when the BE is being updated when the gear orientations change
-
             if (this.turnDir1 != null)
             {
                 if (propagationDir == turnDir1) propagationDir = turnDir2.Opposite;

--- a/Systems/MechanicalPower/BlockEntityBehavior/BEBehaviorMPSpurGear.cs
+++ b/Systems/MechanicalPower/BlockEntityBehavior/BEBehaviorMPSpurGear.cs
@@ -1,6 +1,9 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Vintagestory.API.Common;
 using Vintagestory.API.Config;
+using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Util;
 
@@ -13,26 +16,63 @@ namespace Vintagestory.GameContent.Mechanics
     {
         public BlockFacing Facing => BlockFacing.FromFirstLetter(Block.Variant["orientation"]);
 
-        public BlockFacing axis1 = null;
-        public BlockFacing axis2 = null;
         public BlockFacing turnDir1 = null;
         public BlockFacing turnDir2 = null;
+        public BlockFacing gearOneFacing = null;
+        public BlockFacing gearTwoFacing = null;
+
+        float angleOffset;
+
+        static readonly Dictionary<string, (BlockFacing turnDir1, BlockFacing turnDir2, BlockFacing gearOne, BlockFacing gearTwo)> pairOrientationTable = new()
+        {
+            ["en"] = (BlockFacing.EAST,  BlockFacing.NORTH, BlockFacing.NORTH, BlockFacing.EAST),
+            ["nw"] = (BlockFacing.NORTH, BlockFacing.WEST,  BlockFacing.WEST,  BlockFacing.NORTH),
+            ["ws"] = (BlockFacing.WEST,  BlockFacing.SOUTH, BlockFacing.SOUTH, BlockFacing.WEST),
+            ["es"] = (BlockFacing.EAST,  BlockFacing.SOUTH, BlockFacing.EAST,  BlockFacing.SOUTH),
+            ["nu"] = (BlockFacing.NORTH, BlockFacing.UP,    BlockFacing.UP,    BlockFacing.NORTH),
+            ["eu"] = (BlockFacing.EAST,  BlockFacing.UP,    BlockFacing.UP,    BlockFacing.EAST),
+            ["su"] = (BlockFacing.SOUTH, BlockFacing.UP,    BlockFacing.UP,    BlockFacing.SOUTH),
+            ["wu"] = (BlockFacing.WEST,  BlockFacing.UP,    BlockFacing.UP,    BlockFacing.WEST),
+            ["nd"] = (BlockFacing.NORTH, BlockFacing.DOWN,  BlockFacing.NORTH, BlockFacing.DOWN),
+            ["ed"] = (BlockFacing.EAST,  BlockFacing.DOWN,  BlockFacing.DOWN,  BlockFacing.EAST),
+            ["sd"] = (BlockFacing.SOUTH, BlockFacing.DOWN,  BlockFacing.SOUTH, BlockFacing.DOWN),
+            ["wd"] = (BlockFacing.WEST,  BlockFacing.DOWN,  BlockFacing.WEST,  BlockFacing.DOWN),
+        };
 
         public override float AngleRad
         {
             get
             {
                 if (turnDir1 == null)
-                    return base.AngleRad;
+                    return base.AngleRad + angleOffset;
 
-                float angle = base.AngleRad;
-                bool flip = propagationDir == BlockFacing.DOWN || propagationDir == BlockFacing.WEST;
-                return flip ? GameMath.TWOPI - angle : angle;
+                if (network != null)
+                    lastKnownAngleRad = network.AngleRad * GearedRatio % GameMath.TWOPI;
+
+                return lastKnownAngleRad;
             }
         }
 
         public BEBehaviorMPSpurGear(BlockEntity blockentity) : base(blockentity)
         {
+        }
+
+        public override void Initialize(ICoreAPI api, JsonObject properties)
+        {
+            base.Initialize(api, properties);
+
+            // Each spur gear is rotated a quarter of a tooth,
+            // so when two gears meet their teeth are offset by half a tooth, resulting in their teeth interlacing
+            float quarter16ToothRotationDeg = -5.625f;
+            Vec3f gearToothRotation = Facing.Normalf * (quarter16ToothRotationDeg * GameMath.DEG2RAD);
+            Vec3f rotationAxis = Facing.Axis switch
+            {
+                EnumAxis.X => new Vec3f(-1f, 0f, 0f),
+                EnumAxis.Y => new Vec3f(0f, 1f, 0f),
+                _ => new Vec3f(0f, 0f, -1f),
+            };
+
+            angleOffset = gearToothRotation.Dot(rotationAxis);
         }
 
         public override void SetOrientations()
@@ -50,125 +90,28 @@ namespace Vintagestory.GameContent.Mechanics
                 this.turnDir2 = null;
             }
 
-            axis1 = null;
-            axis2 = null;
+            gearOneFacing = null;
+            gearTwoFacing = null;
 
-            switch (orientations)
+            bool isGearPair = pairOrientationTable.TryGetValue(orientations, out var pair);
+            turnDir1 = pair.turnDir1;
+            turnDir2 = pair.turnDir2;
+            gearOneFacing = pair.gearOne;
+            gearTwoFacing = pair.gearTwo;
+
+            if (isGearPair)
             {
-                // Solo gears and gears with axles
-                case "n":
-                case "ns":
-                case "s":
-                case "sn":
-                    AxisSign = new int[3] { 0, 0, -1 };
-                    break;
-
-                case "e":
-                case "ew":
-                case "w":
-                case "we":
-                    AxisSign = new int[3] { -1, 0, 0 };
-                    break;
-
-                case "u":
-                case "ud":
-                case "d":
-                case "du":
-                    AxisSign = new int[3] { 0, 1, 0 };
-                    break;
-
-                // Two gears
-                case "es":
-                    AxisSign = new int[6] { 1, 0, 0, 0, 0, -1 };
-                    axis1 = BlockFacing.EAST;
-                    this.turnDir1 = BlockFacing.EAST;
-                    this.turnDir2 = BlockFacing.SOUTH;
-                    break;
-
-                case "ws":
-                    AxisSign = new int[6] { 0, 0, -1, -1, 0, 0 };
-                    axis1 = BlockFacing.WEST;
-                    this.turnDir1 = BlockFacing.WEST;
-                    this.turnDir2 = BlockFacing.SOUTH;
-                    break;
-
-                case "nw":
-                    AxisSign = new int[6] { 1, 0, 0, 0, 0, -1 };
-                    axis2 = BlockFacing.EAST;
-                    this.turnDir1 = BlockFacing.NORTH;
-                    this.turnDir2 = BlockFacing.WEST;
-                    break;
-
-                case "sd":
-                    AxisSign = new int[6] { 0, 0, -1, 0, -1, 0 };
-                    this.turnDir1 = BlockFacing.SOUTH;
-                    this.turnDir2 = BlockFacing.DOWN;
-                    break;
-
-                case "ed":
-                    AxisSign = new int[6] { 0, 1, 0, 1, 0, 0 };
-                    axis1 = BlockFacing.EAST;
-                    axis2 = BlockFacing.DOWN;
-                    this.turnDir1 = BlockFacing.EAST;
-                    this.turnDir2 = BlockFacing.DOWN;
-                    break;
-
-                case "wd":
-                    AxisSign = new int[6] { -1, 0, 0, 0, 1, 0 };
-                    axis1 = BlockFacing.DOWN;
-                    axis2 = BlockFacing.WEST;
-                    this.turnDir1 = BlockFacing.WEST;
-                    this.turnDir2 = BlockFacing.DOWN;
-                    break;
-
-                case "nd":
-                    AxisSign = new int[6] { 0, 0, -1, 0, 1, 0 };
-                    axis1 = BlockFacing.DOWN;
-                    this.turnDir1 = BlockFacing.NORTH;
-                    this.turnDir2 = BlockFacing.DOWN;
-                    break;
-
-                case "nu":
-                    AxisSign = new int[6] { 0, -1, 0, 0, 0, -1 };
-                    axis1 = BlockFacing.UP;
-                    this.turnDir1 = BlockFacing.NORTH;
-                    this.turnDir2 = BlockFacing.UP;
-                    break;
-
-                case "eu":
-                    AxisSign = new int[6] { 0, -1, 0, 1, 0, 0 };
-                    axis1 = BlockFacing.UP;
-                    axis2 = BlockFacing.EAST;
-                    this.turnDir1 = BlockFacing.EAST;
-                    this.turnDir2 = BlockFacing.UP;
-                    break;
-
-                case "su":
-                    AxisSign = new int[6] { 0, 1, 0, 0, 0, -1 };
-                    axis1 = BlockFacing.DOWN;
-                    this.turnDir1 = BlockFacing.SOUTH;
-                    this.turnDir2 = BlockFacing.UP;
-                    break;
-
-                case "wu":
-                    AxisSign = new int[6] { 0, -1, 0, -1, 0, 0 };
-                    axis1 = BlockFacing.WEST;
-                    axis2 = BlockFacing.UP;
-                    this.turnDir1 = BlockFacing.WEST;
-                    this.turnDir2 = BlockFacing.UP;
-                    break;
-
-                case "en":
-                    AxisSign = new int[6] { 0, 0, 1, 1, 0, 0 };
-                    axis1 = BlockFacing.SOUTH;
-                    axis2 = BlockFacing.NORTH;
-                    this.turnDir1 = BlockFacing.EAST;
-                    this.turnDir2 = BlockFacing.NORTH;
-                    break;
-
-                default:
-                    AxisSign = new int[3] { 0, 0, -1 };
-                    break;
+                AxisSign = new int[6]; // Defer to SpurGearPairRenderer to spin each gear individually
+            }
+            else
+            {
+                // Solo gears and gears with axles spin around their mounting axle's axis
+                AxisSign = Facing.Axis switch
+                {
+                    EnumAxis.X => [-1, 0, 0],
+                    EnumAxis.Y => [0, 1, 0],
+                    _ => [0, 0, -1],
+                };
             }
         }
 
@@ -213,6 +156,30 @@ namespace Vintagestory.GameContent.Mechanics
 
             return propagationDir == test;
         }
+
+        public BlockFacing GearTurnDir(BlockFacing gearFacing)
+        {
+            if (propagationDir.Axis == gearFacing.Axis)
+                return propagationDir;
+
+            return GetPropagationDirectionInput();
+        }
+
+        public override BlockFacing GetPropagatingTurnDir(BlockFacing toFacing)
+        {
+            BlockSpurGear blockSpurGear = Block as BlockSpurGear;
+            BlockFacing meshedGear;
+            if (Api == null)
+                meshedGear = null;
+            else
+                meshedGear = blockSpurGear.GetInterlacingGearsFace(Api.World.BlockAccessor.GetBlock(Position.AddCopy(toFacing)), toFacing);
+
+            if (meshedGear != null)
+                return GearTurnDir(meshedGear).Opposite; // Side by side. Turn the interlaced spur the opposite rotation
+
+            return base.GetPropagatingTurnDir(toFacing);
+        }
+
         public override float GetResistance()
         {
             return 0.0005f;
@@ -221,54 +188,93 @@ namespace Vintagestory.GameContent.Mechanics
         public override MechPowerPath[] GetMechPowerExits(MechPowerPath fromExitTurnDir)
         {
             // This method could be called from another (earlier in the loading chunk) block's Initialise() method, i.e. before this itself is initialised.
-            if (this.AxisSign == null) this.SetOrientations();
+            if (this.AxisSign == null)
+                this.SetOrientations();
 
             BlockSpurGear blockSpurGear = Block as BlockSpurGear;
+            List<MechPowerPath> paths = [];
 
             if (blockSpurGear.HasExtraGear())
             {
-                bool invert = fromExitTurnDir.invert;
                 BlockFacing[] connectors = blockSpurGear.Facings;
                 BlockFacing inputSide = fromExitTurnDir.OutFacing;
-                if (!connectors.Contains(inputSide))
+                bool invert = fromExitTurnDir.invert;
+
+                if (connectors.Contains(inputSide) || connectors.Contains(inputSide.Opposite)) // Power came in through an axle
                 {
-                    inputSide = inputSide.Opposite;
-                    invert = !invert;
+                    if (!connectors.Contains(inputSide))
+                    {
+                        inputSide = inputSide.Opposite;
+                        invert = !invert;
+                    }
+
+                    foreach (BlockFacing pathFacing in connectors)
+                    {
+                        if (GetInterlacingGearFace(pathFacing) != null)
+                            continue;
+
+                        paths.Add(new MechPowerPath(pathFacing, this.GearedRatio, null, pathFacing == inputSide ? invert : !invert));
+                    }
+                }
+                else // Power came in through an interlaced gear
+                {
+                    foreach (BlockFacing pathFacing in connectors)
+                    {
+                        if (GetInterlacingGearFace(pathFacing) != null)
+                            continue;
+
+                        BlockFacing gearTurnDir = GearTurnDir(pathFacing);
+                        paths.Add(fromExitTurnDir.PropagatedClone(pathFacing, gearTurnDir != pathFacing, gearTurnDir));
+                    }
+                }
+            }
+            else
+            {
+                MechPowerPath mechPower;
+                MechPowerPath oppositeMechPower = null;
+                if (blockSpurGear.HasInsideAxle()) // Power the mounting and opposite axle
+                {
+                    if (fromExitTurnDir.OutFacing.Opposite == Facing)
+                        mechPower = fromExitTurnDir;
+                    else
+                        mechPower = fromExitTurnDir.PropagatedClone(Facing, fromExitTurnDir.invert, propagationDir);
+                    oppositeMechPower = new MechPowerPath(mechPower.OutFacing.Opposite, mechPower.gearingRatio, Position, !mechPower.invert);
+                }
+                else // Just power the mounting axle
+                {
+                    if (fromExitTurnDir.OutFacing == Facing)
+                        mechPower = fromExitTurnDir;
+                    else if (fromExitTurnDir.OutFacing.Axis != Facing.Axis)
+                        mechPower = fromExitTurnDir.PropagatedClone(Facing, fromExitTurnDir.invert, propagationDir);
+                    else
+                        mechPower = new MechPowerPath(Facing, fromExitTurnDir.gearingRatio, Position, !fromExitTurnDir.invert);
                 }
 
-                MechPowerPath[] paths = new MechPowerPath[connectors.Length];
-                for (int i = 0; i < paths.Length; i++)
-                {
-                    BlockFacing pathFacing = connectors[i];
-
-                    // An spur gear's output side rotates in the opposite sense from the input side
-                    paths[i] = new MechPowerPath(pathFacing, this.GearedRatio, null, pathFacing == inputSide ? invert : !invert);
-                }
-                return paths;
+                paths.Add(mechPower);
+                if (oppositeMechPower != null)
+                    paths.Add(oppositeMechPower);
             }
 
-            BlockFacing facing = Facing;
-
-            if (blockSpurGear.HasInsideAxle()) // Power the mounting and opposite axle
+            // Spin the adjaceent+interlaced spur gears in the opposite sense
+            foreach (BlockFacing face in BlockFacing.ALLFACES)
             {
-                MechPowerPath axial;
-                if (fromExitTurnDir.OutFacing.Opposite == facing)
-                    axial = fromExitTurnDir;
-                else
-                    axial = fromExitTurnDir.PropagatedClone(facing, fromExitTurnDir.invert, propagationDir);
-
-                return [axial, new MechPowerPath(axial.OutFacing.Opposite, axial.gearingRatio, Position, !axial.invert)];
+                BlockFacing meshedGear = GetInterlacingGearFace(face);
+                if (meshedGear != null)
+                    paths.Add(fromExitTurnDir.PropagatedClone(face, !fromExitTurnDir.invert, GearTurnDir(meshedGear).Opposite));
             }
-            else // Just power the mounting axle
-            {
-                MechPowerPath toMount;
-                if (fromExitTurnDir.OutFacing == facing)
-                    toMount = fromExitTurnDir;
-                else
-                    toMount = new MechPowerPath(facing, fromExitTurnDir.gearingRatio, Position, !fromExitTurnDir.invert);
 
-                return [toMount];
-            }
+            return [.. paths];
+        }
+
+        /// <summary>
+        /// Null if not interlacing
+        /// </summary>
+        private BlockFacing GetInterlacingGearFace(BlockFacing face)
+        {
+            if (Api == null)
+                return null;
+
+            return (Block as BlockSpurGear).GetInterlacingGearsFace(Api.World.BlockAccessor.GetBlock(Pos.AddCopy(face)), face);
         }
 
         public override void GetBlockInfo(IPlayer forPlayer, StringBuilder sb)
@@ -276,9 +282,11 @@ namespace Vintagestory.GameContent.Mechanics
             base.GetBlockInfo(forPlayer, sb);
             if (Api.World.EntityDebugMode)
             {
-                string orientations = Block.Variant["orientation"];
-                bool rev = propagationDir == axis1 || propagationDir == axis2;
-                sb.AppendLine(string.Format(Lang.Get("Orientation: {0} {1}", orientations, rev ? "-" : "")));
+                sb.AppendLine(string.Format(Lang.Get("Orientation: {0}", Block.Variant["orientation"])));
+                if (gearOneFacing != null)
+                {
+                    sb.AppendLine(string.Format("Gear one: {0} turning {1}, gear two: {2} turning {3}", gearOneFacing, GearTurnDir(gearOneFacing), gearTwoFacing, GearTurnDir(gearTwoFacing)));
+                }
             }
         }
     }

--- a/Systems/MechanicalPower/BlockEntityBehavior/BEBehaviorMPSpurGear.cs
+++ b/Systems/MechanicalPower/BlockEntityBehavior/BEBehaviorMPSpurGear.cs
@@ -1,126 +1,286 @@
-using System.Collections.Generic;
-using System.Diagnostics;
+using System.Text;
 using Vintagestory.API.Common;
-using Vintagestory.API.Datastructures;
+using Vintagestory.API.Config;
 using Vintagestory.API.MathTools;
+using Vintagestory.API.Util;
 
 #nullable disable
 
 namespace Vintagestory.GameContent.Mechanics
 {
+    // Largely similar to BEBehaviorMPAngledGears
     public class BEBehaviorMPSpurGear : BEBehaviorMPBase
     {
         public BlockFacing Facing => BlockFacing.FromFirstLetter(Block.Variant["orientation"]);
 
-        float angleOffset;
-        public override float AngleRad => base.AngleRad + angleOffset;
+        public BlockFacing axis1 = null;
+        public BlockFacing axis2 = null;
+        public BlockFacing turnDir1 = null;
+        public BlockFacing turnDir2 = null;
+
+        public override float AngleRad
+        {
+            get
+            {
+                if (turnDir1 == null)
+                    return base.AngleRad;
+
+                float angle = base.AngleRad;
+                bool flip = propagationDir == BlockFacing.DOWN || propagationDir == BlockFacing.WEST;
+                return flip ? GameMath.TWOPI - angle : angle;
+            }
+        }
 
         public BEBehaviorMPSpurGear(BlockEntity blockentity) : base(blockentity)
         {
         }
 
-        public override void Initialize(ICoreAPI api, JsonObject properties)
+        public override void SetOrientations()
         {
-            base.Initialize(api, properties);
+            string orientations = (Block as BlockSpurGear).Orientation;
 
-            // Makes it correct in most cases. Whoever reads this - feel free to make it perfect
-            angleOffset = 11.25f * GameMath.DEG2RAD * (Pos.X % 32 + Pos.Y % 32 + Pos.Z % 32);
+            // This applies only when the BE is being updated when the gear orientations change
 
-            AxisSign = new int[3] { 0, 0, 0 };
-            switch (Facing.Index)
+            if (this.turnDir1 != null)
             {
-                case 0: // N
-                    AxisSign[2] = -1;
+                if (propagationDir == turnDir1) propagationDir = turnDir2.Opposite;
+                else if (propagationDir == turnDir2) propagationDir = turnDir1.Opposite;
+                else if (propagationDir == turnDir2.Opposite) propagationDir = turnDir1;
+                else if (propagationDir == turnDir1.Opposite) propagationDir = turnDir2;
+                this.turnDir1 = null;
+                this.turnDir2 = null;
+            }
+
+            axis1 = null;
+            axis2 = null;
+
+            switch (orientations)
+            {
+                // Solo gears and gears with axles
+                case "n":
+                case "ns":
+                case "s":
+                case "sn":
+                    AxisSign = new int[3] { 0, 0, -1 };
                     break;
-                case 1: // E
-                    AxisSign[0] = -1;
+
+                case "e":
+                case "ew":
+                case "w":
+                case "we":
+                    AxisSign = new int[3] { -1, 0, 0 };
                     break;
-                case 2: // S
-                    AxisSign[2] = -1;
+
+                case "u":
+                case "ud":
+                case "d":
+                case "du":
+                    AxisSign = new int[3] { 0, 1, 0 };
                     break;
-                case 3: // W
-                    AxisSign[0] = -1;
+
+                // Two gears
+                case "es":
+                    AxisSign = new int[6] { 1, 0, 0, 0, 0, -1 };
+                    axis1 = BlockFacing.EAST;
+                    this.turnDir1 = BlockFacing.EAST;
+                    this.turnDir2 = BlockFacing.SOUTH;
                     break;
-                case 4: // U
-                    AxisSign[1] = 1;
+
+                case "ws":
+                    AxisSign = new int[6] { 0, 0, -1, -1, 0, 0 };
+                    axis1 = BlockFacing.WEST;
+                    this.turnDir1 = BlockFacing.WEST;
+                    this.turnDir2 = BlockFacing.SOUTH;
                     break;
-                case 5: // D
-                    AxisSign[1] = 1;
+
+                case "nw":
+                    AxisSign = new int[6] { 1, 0, 0, 0, 0, -1 };
+                    axis2 = BlockFacing.EAST;
+                    this.turnDir1 = BlockFacing.NORTH;
+                    this.turnDir2 = BlockFacing.WEST;
+                    break;
+
+                case "sd":
+                    AxisSign = new int[6] { 0, 0, -1, 0, -1, 0 };
+                    this.turnDir1 = BlockFacing.SOUTH;
+                    this.turnDir2 = BlockFacing.DOWN;
+                    break;
+
+                case "ed":
+                    AxisSign = new int[6] { 0, 1, 0, 1, 0, 0 };
+                    axis1 = BlockFacing.EAST;
+                    axis2 = BlockFacing.DOWN;
+                    this.turnDir1 = BlockFacing.EAST;
+                    this.turnDir2 = BlockFacing.DOWN;
+                    break;
+
+                case "wd":
+                    AxisSign = new int[6] { -1, 0, 0, 0, 1, 0 };
+                    axis1 = BlockFacing.DOWN;
+                    axis2 = BlockFacing.WEST;
+                    this.turnDir1 = BlockFacing.WEST;
+                    this.turnDir2 = BlockFacing.DOWN;
+                    break;
+
+                case "nd":
+                    AxisSign = new int[6] { 0, 0, -1, 0, 1, 0 };
+                    axis1 = BlockFacing.DOWN;
+                    this.turnDir1 = BlockFacing.NORTH;
+                    this.turnDir2 = BlockFacing.DOWN;
+                    break;
+
+                case "nu":
+                    AxisSign = new int[6] { 0, -1, 0, 0, 0, -1 };
+                    axis1 = BlockFacing.UP;
+                    this.turnDir1 = BlockFacing.NORTH;
+                    this.turnDir2 = BlockFacing.UP;
+                    break;
+
+                case "eu":
+                    AxisSign = new int[6] { 0, -1, 0, 1, 0, 0 };
+                    axis1 = BlockFacing.UP;
+                    axis2 = BlockFacing.EAST;
+                    this.turnDir1 = BlockFacing.EAST;
+                    this.turnDir2 = BlockFacing.UP;
+                    break;
+
+                case "su":
+                    AxisSign = new int[6] { 0, 1, 0, 0, 0, -1 };
+                    axis1 = BlockFacing.DOWN;
+                    this.turnDir1 = BlockFacing.SOUTH;
+                    this.turnDir2 = BlockFacing.UP;
+                    break;
+
+                case "wu":
+                    AxisSign = new int[6] { 0, -1, 0, -1, 0, 0 };
+                    axis1 = BlockFacing.WEST;
+                    axis2 = BlockFacing.UP;
+                    this.turnDir1 = BlockFacing.WEST;
+                    this.turnDir2 = BlockFacing.UP;
+                    break;
+
+                case "en":
+                    AxisSign = new int[6] { 0, 0, 1, 1, 0, 0 };
+                    axis1 = BlockFacing.SOUTH;
+                    axis2 = BlockFacing.NORTH;
+                    this.turnDir1 = BlockFacing.EAST;
+                    this.turnDir2 = BlockFacing.NORTH;
+                    break;
+
+                default:
+                    AxisSign = new int[3] { 0, 0, -1 };
                     break;
             }
         }
 
-        public override MechPowerPath[] GetMechPowerExits(MechPowerPath entryDir)
+        public override void SetPropagationDirection(MechPowerPath path)
         {
-            BlockFacing left, right, above, below;
-
-            // Get the directions of potential neighbour connectable spur gears from this block's Facing
-            if (Facing.IsHorizontal)
+            BlockFacing turnDir = path.NetworkDir();
+            if (this.turnDir1 != null)
             {
-                left = entryDir.OutFacing.Opposite == Facing ? entryDir.OutFacing.GetCW() : Facing.GetCW();
-                right = entryDir.OutFacing.Opposite == Facing ? entryDir.OutFacing.GetCCW() : Facing.GetCCW();
-                above = BlockFacing.UP;
-                below = BlockFacing.DOWN;
-            }
-            else
-            {
-                left = BlockFacing.WEST;
-                right = BlockFacing.EAST;
-                above = BlockFacing.NORTH;
-                below = BlockFacing.SOUTH;
+                // Rotate the input turn direction if it has an extra gear (this helps later blocks to know which sense the network is turning)
+                if (turnDir == turnDir1) turnDir = turnDir2.Opposite;
+                else if (turnDir == turnDir2) turnDir = turnDir1.Opposite;
+                else if (turnDir == turnDir2.Opposite) turnDir = turnDir1;
+                else if (turnDir == turnDir1.Opposite) turnDir = turnDir2;
+                path = new MechPowerPath(turnDir, path.gearingRatio, null, false);
             }
 
-            // Test whether we have any valid connectable spur gear neighbours (must be same orientation as this one, to connect) - if so, these are potential output paths
-            BlockPos tmpPos = Pos.Copy();
-            bool doLeft = Api.World.BlockAccessor.GetBlock(tmpPos.Add(left)) == Block;
-            bool doRight = Api.World.BlockAccessor.GetBlock(tmpPos.Set(Pos).Add(right)) == Block;
-            bool doAbove = Api.World.BlockAccessor.GetBlock(tmpPos.Set(Pos).Add(above)) == Block;
-            bool doBelow = Api.World.BlockAccessor.GetBlock(tmpPos.Set(Pos).Add(below)) == Block;
-
-            // Convenient way to quickly test all 4 conditions in a single == test below
-            SmallBoolArray bools = new SmallBoolArray();
-            bools[0] = doLeft;
-            bools[1] = doRight;
-            bools[2] = doAbove;
-            bools[3] = doBelow;
-
-            // The axial path - this is the axis of this spur gear
-            MechPowerPath axial = entryDir.OutFacing.Opposite == Facing ? entryDir : entryDir.PropagatedClone(Facing, entryDir.invert, propagationDir);
-
-            // Outputs for zero spur gear neighbours
-            if (bools == 0) return [axial];
-
-            // Outputs for exactly one spur gear neighbour
-            MechPowerPath side = null;
-            if (bools == 1) side = entryDir.PropagatedClone(left, !entryDir.invert, propagationDir.Opposite);
-            if (bools == 2) side = entryDir.PropagatedClone(right, !entryDir.invert, propagationDir.Opposite);
-            if (bools == 4) side = entryDir.PropagatedClone(above, !entryDir.invert, propagationDir.Opposite);
-            if (bools == 8) side = entryDir.PropagatedClone(below, !entryDir.invert, propagationDir.Opposite);
-            if (side != null)
-            {
-                return [axial, side];
-            }
-
-            // Outputs for more than one spur gear neighbour (uncommon, here we temporarily create a List<>)
-            List<MechPowerPath> paths = [axial];
-            if (doLeft) paths.Add(entryDir.PropagatedClone(left, !entryDir.invert, propagationDir.Opposite));
-            if (doRight) paths.Add(entryDir.PropagatedClone(right, !entryDir.invert, propagationDir.Opposite));
-            if (doAbove) paths.Add(entryDir.PropagatedClone(above, !entryDir.invert, propagationDir.Opposite));
-            if (doBelow) paths.Add(entryDir.PropagatedClone(below, !entryDir.invert, propagationDir.Opposite));
-
-            return paths.ToArray();
+            base.SetPropagationDirection(path);
         }
 
-
-        public override BlockFacing GetPropagatingTurnDir(BlockFacing toFacing)
+        public override BlockFacing GetPropagationDirectionInput()
         {
-            return propagationDir.Opposite;
+            if (this.turnDir1 != null)
+            {
+                if (propagationDir == turnDir1) return turnDir2.Opposite;
+                if (propagationDir == turnDir2) return turnDir1.Opposite;
+                if (propagationDir == turnDir1.Opposite) return turnDir2;
+                if (propagationDir == turnDir2.Opposite) return turnDir1;
+            }
+
+            return propagationDir;
         }
 
+        public override bool IsPropagationDirection(BlockPos fromPos, BlockFacing test)
+        {
+            if (this.turnDir1 != null)
+            {
+                if (propagationDir == turnDir1) return propagationDir == test || test == turnDir2.Opposite;
+                if (propagationDir == turnDir2) return propagationDir == test || test == turnDir1.Opposite;
+                if (propagationDir == turnDir1.Opposite) return propagationDir == test || test == turnDir2;
+                if (propagationDir == turnDir2.Opposite) return propagationDir == test || test == turnDir1;
+            }
 
+            return propagationDir == test;
+        }
         public override float GetResistance()
         {
             return 0.0005f;
+        }
+
+        public override MechPowerPath[] GetMechPowerExits(MechPowerPath fromExitTurnDir)
+        {
+            // This method could be called from another (earlier in the loading chunk) block's Initialise() method, i.e. before this itself is initialised.
+            if (this.AxisSign == null) this.SetOrientations();
+
+            BlockSpurGear blockSpurGear = Block as BlockSpurGear;
+
+            if (blockSpurGear.HasExtraGear())
+            {
+                bool invert = fromExitTurnDir.invert;
+                BlockFacing[] connectors = blockSpurGear.Facings;
+                BlockFacing inputSide = fromExitTurnDir.OutFacing;
+                if (!connectors.Contains(inputSide))
+                {
+                    inputSide = inputSide.Opposite;
+                    invert = !invert;
+                }
+
+                MechPowerPath[] paths = new MechPowerPath[connectors.Length];
+                for (int i = 0; i < paths.Length; i++)
+                {
+                    BlockFacing pathFacing = connectors[i];
+
+                    // An spur gear's output side rotates in the opposite sense from the input side
+                    paths[i] = new MechPowerPath(pathFacing, this.GearedRatio, null, pathFacing == inputSide ? invert : !invert);
+                }
+                return paths;
+            }
+
+            BlockFacing facing = Facing;
+
+            if (blockSpurGear.HasInsideAxle()) // Power the mounting and opposite axle
+            {
+                MechPowerPath axial;
+                if (fromExitTurnDir.OutFacing.Opposite == facing)
+                    axial = fromExitTurnDir;
+                else
+                    axial = fromExitTurnDir.PropagatedClone(facing, fromExitTurnDir.invert, propagationDir);
+
+                return [axial, new MechPowerPath(axial.OutFacing.Opposite, axial.gearingRatio, Position, !axial.invert)];
+            }
+            else // Just power the mounting axle
+            {
+                MechPowerPath toMount;
+                if (fromExitTurnDir.OutFacing == facing)
+                    toMount = fromExitTurnDir;
+                else
+                    toMount = new MechPowerPath(facing, fromExitTurnDir.gearingRatio, Position, !fromExitTurnDir.invert);
+
+                return [toMount];
+            }
+        }
+
+        public override void GetBlockInfo(IPlayer forPlayer, StringBuilder sb)
+        {
+            base.GetBlockInfo(forPlayer, sb);
+            if (Api.World.EntityDebugMode)
+            {
+                string orientations = Block.Variant["orientation"];
+                bool rev = propagationDir == axis1 || propagationDir == axis2;
+                sb.AppendLine(string.Format(Lang.Get("Orientation: {0} {1}", orientations, rev ? "-" : "")));
+            }
         }
     }
 }

--- a/Systems/MechanicalPower/Renderer/MechNetworkRenderer.cs
+++ b/Systems/MechanicalPower/Renderer/MechNetworkRenderer.cs
@@ -24,6 +24,7 @@ namespace Vintagestory.GameContent.Mechanics
         {
             { "generic", typeof(GenericMechBlockRenderer) },
             { "angledgears", typeof(AngledGearsBlockRenderer) },
+            { "spurgearpair", typeof(SpurGearPairRenderer) },
             { "angledgearcage", typeof(AngledCageGearRenderer) },
             { "transmission", typeof(TransmissionBlockRenderer) },
             { "clutch", typeof(ClutchBlockRenderer) },

--- a/Systems/MechanicalPower/Renderer/SpurGearPairRenderer.cs
+++ b/Systems/MechanicalPower/Renderer/SpurGearPairRenderer.cs
@@ -47,32 +47,36 @@ namespace Vintagestory.GameContent.Mechanics
         protected override void UpdateLightAndTransformMatrix(int index, Vec3f distToCamera, float rotationRad, IMechanicalPowerRenderable dev)
         {
             BEBehaviorMPSpurGear gear = dev as BEBehaviorMPSpurGear;
-            if (gear != null)
+
+            UpdateGearTransformMatrix(floatsSpurGearOne.Values, index, distToCamera, dev, gear, gear?.gearOneFacing, rotationRad);
+            UpdateGearTransformMatrix(floatsSpurGearTwo.Values, index, distToCamera, dev, gear, gear?.gearTwoFacing, rotationRad);
+        }
+
+        private void UpdateGearTransformMatrix(float[] values, int index, Vec3f distToCamera, IMechanicalPowerRenderable dev, BEBehaviorMPSpurGear gear, BlockFacing gearFacing, float rotationRad)
+        {
+            float rotX = 0f, rotY = 0f, rotZ = 0f;
+
+            if (gearFacing != null)
             {
-                BlockFacing inTurn = gear.GetPropagationDirection();
-                if (inTurn == gear.axis1 || inTurn == gear.axis2)
+                BlockFacing turnDir = gear.GearTurnDir(gearFacing);
+                if (turnDir == BlockFacing.DOWN || turnDir == BlockFacing.EAST || turnDir == BlockFacing.SOUTH)
                 {
                     rotationRad = -rotationRad;
                 }
+
+                // Each spur gear is rotated a quarter of a tooth,
+                // so when two gears meet their teeth are offset by half a tooth, resulting in their teeth interlacing
+                float gearToothPhase = -5.625f * GameMath.DEG2RAD * (gearFacing.Normali.X + gearFacing.Normali.Y + gearFacing.Normali.Z);
+
+                switch (gearFacing.Axis)
+                {
+                    case EnumAxis.X: rotX = -rotationRad + gearToothPhase; break;
+                    case EnumAxis.Y: rotY = rotationRad + gearToothPhase; break;
+                    case EnumAxis.Z: rotZ = -rotationRad + gearToothPhase; break;
+                }
             }
-            float rotX = rotationRad * dev.AxisSign[0];
-            float rotY = rotationRad * dev.AxisSign[1];
-            float rotZ = rotationRad * dev.AxisSign[2];
-            UpdateLightAndTransformMatrix(floatsSpurGearOne.Values, index, distToCamera, dev.LightRgba, rotX, rotY, rotZ);
 
-            if (dev.AxisSign.Length < 4)
-            {
-                return;
-            }
-
-            // Each gear tooth takes 22.5 degrees of rotation to reach the initial position of the tooth in front,
-            // so we mesh the two gear's teeth together by offsetting the 2nd gear's rotation by half of that
-            rotationRad += 11.25f * GameMath.DEG2RAD;
-
-            rotX = rotationRad * dev.AxisSign[3];
-            rotY = rotationRad * dev.AxisSign[4];
-            rotZ = rotationRad * dev.AxisSign[5];
-            UpdateLightAndTransformMatrix(floatsSpurGearTwo.Values, index, distToCamera, dev.LightRgba, rotX, rotY, rotZ);
+            UpdateLightAndTransformMatrix(values, index, distToCamera, dev.LightRgba, rotX, rotY, rotZ);
         }
 
         public override void OnRenderFrame(float deltaTime, IShaderProgram prog)

--- a/Systems/MechanicalPower/Renderer/SpurGearPairRenderer.cs
+++ b/Systems/MechanicalPower/Renderer/SpurGearPairRenderer.cs
@@ -1,0 +1,106 @@
+using Vintagestory.API.Client;
+using Vintagestory.API.Common;
+using Vintagestory.API.MathTools;
+
+#nullable disable
+
+namespace Vintagestory.GameContent.Mechanics
+{
+    // Based off of AngledGearBlockRenderer
+    public class SpurGearPairRenderer : MechBlockRenderer
+    {
+        MeshRef spurGearOne;
+        MeshRef spurGearTwo;
+
+        CustomMeshDataPartFloat floatsSpurGearOne;
+        CustomMeshDataPartFloat floatsSpurGearTwo;
+
+        static readonly Vec3f center = new(0.5f, 0.5f, 0.5f);
+
+        public SpurGearPairRenderer(ICoreClientAPI capi, MechanicalPowerMod mechanicalPowerMod, Block textureSourceBlock, CompositeShape shapeLoc) : base(capi, mechanicalPowerMod)
+        {
+            Vec3f rot = new Vec3f(shapeLoc.rotateX, shapeLoc.rotateY, shapeLoc.rotateZ);
+            Shape shape = Shape.TryGet(capi, "shapes/block/wood/mechanics/spurgear16.json");
+
+            // Gear two is perpendicular to gear one
+            capi.Tesselator.TesselateShape(textureSourceBlock, shape, out MeshData spurGearOneMesh, rot);
+            capi.Tesselator.TesselateShape(textureSourceBlock, shape, out MeshData spurGearTwoMesh, new Vec3f(0, 270, 0));
+
+            _ = spurGearTwoMesh.Rotate(center, rot.X * GameMath.DEG2RAD, rot.Y * GameMath.DEG2RAD, rot.Z * GameMath.DEG2RAD);
+
+            // 16 floats matrix, 4 floats light rgbs
+            spurGearOneMesh.CustomFloats = floatsSpurGearOne = new CustomMeshDataPartFloat((16 + 4) * 10100)
+            {
+                Instanced = true,
+                InterleaveOffsets = [0, 16, 32, 48, 64],
+                InterleaveSizes = [4, 4, 4, 4, 4],
+                InterleaveStride = 16 + (4 * 16),
+                StaticDraw = false,
+            };
+            spurGearOneMesh.CustomFloats.SetAllocationSize((16 + 4) * 10100);
+            spurGearTwoMesh.CustomFloats = floatsSpurGearTwo = floatsSpurGearOne.Clone();
+
+            this.spurGearOne = capi.Render.UploadMesh(spurGearOneMesh);
+            this.spurGearTwo = capi.Render.UploadMesh(spurGearTwoMesh);
+        }
+
+        protected override void UpdateLightAndTransformMatrix(int index, Vec3f distToCamera, float rotationRad, IMechanicalPowerRenderable dev)
+        {
+            BEBehaviorMPSpurGear gear = dev as BEBehaviorMPSpurGear;
+            if (gear != null)
+            {
+                BlockFacing inTurn = gear.GetPropagationDirection();
+                if (inTurn == gear.axis1 || inTurn == gear.axis2)
+                {
+                    rotationRad = -rotationRad;
+                }
+            }
+            float rotX = rotationRad * dev.AxisSign[0];
+            float rotY = rotationRad * dev.AxisSign[1];
+            float rotZ = rotationRad * dev.AxisSign[2];
+            UpdateLightAndTransformMatrix(floatsSpurGearOne.Values, index, distToCamera, dev.LightRgba, rotX, rotY, rotZ);
+
+            if (dev.AxisSign.Length < 4)
+            {
+                return;
+            }
+
+            // Each gear tooth takes 22.5 degrees of rotation to reach the initial position of the tooth in front,
+            // so we mesh the two gear's teeth together by offsetting the 2nd gear's rotation by half of that
+            rotationRad += 11.25f * GameMath.DEG2RAD;
+
+            rotX = rotationRad * dev.AxisSign[3];
+            rotY = rotationRad * dev.AxisSign[4];
+            rotZ = rotationRad * dev.AxisSign[5];
+            UpdateLightAndTransformMatrix(floatsSpurGearTwo.Values, index, distToCamera, dev.LightRgba, rotX, rotY, rotZ);
+        }
+
+        public override void OnRenderFrame(float deltaTime, IShaderProgram prog)
+        {
+            UpdateCustomFloatBuffer();
+
+            if (quantityBlocks > 0)
+            {
+                floatsSpurGearOne.Count = quantityBlocks * 20;
+                floatsSpurGearTwo.Count = quantityBlocks * 20;
+
+                updateMesh.CustomFloats = floatsSpurGearOne;
+                capi.Render.UpdateMesh(spurGearOne, updateMesh);
+
+                updateMesh.CustomFloats = floatsSpurGearTwo;
+                capi.Render.UpdateMesh(spurGearTwo, updateMesh);
+
+                capi.Render.RenderMeshInstanced(spurGearOne, quantityBlocks);
+                capi.Render.RenderMeshInstanced(spurGearTwo, quantityBlocks);
+            }
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+
+            spurGearOne?.Dispose();
+            spurGearTwo?.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Adds placement logic to spur gears.

You can now place axles inside spur gears to allow mechanical power through the spur's axle input axis.
You can now place an extra spur gear perpendicularly in another spur gear by placing it on an adjacent axle.
 In total this allows you to send power from a spur gear to any of it's adjacent directions.

<img width="1895" height="983" alt="{6DCE526E-0CDC-4070-A53C-4A4606402D2C}" src="https://github.com/user-attachments/assets/b58dd7a0-495b-4494-8aab-e43e3761d72c" />

This comes with JSON changes in the assets folder. Since assets aren't in this repo you can download them here https://drive.google.com/file/d/1jKhaOI2VtG3A3kl8O5_Usy2N_KEb8Inm/view?usp=sharing
or I can send them another way.


### Followups
1: Should there be 3 way gears? Placing gears at all the arrows in your requirement image would result in a deadlock, but it does feel like this type of gear should allow 3 or 4 way configurations.
<img width="500" height="375" alt="image" src="https://github.com/user-attachments/assets/5e780387-fbb7-410e-8490-e483155b7e83" />

2: My current logic has one spur/axle item for each spur/axle that is shown in the block. The angled gear's logic has just 1 gear item for each block, and it updates the gear block based on the adjacent axles. In other words you need 2 spurs to create an angled connection with my spur logic, and 1 angled gear to create an angled connection with the angled gears logic.
Should we use my logic or the angled gear's logic? 
<img width="821" height="647" alt="image" src="https://github.com/user-attachments/assets/7fe3f9c8-1423-41fb-b0c2-fe75f6039112" />

3. How should the different axle types work on the spurs? Currently only the wooden axle can be put on the spur.
<img width="217" height="154" alt="image" src="https://github.com/user-attachments/assets/76bd328a-eb37-4de4-8496-3bd525dff8ce" />

4. For the extra spur, in addition to the current placement on the adjacent axles, should there be directional placement on the spur hitbox?
<img width="979" height="830" alt="image" src="https://github.com/user-attachments/assets/4f7b5fbe-9074-424f-ba99-a35330485443" />

5. How should the connection to the spur look?
<img width="697" height="636" alt="image" src="https://github.com/user-attachments/assets/bf386efc-af76-4adc-b574-a77244f96e4f" />

6. In order to mesh the spur-16 shape's gear teeth with adjacent spurs, I needed to move the spur halfway out of the block's boundary.
If that is the right approach, then how should the spur hitbox look?
<img width="996" height="732" alt="image" src="https://github.com/user-attachments/assets/7200ad6a-3aaf-41a6-bb2c-82628718702d" />
