### PR TITLE
Bug bounty - Improved Spur Gears

### DIFF
--- a/Systems/Core.cs
+++ b/Systems/Core.cs
@@ -493,6 +493,7 @@ namespace Vintagestory.GameContent
             api.RegisterBlockClass("BlockAxle", typeof(BlockAxle));
             api.RegisterBlockClass("BlockAngledGears", typeof(BlockAngledGears));
             api.RegisterBlockClass("BlockSpurGear", typeof(BlockSpurGear));
+            api.RegisterBlockClass("BlockSpurGearMulti", typeof(BlockSpurGearMulti));
             api.RegisterBlockClass("BlockWindmillRotor", typeof(BlockWindmillRotor));
             api.RegisterBlockClass("BlockToggle", typeof(BlockToggle));
             api.RegisterBlockClass("BlockPulverizer", typeof(BlockPulverizer));

--- a/Systems/MechanicalPower/Block/BlockAxle.cs
+++ b/Systems/MechanicalPower/Block/BlockAxle.cs
@@ -22,8 +22,63 @@ namespace Vintagestory.GameContent.Mechanics
 
         public override bool TryPlaceBlock(IWorldAccessor world, IPlayer byPlayer, ItemStack itemstack, BlockSelection blockSel, ref string failureCode)
         {
+            BlockPos originalPos = blockSel.Position.Copy();
+            BlockFacing originalFace = blockSel.Face;
+            bool originalDidOffset = blockSel.DidOffset;
+            Block blockAtSelection = world.BlockAccessor.GetBlock(blockSel.Position);
+
             if (!CanPlaceBlock(world, byPlayer, blockSel, ref failureCode))
             {
+                if (failureCode != "notreplaceable") return false;
+
+                if (blockAtSelection is BlockSpurGear selectedGear)
+                {
+                    BlockFacing gearOrientation = BlockFacing.FromFirstLetter(selectedGear.Variant["orientation"]);
+                    BlockFacing hubFace = gearOrientation.Opposite;
+                    BlockPos hubAxlePos = originalPos.AddCopy(hubFace);
+
+                    Block blockAtHub = world.BlockAccessor.GetBlock(hubAxlePos);
+                    if (blockAtHub != null && blockAtHub.BlockId != 0 && !blockAtHub.IsReplacableBy(this))
+                    {
+                        failureCode = "notreplaceable";
+                        return false;
+                    }
+
+                    string axleRotation = (hubFace == BlockFacing.NORTH || hubFace == BlockFacing.SOUTH) ? "ns"
+                        : (hubFace == BlockFacing.UP || hubFace == BlockFacing.DOWN) ? "ud" : "we";
+                    Block axleVariant = world.GetBlock(new AssetLocation("game", "woodenaxle-" + axleRotation));
+                    if (axleVariant == null) axleVariant = world.GetBlock(new AssetLocation("woodenaxle-" + axleRotation));
+
+                    if (axleVariant != null && !BEBehaviorMPAxle.IsAttachedToBlock(world.BlockAccessor, axleVariant, hubAxlePos))
+                    {
+                        failureCode = "axlemusthavesupport";
+                        return false;
+                    }
+
+                    if (axleVariant != null)
+                    {
+                        world.BlockAccessor.SetBlock(axleVariant.BlockId, hubAxlePos);
+                    }
+
+                    if (selectedGear.TryAddHubAxle(world, originalPos, hubFace))
+                    {
+                        failureCode = null;
+                        return true;
+                    }
+
+                    if (axleVariant != null)
+                    {
+                        world.BlockAccessor.SetBlock(0, hubAxlePos);
+                    }
+                    return false;
+                }
+
+                if (blockAtSelection is BlockAxle selectedAxle
+                    && TryPlaceAcrossAdjacentSpurGear(world, blockSel, originalPos, originalFace, originalDidOffset, selectedAxle, ref failureCode))
+                {
+                    return true;
+                }
+
                 return false;
             }
 
@@ -71,6 +126,33 @@ namespace Vintagestory.GameContent.Mechanics
                 WasPlaced(world, blockSel.Position, null);
                 return true;
             }
+            return false;
+        }
+
+        bool TryPlaceAcrossAdjacentSpurGear(IWorldAccessor world, BlockSelection blockSel, BlockPos originalPos, BlockFacing originalFace, bool originalDidOffset, BlockAxle selectedAxle, ref string failureCode)
+        {
+            foreach (BlockFacing faceToGear in BlockFacing.ALLFACES)
+            {
+                BlockPos gearPos = originalPos.AddCopy(faceToGear);
+                if (!(world.BlockAccessor.GetBlock(gearPos) is BlockSpurGear gearBlock)) continue;
+
+                BlockFacing axleFaceFromGear = faceToGear.Opposite;
+                BlockFacing gearOrientation = BlockFacing.FromFirstLetter(gearBlock.Variant["orientation"]);
+                if (axleFaceFromGear != gearOrientation && axleFaceFromGear != gearOrientation.Opposite) continue;
+
+                if (!selectedAxle.HasMechPowerConnectorAt(world, originalPos, faceToGear, gearBlock)) continue;
+                if (!gearBlock.HasMechPowerConnectorAt(world, gearPos, axleFaceFromGear, selectedAxle)) continue;
+
+                if (gearBlock.IsHubAxleFace(axleFaceFromGear) && gearBlock.TryAddHubAxle(world, gearPos, axleFaceFromGear))
+                {
+                    failureCode = null;
+                    return true;
+                }
+            }
+
+            blockSel.Position = originalPos;
+            blockSel.Face = originalFace;
+            blockSel.DidOffset = originalDidOffset;
             return false;
         }
 

--- a/Systems/MechanicalPower/Block/BlockSpurGear.cs
+++ b/Systems/MechanicalPower/Block/BlockSpurGear.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;
@@ -9,7 +8,7 @@ namespace Vintagestory.GameContent.Mechanics
 {
     public class BlockSpurGear : BlockMPBase
     {
-        protected BlockFacing Orientation; 
+        protected BlockFacing Orientation;
 
         public override void OnLoaded(ICoreAPI api)
         {
@@ -17,65 +16,155 @@ namespace Vintagestory.GameContent.Mechanics
             Orientation = BlockFacing.FromFirstLetter(Variant["orientation"]);
         }
 
-        public override bool HasMechPowerConnectorAt(IWorldAccessor world, BlockPos pos, BlockFacing face, BlockMPBase forBlock)
-        {
-            // Original: face == Orientation || side-by-side matching spur gears
-            // Added: hub variant accepts both ends of the rotation axis (drive side + continuation)
-            if (face == Orientation) return true;
-            if (face == Orientation.Opposite && IsHubVariant()) return true;
-            if (forBlock == this && face != Orientation.Opposite) return true;
-
-            // Multi-disc block requesting connection on any face with a supported axle
-            if (forBlock is BlockSpurGearMulti) return face == Orientation || face == Orientation.Opposite;
-
-            return false;
-        }
-
         bool IsHubVariant()
         {
-            return Code.Path.StartsWith("spurgearhub-");
+            return Code?.PathStartsWith("spurgearhub-") == true;
+        }
+
+        bool IsSameSpurGearVariant(Block block)
+        {
+            string path = block?.Code?.Path;
+            if (path == null || (!path.StartsWith("spurgear-") && !path.StartsWith("spurgearhub-"))) return false;
+            return block is BlockSpurGear && block.Variant?["orientation"] == Variant?["orientation"];
+        }
+
+        Block GetSpurGearVariant(IWorldAccessor world, bool hub, BlockFacing orientation)
+        {
+            string code = (hub ? "spurgearhub-" : "spurgear-") + orientation.Code[0];
+            return world.GetBlock(new AssetLocation(Code.Domain, code)) ?? world.GetBlock(new AssetLocation(code));
+        }
+
+        void ExchangeTo(IWorldAccessor world, BlockPos pos, Block toBlock)
+        {
+            world.BlockAccessor.ExchangeBlock(toBlock.BlockId, pos);
+
+            BEBehaviorMPBase bemp = world.BlockAccessor.GetBlockEntity(pos)?.GetBehavior<BEBehaviorMPBase>();
+            if (bemp != null)
+            {
+                bemp.SetOrientations();
+                bemp.Shape = toBlock.Shape;
+                bemp.Blockentity.MarkDirty();
+            }
+        }
+
+        public bool IsHubAxleFace(BlockFacing face)
+        {
+            return face == Orientation.Opposite;
+        }
+
+        public bool TryAddHubAxle(IWorldAccessor world, BlockPos pos, BlockFacing connectedOnFace = null)
+        {
+            if (IsHubVariant()) return true;
+            if (!(GetSpurGearVariant(world, true, Orientation) is BlockMPBase hubBlock)) return false;
+
+            ExchangeTo(world, pos, hubBlock);
+            ReconnectAxis(world, pos, hubBlock, connectedOnFace);
+            return true;
+        }
+
+        void ReconnectAxis(IWorldAccessor world, BlockPos pos, BlockMPBase ownBlock, BlockFacing connectedOnFace)
+        {
+            if (connectedOnFace == Orientation || connectedOnFace == Orientation.Opposite)
+            {
+                TryReconnectFace(world, pos, ownBlock, connectedOnFace);
+                TryReconnectFace(world, pos, ownBlock, connectedOnFace.Opposite);
+                return;
+            }
+
+            TryReconnectFace(world, pos, ownBlock, Orientation);
+            TryReconnectFace(world, pos, ownBlock, Orientation.Opposite);
+        }
+
+        void TryReconnectFace(IWorldAccessor world, BlockPos pos, BlockMPBase ownBlock, BlockFacing face)
+        {
+            BlockPos npos = pos.AddCopy(face);
+            IMechanicalPowerBlock neighbour = world.BlockAccessor.GetBlock(npos) as IMechanicalPowerBlock;
+            if (neighbour == null) return;
+            if (!neighbour.HasMechPowerConnectorAt(world, npos, face.Opposite, ownBlock)) return;
+            if (!ownBlock.HasMechPowerConnectorAt(world, pos, face, neighbour as BlockMPBase)) return;
+
+            neighbour.DidConnectAt(world, npos, face.Opposite);
+            ownBlock.WasPlaced(world, pos, face);
+        }
+
+        bool AxisEndHolds(IWorldAccessor world, BlockPos pos, BlockFacing face)
+        {
+            BlockPos npos = pos.AddCopy(face);
+            return world.BlockAccessor.GetBlock(npos) is BlockMPBase nblock
+                && nblock.HasMechPowerConnectorAt(world, npos, face.Opposite, this)
+                && HasMechPowerConnectorAt(world, pos, face, nblock);
+        }
+
+        public override bool HasMechPowerConnectorAt(IWorldAccessor world, BlockPos pos, BlockFacing face, BlockMPBase forBlock)
+        {
+            if (face == Orientation || face == Orientation.Opposite) return true;
+            return IsSameSpurGearVariant(forBlock);
         }
 
         public override ItemStack OnPickBlock(IWorldAccessor world, BlockPos pos)
         {
-            return new ItemStack(world.GetBlock(CodeWithVariant("orientation", "s")));
+            return new ItemStack(GetSpurGearVariant(world, false, BlockFacing.SOUTH));
         }
-
 
         public override bool TryPlaceBlock(IWorldAccessor world, IPlayer byPlayer, ItemStack itemstack, BlockSelection blockSel, ref string failureCode)
         {
             if (!CanPlaceBlock(world, byPlayer, blockSel, ref failureCode))
             {
-                return false;
-            }
+                if (failureCode != "notreplaceable" || blockSel.Face == null) return false;
 
-            // If clicking on an existing spur gear, redirect to multi-disc growth
-            Block targetBlock = world.BlockAccessor.GetBlock(blockSel.Position);
-            if (targetBlock is BlockSpurGear || targetBlock is BlockSpurGearMulti)
-            {
-                if (BlockSpurGearMulti.TryAddDisc(world, blockSel.Position, blockSel.Face.Opposite, ref failureCode, byPlayer))
+                Block blockAtSelection = world.BlockAccessor.GetBlock(blockSel.Position);
+                if (blockAtSelection is BlockSpurGear || blockAtSelection is BlockSpurGearMulti)
                 {
-                    if (byPlayer.WorldData.CurrentGameMode != EnumGameMode.Creative)
-                    {
-                        byPlayer.InventoryManager.ActiveHotbarSlot.TakeOut(1);
-                        byPlayer.InventoryManager.ActiveHotbarSlot.MarkDirty();
-                    }
-                    return true;
+                    BlockFacing discFace = blockSel.Face.Opposite;
+                    return BlockSpurGearMulti.TryAddDisc(world, blockSel.Position, discFace, ref failureCode, byPlayer);
                 }
-                // Fall through to normal placement if adding a disc failed
+
+                if (!TryMoveSelectionToReplaceableNeighbour(world, byPlayer, blockSel, ref failureCode))
+                {
+                    return false;
+                }
             }
 
-            // Scan all 6 faces for a valid axle, prioritizing the clicked face
-            BlockFacing targetFace = blockSel.Face.Opposite;
-            BlockPos targetPos = blockSel.Position.AddCopy(targetFace);
-            BlockEntity targetBe = world.BlockAccessor.GetBlockEntity(targetPos);
-
-            if (!TryFindAxle(world, blockSel.Position, targetFace, out targetFace, out targetPos, out targetBe, ref failureCode))
+            if (TryRedirectToNeighbourMulti(world, byPlayer, blockSel, ref failureCode))
             {
+                return true;
+            }
+
+            BlockFacing targetFace = null;
+            Block toPlaceBlock = null;
+            BlockFacing clickedFace = blockSel.Face.Opposite;
+            bool unsupportedAxleSeen = false;
+
+            for (int i = -1; i < BlockFacing.ALLFACES.Length; i++)
+            {
+                BlockFacing face = i < 0 ? clickedFace : BlockFacing.ALLFACES[i];
+                if (i >= 0 && face == clickedFace) continue;
+
+                Block candidateBlock = GetSpurGearVariant(world, false, face) ?? world.GetBlock(CodeWithVariant("orientation", face.Code[0] + ""));
+                if (!(candidateBlock is BlockMPBase candidateMechBlock)) continue;
+
+                BlockPos npos = blockSel.Position.AddCopy(face);
+                BlockEntity nbe = world.BlockAccessor.GetBlockEntity(npos);
+                if (!(nbe?.Block is BlockMPBase neighbourBlock)) continue;
+                if (!neighbourBlock.HasMechPowerConnectorAt(world, npos, face.Opposite, candidateMechBlock)) continue;
+                if (nbe.GetBehavior<BEBehaviorMPAxle>() == null) continue;
+                if (!BEBehaviorMPAxle.IsAttachedToBlock(world.BlockAccessor, nbe.Block, npos))
+                {
+                    unsupportedAxleSeen = true;
+                    continue;
+                }
+
+                targetFace = face;
+                toPlaceBlock = candidateBlock;
+                break;
+            }
+
+            if (targetFace == null)
+            {
+                failureCode = unsupportedAxleSeen ? "axlemusthavesupport" : "requiresaxle";
                 return false;
             }
 
-            BlockSpurGear toPlaceBlock = world.GetBlock(CodeWithVariant("orientation", targetFace.Code[0] + "")) as BlockSpurGear;
             world.BlockAccessor.SetBlock(toPlaceBlock.BlockId, blockSel.Position);
 
             var selfBeh = GetBEBehavior<BEBehaviorMPBase>(blockSel.Position);
@@ -86,92 +175,94 @@ namespace Vintagestory.GameContent.Mechanics
             {
                 var npos = blockSel.Position.AddCopy(exit.OutFacing);
                 var neibBlock = world.BlockAccessor.GetBlock(npos) as IMechanicalPowerBlock;
-                neibBlock?.DidConnectAt(world, blockSel.Position, exit.OutFacing.Opposite);
-                if (neibBlock != null)
+                neibBlock?.DidConnectAt(world, npos, exit.OutFacing.Opposite);
+                if (neibBlock != null && !selfBeh.tryConnect(exit.OutFacing))
                 {
-                    if (!selfBeh.tryConnect(exit.OutFacing))
-                    {
-                        // We might be trying to connect to a side which is has no power node, which means it has no network.
-                        // We first need to connect to a network, before we can connect our neighbours, so lets try to connect these again
-                        possiblyNetworklessCandidates.Add(exit.OutFacing);
-                    }
+                    possiblyNetworklessCandidates.Add(exit.OutFacing);
                 }
             }
 
-            // Looks like we managed to connect
             if (selfBeh.Network != null)
             {
                 foreach (var face in possiblyNetworklessCandidates) selfBeh.tryConnect(face);
             }
 
-
             return true;
         }
 
-        /// <summary>
-        /// Searches for a valid axle to attach the gear to, starting with the preferred face
-        /// and falling through to all other faces if that one fails.
-        /// </summary>
-        bool TryFindAxle(IWorldAccessor world, BlockPos gearPos, BlockFacing preferred, out BlockFacing foundFace, out BlockPos foundPos, out BlockEntity foundBe, ref string failureCode)
+        bool TryRedirectToNeighbourMulti(IWorldAccessor world, IPlayer byPlayer, BlockSelection blockSel, ref string failureCode)
         {
-            // Try preferred face first
-            if (CheckAxleFace(world, gearPos, preferred, out foundPos, out foundBe))
+            BlockFacing clickedFace = blockSel.Face;
+            if (clickedFace == null) return false;
+
+            BlockPos pos = blockSel.Position;
+            BlockFacing scanDir = clickedFace.Opposite;
+            for (int depth = 1; depth <= 2; depth++)
             {
-                foundFace = preferred;
-                return true;
+                BlockPos candidatePos = pos.AddCopy(scanDir, depth);
+                Block candidate = world.BlockAccessor.GetBlock(candidatePos);
+
+                if (candidate is BlockSpurGear || candidate is BlockSpurGearMulti)
+                {
+                    BlockFacing discFace = scanDir.Opposite;
+                    return BlockSpurGearMulti.TryAddDisc(world, candidatePos, discFace, ref failureCode, byPlayer);
+                }
+
+                if (candidate.BlockMaterial != EnumBlockMaterial.Wood && !(candidate is BlockMPBase))
+                {
+                    break;
+                }
             }
 
-            // Scan remaining faces
-            foreach (BlockFacing face in BlockFacing.ALLFACES)
+            return false;
+        }
+
+        bool TryMoveSelectionToReplaceableNeighbour(IWorldAccessor world, IPlayer byPlayer, BlockSelection blockSel, ref string failureCode)
+        {
+            BlockPos originalPos = blockSel.Position.Copy();
+            BlockFacing originalFace = blockSel.Face;
+            bool originalDidOffset = blockSel.DidOffset;
+
+            for (int i = -1; i < BlockFacing.ALLFACES.Length; i++)
             {
-                if (face == preferred) continue;
-                if (CheckAxleFace(world, gearPos, face, out foundPos, out foundBe))
+                BlockFacing face = i < 0 ? originalFace : BlockFacing.ALLFACES[i];
+                if (face == null || (i >= 0 && face == originalFace)) continue;
+
+                blockSel.Position = originalPos.AddCopy(face);
+                blockSel.Face = face;
+                blockSel.DidOffset = true;
+
+                string offsetFailureCode = null;
+                if (CanPlaceBlock(world, byPlayer, blockSel, ref offsetFailureCode))
                 {
-                    foundFace = face;
+                    failureCode = offsetFailureCode;
                     return true;
                 }
             }
 
-            foundFace = preferred;
-            foundPos = null;
-            foundBe = null;
-            failureCode = "requiresaxle";
+            blockSel.Position = originalPos;
+            blockSel.Face = originalFace;
+            blockSel.DidOffset = originalDidOffset;
             return false;
         }
-
-        bool CheckAxleFace(IWorldAccessor world, BlockPos gearPos, BlockFacing face, out BlockPos axlePos, out BlockEntity axleBe)
-        {
-            axlePos = gearPos.AddCopy(face);
-            axleBe = world.BlockAccessor.GetBlockEntity(axlePos);
-
-            BEBehaviorMPAxle bempaxle = axleBe?.GetBehavior<BEBehaviorMPAxle>();
-            if (bempaxle == null) return false;
-            if (!(bempaxle.Block as BlockMPBase).HasMechPowerConnectorAt(world, axlePos, face, this)) return false;
-            if (!BEBehaviorMPAxle.IsAttachedToBlock(world.BlockAccessor, bempaxle.Block as Block, axlePos)) return false;
-
-            return true;
-        }
-
 
         public override void OnNeighbourBlockChange(IWorldAccessor world, BlockPos pos, BlockPos neibpos)
         {
             var nblock = world.BlockAccessor.GetBlock(pos.AddCopy(Orientation));
-            if (!(nblock is BlockMPBase) || nblock.SideIsSolid(world.BlockAccessor, pos, Orientation.Opposite.Index))
-            {
-                // Before breaking, check if the hub-side axle still supports us
-                if (IsHubVariant())
-                {
-                    var hubBlock = world.BlockAccessor.GetBlock(pos.AddCopy(Orientation.Opposite));
-                    if (hubBlock is BlockMPBase) return; // Hub axle holds the gear
-                }
+            bool frontHolds = nblock is BlockMPBase && !nblock.SideIsSolid(world.BlockAccessor, pos, Orientation.Opposite.Index);
 
-                world.BlockAccessor.BreakBlock(pos, null);
+            if (frontHolds)
+            {
+                base.OnNeighbourBlockChange(world, pos, neibpos);
                 return;
             }
 
-            base.OnNeighbourBlockChange(world, pos, neibpos);
+            bool hubHolds = IsHubVariant() && AxisEndHolds(world, pos, Orientation.Opposite);
+            if (!hubHolds)
+            {
+                world.BlockAccessor.BreakBlock(pos, null);
+            }
         }
-
 
         public override void DidConnectAt(IWorldAccessor world, BlockPos pos, BlockFacing face) { }
     }

--- a/Systems/MechanicalPower/Block/BlockSpurGear.cs
+++ b/Systems/MechanicalPower/Block/BlockSpurGear.cs
@@ -19,7 +19,21 @@ namespace Vintagestory.GameContent.Mechanics
 
         public override bool HasMechPowerConnectorAt(IWorldAccessor world, BlockPos pos, BlockFacing face, BlockMPBase forBlock)
         {
-            return face == Orientation || (forBlock == this && face != Orientation.Opposite);    // Side by side: powers any matching spur gear adjacent
+            // Original: face == Orientation || side-by-side matching spur gears
+            // Added: hub variant accepts both ends of the rotation axis (drive side + continuation)
+            if (face == Orientation) return true;
+            if (face == Orientation.Opposite && IsHubVariant()) return true;
+            if (forBlock == this && face != Orientation.Opposite) return true;
+
+            // Multi-disc block requesting connection on any face with a supported axle
+            if (forBlock is BlockSpurGearMulti) return face == Orientation || face == Orientation.Opposite;
+
+            return false;
+        }
+
+        bool IsHubVariant()
+        {
+            return Code.Path.StartsWith("spurgearhub-");
         }
 
         public override ItemStack OnPickBlock(IWorldAccessor world, BlockPos pos)
@@ -35,20 +49,29 @@ namespace Vintagestory.GameContent.Mechanics
                 return false;
             }
 
-            BlockFacing targetFace = blockSel.Face.Opposite;
-            BlockPos pos = blockSel.Position.AddCopy(targetFace);
-            BlockEntity be = world.BlockAccessor.GetBlockEntity(pos);
-            IMechanicalPowerBlock neighbour = be?.Block as IMechanicalPowerBlock;
-
-            BEBehaviorMPAxle bempaxle = be?.GetBehavior<BEBehaviorMPAxle>();
-            if (bempaxle == null || !(bempaxle.Block as BlockMPBase).HasMechPowerConnectorAt(world, pos, targetFace, this))
+            // If clicking on an existing spur gear, redirect to multi-disc growth
+            Block targetBlock = world.BlockAccessor.GetBlock(blockSel.Position);
+            if (targetBlock is BlockSpurGear || targetBlock is BlockSpurGearMulti)
             {
-                failureCode = "requiresaxle";
-                return false;
+                if (BlockSpurGearMulti.TryAddDisc(world, blockSel.Position, blockSel.Face.Opposite, ref failureCode, byPlayer))
+                {
+                    if (byPlayer.WorldData.CurrentGameMode != EnumGameMode.Creative)
+                    {
+                        byPlayer.InventoryManager.ActiveHotbarSlot.TakeOut(1);
+                        byPlayer.InventoryManager.ActiveHotbarSlot.MarkDirty();
+                    }
+                    return true;
+                }
+                // Fall through to normal placement if adding a disc failed
             }
-            if (bempaxle != null && !BEBehaviorMPAxle.IsAttachedToBlock(world.BlockAccessor, neighbour as Block, pos))
+
+            // Scan all 6 faces for a valid axle, prioritizing the clicked face
+            BlockFacing targetFace = blockSel.Face.Opposite;
+            BlockPos targetPos = blockSel.Position.AddCopy(targetFace);
+            BlockEntity targetBe = world.BlockAccessor.GetBlockEntity(targetPos);
+
+            if (!TryFindAxle(world, blockSel.Position, targetFace, out targetFace, out targetPos, out targetBe, ref failureCode))
             {
-                failureCode = "axlemusthavesupport";
                 return false;
             }
 
@@ -85,12 +108,63 @@ namespace Vintagestory.GameContent.Mechanics
             return true;
         }
 
+        /// <summary>
+        /// Searches for a valid axle to attach the gear to, starting with the preferred face
+        /// and falling through to all other faces if that one fails.
+        /// </summary>
+        bool TryFindAxle(IWorldAccessor world, BlockPos gearPos, BlockFacing preferred, out BlockFacing foundFace, out BlockPos foundPos, out BlockEntity foundBe, ref string failureCode)
+        {
+            // Try preferred face first
+            if (CheckAxleFace(world, gearPos, preferred, out foundPos, out foundBe))
+            {
+                foundFace = preferred;
+                return true;
+            }
+
+            // Scan remaining faces
+            foreach (BlockFacing face in BlockFacing.ALLFACES)
+            {
+                if (face == preferred) continue;
+                if (CheckAxleFace(world, gearPos, face, out foundPos, out foundBe))
+                {
+                    foundFace = face;
+                    return true;
+                }
+            }
+
+            foundFace = preferred;
+            foundPos = null;
+            foundBe = null;
+            failureCode = "requiresaxle";
+            return false;
+        }
+
+        bool CheckAxleFace(IWorldAccessor world, BlockPos gearPos, BlockFacing face, out BlockPos axlePos, out BlockEntity axleBe)
+        {
+            axlePos = gearPos.AddCopy(face);
+            axleBe = world.BlockAccessor.GetBlockEntity(axlePos);
+
+            BEBehaviorMPAxle bempaxle = axleBe?.GetBehavior<BEBehaviorMPAxle>();
+            if (bempaxle == null) return false;
+            if (!(bempaxle.Block as BlockMPBase).HasMechPowerConnectorAt(world, axlePos, face, this)) return false;
+            if (!BEBehaviorMPAxle.IsAttachedToBlock(world.BlockAccessor, bempaxle.Block as Block, axlePos)) return false;
+
+            return true;
+        }
+
 
         public override void OnNeighbourBlockChange(IWorldAccessor world, BlockPos pos, BlockPos neibpos)
         {
             var nblock = world.BlockAccessor.GetBlock(pos.AddCopy(Orientation));
             if (!(nblock is BlockMPBase) || nblock.SideIsSolid(world.BlockAccessor, pos, Orientation.Opposite.Index))
             {
+                // Before breaking, check if the hub-side axle still supports us
+                if (IsHubVariant())
+                {
+                    var hubBlock = world.BlockAccessor.GetBlock(pos.AddCopy(Orientation.Opposite));
+                    if (hubBlock is BlockMPBase) return; // Hub axle holds the gear
+                }
+
                 world.BlockAccessor.BreakBlock(pos, null);
                 return;
             }

--- a/Systems/MechanicalPower/Block/BlockSpurGearMulti.cs
+++ b/Systems/MechanicalPower/Block/BlockSpurGearMulti.cs
@@ -1,0 +1,265 @@
+using System.Collections.Generic;
+using Vintagestory.API.Common;
+using Vintagestory.API.MathTools;
+using Vintagestory.API.Server;
+using Vintagestory.GameContent.Mechanics;
+
+#nullable disable
+
+namespace Vintagestory.GameContent.Mechanics
+{
+    /// <summary>
+    /// Multi-disc spur gear hub: one cell carrying up to six gear discs, one per face,
+    /// each mounted on its own supported axle, all coupled as one network node.
+    /// </summary>
+    public class BlockSpurGearMulti : BlockMPBase
+    {
+        Cuboidf[][] discBoxes;
+
+        public override void OnLoaded(ICoreAPI api)
+        {
+            base.OnLoaded(api);
+
+            Cuboidf horiz = new Cuboidf(0.125f, 0f, 0.625f, 0.85f, 1f, 1f);
+            Cuboidf vert = new Cuboidf(0.125f, 0f, 0.125f, 0.875f, 0.375f, 0.875f);
+            Vec3d center = new Vec3d(0.5, 0.5, 0.5);
+
+            discBoxes = new Cuboidf[6][];
+            discBoxes[BlockFacing.NORTH.Index] = new[] { horiz.RotatedCopy(0, 180, 0, center) };
+            discBoxes[BlockFacing.EAST.Index] = new[] { horiz.RotatedCopy(0, 90, 0, center) };
+            discBoxes[BlockFacing.SOUTH.Index] = new[] { horiz.RotatedCopy(0, 0, 0, center) };
+            discBoxes[BlockFacing.WEST.Index] = new[] { horiz.RotatedCopy(0, 270, 0, center) };
+            discBoxes[BlockFacing.UP.Index] = new[] { vert.RotatedCopy(180, 0, 0, center) };
+            discBoxes[BlockFacing.DOWN.Index] = new[] { vert.RotatedCopy(0, 0, 0, center) };
+        }
+
+        static BEBehaviorMPSpurGear GetGearBehavior(IBlockAccessor blockAccessor, BlockPos pos)
+        {
+            return blockAccessor.GetBlockEntity(pos)?.GetBehavior<BEBehaviorMPSpurGear>();
+        }
+
+        static Block GearItemBlock(IWorldAccessor world, Block from)
+        {
+            return world.GetBlock(new AssetLocation(from.Code.Domain, "spurgear-s"))
+                ?? world.GetBlock(new AssetLocation("spurgear-s"));
+        }
+
+        public override bool HasMechPowerConnectorAt(IWorldAccessor world, BlockPos pos, BlockFacing face, BlockMPBase forBlock)
+        {
+            return GetGearBehavior(world.BlockAccessor, pos)?.HasDisc(face) == true;
+        }
+
+        public override void DidConnectAt(IWorldAccessor world, BlockPos pos, BlockFacing face) { }
+
+        public override ItemStack OnPickBlock(IWorldAccessor world, BlockPos pos)
+        {
+            return new ItemStack(GearItemBlock(world, this));
+        }
+
+        public override ItemStack[] GetDrops(IWorldAccessor world, BlockPos pos, IPlayer byPlayer, float dropQuantityMultiplier = 1f)
+        {
+            int count = GetGearBehavior(world.BlockAccessor, pos)?.DiscCount ?? 0;
+            if (count <= 0) return new ItemStack[0];
+
+            return new[] { new ItemStack(GearItemBlock(world, this), count) };
+        }
+
+        public override Cuboidf[] GetSelectionBoxes(IBlockAccessor blockAccessor, BlockPos pos)
+        {
+            var beh = GetGearBehavior(blockAccessor, pos);
+            if (beh == null || beh.DiscCount == 0) return base.GetSelectionBoxes(blockAccessor, pos);
+
+            List<Cuboidf> boxes = new List<Cuboidf>();
+            foreach (BlockFacing face in BlockFacing.ALLFACES)
+            {
+                if (beh.HasDisc(face)) boxes.AddRange(discBoxes[face.Index]);
+            }
+
+            return boxes.ToArray();
+        }
+
+        public override Cuboidf[] GetCollisionBoxes(IBlockAccessor blockAccessor, BlockPos pos)
+        {
+            return GetSelectionBoxes(blockAccessor, pos);
+        }
+
+        /// <summary>
+        /// Grows a disc on the cell: a plain gear morphs to the multi block with both discs
+        /// set; an existing multi gains one bit.
+        /// </summary>
+        public static bool TryAddDisc(IWorldAccessor world, BlockPos gearPos, BlockFacing requestedFace, ref string failureCode, IPlayer byPlayer = null)
+        {
+            Block current = world.BlockAccessor.GetBlock(gearPos);
+            BEBehaviorMPSpurGear currentBeh = GetGearBehavior(world.BlockAccessor, gearPos);
+
+            BlockFacing existingOrientation = null;
+            if (current is BlockSpurGearMulti)
+            {
+                if (currentBeh == null) return false;
+            }
+            else if (current is BlockSpurGear && current.Code.PathStartsWith("spurgear-"))
+            {
+                existingOrientation = BlockFacing.FromFirstLetter(current.Variant["orientation"]);
+            }
+            else
+            {
+                failureCode = "requiresaxle";
+                return false;
+            }
+
+            Block multiBlock = world.GetBlock(new AssetLocation(current.Code.Domain, "spurgearmulti-s"))
+                ?? world.GetBlock(new AssetLocation("spurgearmulti-s"));
+            if (!(multiBlock is BlockSpurGearMulti multiMech))
+            {
+                failureCode = "requiresaxle";
+                return false;
+            }
+
+            BlockFacing face = null;
+            BlockEntity axleBe = null;
+            string bestFailure = null;
+
+            // Try requested face first, then scan all others
+            for (int i = -1; i < BlockFacing.ALLFACES.Length; i++)
+            {
+                BlockFacing candidate = i < 0 ? requestedFace : BlockFacing.ALLFACES[i];
+                if (candidate == null || (i >= 0 && candidate == requestedFace)) continue;
+
+                if (current is BlockSpurGearMulti && currentBeh.HasDisc(candidate)) continue;
+                if (existingOrientation != null && candidate == existingOrientation) continue;
+
+                if (TryGetAddableAxle(world, gearPos, candidate, multiMech, out axleBe, out string candidateFailure))
+                {
+                    face = candidate;
+                    break;
+                }
+
+                if (candidateFailure != null && (bestFailure == null || candidateFailure == "axlemusthavesupport"))
+                    bestFailure = candidateFailure;
+            }
+
+            if (face == null)
+            {
+                failureCode = bestFailure ?? "requiresaxle";
+                return false;
+            }
+
+            if (current is BlockSpurGearMulti)
+            {
+                currentBeh.SetDisc(face, true);
+            }
+            else
+            {
+                Exchange(world, gearPos, multiBlock);
+                var beh = GetGearBehavior(world.BlockAccessor, gearPos);
+                if (beh == null) return false;
+                beh.SetDisc(existingOrientation, true);
+                beh.SetDisc(face, true);
+            }
+
+            BlockPos axlePos = gearPos.AddCopy(face);
+            (world.BlockAccessor.GetBlock(axlePos) as IMechanicalPowerBlock)?.DidConnectAt(world, axlePos, face.Opposite);
+            world.BlockAccessor.GetBlockEntity(gearPos)?.GetBehavior<BEBehaviorMPBase>()?.tryConnect(face);
+
+            if (byPlayer != null && face != requestedFace)
+            {
+                (byPlayer as IServerPlayer)?.SendMessage(
+                    0, "Disc placed on " + face.Code + " face (aimed face unavailable)", EnumChatType.Notification);
+            }
+
+            return true;
+        }
+
+        static bool TryGetAddableAxle(IWorldAccessor world, BlockPos gearPos, BlockFacing face, BlockSpurGearMulti multiMech, out BlockEntity axleBe, out string failureCode)
+        {
+            BlockPos axlePos = gearPos.AddCopy(face);
+            axleBe = world.BlockAccessor.GetBlockEntity(axlePos);
+
+            if (axleBe?.GetBehavior<BEBehaviorMPAxle>() == null
+                || !(axleBe.Block is BlockMPBase axleBlock)
+                || !axleBlock.HasMechPowerConnectorAt(world, axlePos, face.Opposite, multiMech))
+            {
+                failureCode = "requiresaxle";
+                return false;
+            }
+            if (!BEBehaviorMPAxle.IsAttachedToBlock(world.BlockAccessor, axleBe.Block, axlePos))
+            {
+                failureCode = "axlemusthavesupport";
+                return false;
+            }
+
+            failureCode = null;
+            return true;
+        }
+
+        internal static void Exchange(IWorldAccessor world, BlockPos pos, Block toBlock)
+        {
+            world.BlockAccessor.ExchangeBlock(toBlock.BlockId, pos);
+            BEBehaviorMPBase bemp = world.BlockAccessor.GetBlockEntity(pos)?.GetBehavior<BEBehaviorMPBase>();
+            if (bemp != null)
+            {
+                bemp.SetOrientations();
+                bemp.Shape = toBlock.Shape;
+                bemp.Blockentity.MarkDirty(true);
+            }
+        }
+
+        bool DiscHasConnector(IWorldAccessor world, BlockPos pos, BlockFacing face)
+        {
+            BlockPos npos = pos.AddCopy(face);
+            Block nblockRaw = world.BlockAccessor.GetBlock(npos);
+            if (!(nblockRaw is BlockMPBase nblock)) return false;
+
+            bool hasConnector = nblock.HasMechPowerConnectorAt(world, npos, face.Opposite, this);
+            BEBehaviorMPBase nbeh = world.BlockAccessor.GetBlockEntity(npos)?.GetBehavior<BEBehaviorMPBase>();
+            return hasConnector && nbeh?.disconnected != true;
+        }
+
+        public override void OnNeighbourBlockChange(IWorldAccessor world, BlockPos pos, BlockPos neibpos)
+        {
+            var beh = GetGearBehavior(world.BlockAccessor, pos);
+            if (beh == null)
+            {
+                base.OnNeighbourBlockChange(world, pos, neibpos);
+                return;
+            }
+
+            Block gearItem = GearItemBlock(world, this);
+            bool removedAny = false;
+            foreach (BlockFacing face in BlockFacing.ALLFACES)
+            {
+                if (!beh.HasDisc(face) || DiscHasConnector(world, pos, face)) continue;
+
+                beh.SetDisc(face, false);
+                removedAny = true;
+                world.SpawnItemEntity(new ItemStack(gearItem), pos.ToVec3d().Add(0.5, 0.5, 0.5));
+            }
+
+            int count = beh.DiscCount;
+            if (count == 0)
+            {
+                if (removedAny) world.BlockAccessor.BreakBlock(pos, null);
+                return;
+            }
+            if (count > 1) return;
+
+            // One disc left: shrink back to the plain spur gear
+            BlockFacing last = null;
+            foreach (BlockFacing face in BlockFacing.ALLFACES)
+            {
+                if (beh.HasDisc(face)) { last = face; break; }
+            }
+
+            Block plain = world.GetBlock(new AssetLocation(Code.Domain, "spurgear-" + last.Code[0]))
+                ?? world.GetBlock(new AssetLocation("spurgear-" + last.Code[0]));
+            if (!(plain is BlockMPBase plainMech)) return;
+
+            beh.SetDisc(last, false);
+            Exchange(world, pos, plain);
+
+            BlockPos lastNpos = pos.AddCopy(last);
+            (world.BlockAccessor.GetBlock(lastNpos) as IMechanicalPowerBlock)?.DidConnectAt(world, lastNpos, last.Opposite);
+            plainMech.WasPlaced(world, pos, last);
+        }
+    }
+}

--- a/Systems/MechanicalPower/Block/BlockSpurGearMulti.cs
+++ b/Systems/MechanicalPower/Block/BlockSpurGearMulti.cs
@@ -2,18 +2,19 @@ using System.Collections.Generic;
 using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Server;
-using Vintagestory.GameContent.Mechanics;
 
 #nullable disable
 
 namespace Vintagestory.GameContent.Mechanics
 {
     /// <summary>
-    /// Multi-disc spur gear hub: one cell carrying up to six gear discs, one per face,
-    /// each mounted on its own supported axle, all coupled as one network node.
+    /// One block carrying multiple spur gear discs, one per face, each mounted on its own
+    /// supported axle and coupled as one network node.
     /// </summary>
     public class BlockSpurGearMulti : BlockMPBase
     {
+        const string GearsWouldJamFailureCode = "gearswouldjam";
+
         Cuboidf[][] discBoxes;
 
         public override void OnLoaded(ICoreAPI api)
@@ -46,7 +47,8 @@ namespace Vintagestory.GameContent.Mechanics
 
         public override bool HasMechPowerConnectorAt(IWorldAccessor world, BlockPos pos, BlockFacing face, BlockMPBase forBlock)
         {
-            return GetGearBehavior(world.BlockAccessor, pos)?.HasDisc(face) == true;
+            var beh = GetGearBehavior(world.BlockAccessor, pos);
+            return beh == null || beh.HasDisc(face);
         }
 
         public override void DidConnectAt(IWorldAccessor world, BlockPos pos, BlockFacing face) { }
@@ -83,16 +85,12 @@ namespace Vintagestory.GameContent.Mechanics
             return GetSelectionBoxes(blockAccessor, pos);
         }
 
-        /// <summary>
-        /// Grows a disc on the cell: a plain gear morphs to the multi block with both discs
-        /// set; an existing multi gains one bit.
-        /// </summary>
         public static bool TryAddDisc(IWorldAccessor world, BlockPos gearPos, BlockFacing requestedFace, ref string failureCode, IPlayer byPlayer = null)
         {
             Block current = world.BlockAccessor.GetBlock(gearPos);
-            BEBehaviorMPSpurGear currentBeh = GetGearBehavior(world.BlockAccessor, gearPos);
 
             BlockFacing existingOrientation = null;
+            BEBehaviorMPSpurGear currentBeh = GetGearBehavior(world.BlockAccessor, gearPos);
             if (current is BlockSpurGearMulti)
             {
                 if (currentBeh == null) return false;
@@ -119,23 +117,32 @@ namespace Vintagestory.GameContent.Mechanics
             BlockEntity axleBe = null;
             string bestFailure = null;
 
-            // Try requested face first, then scan all others
-            for (int i = -1; i < BlockFacing.ALLFACES.Length; i++)
+            for (int i = -2; i < 0; i++)
             {
-                BlockFacing candidate = i < 0 ? requestedFace : BlockFacing.ALLFACES[i];
-                if (candidate == null || (i >= 0 && candidate == requestedFace)) continue;
+                BlockFacing candidate = i == -2 ? requestedFace : requestedFace?.Opposite;
+                if (candidate == null) continue;
 
-                if (current is BlockSpurGearMulti && currentBeh.HasDisc(candidate)) continue;
-                if (existingOrientation != null && candidate == existingOrientation) continue;
+                string candidateFailure = null;
+                if (current is BlockSpurGearMulti && currentBeh.HasDisc(candidate))
+                {
+                    candidateFailure = "notreplaceable";
+                    RememberFailure(ref bestFailure, candidateFailure);
+                    continue;
+                }
+                if (existingOrientation != null && candidate == existingOrientation)
+                {
+                    candidateFailure = "notreplaceable";
+                    RememberFailure(ref bestFailure, candidateFailure);
+                    continue;
+                }
 
-                if (TryGetAddableAxle(world, gearPos, candidate, multiMech, out axleBe, out string candidateFailure))
+                if (TryGetAddableAxle(world, gearPos, candidate, multiMech, out axleBe, out candidateFailure))
                 {
                     face = candidate;
                     break;
                 }
 
-                if (candidateFailure != null && (bestFailure == null || candidateFailure == "axlemusthavesupport"))
-                    bestFailure = candidateFailure;
+                RememberFailure(ref bestFailure, candidateFailure);
             }
 
             if (face == null)
@@ -146,11 +153,12 @@ namespace Vintagestory.GameContent.Mechanics
 
             if (current is BlockSpurGearMulti)
             {
-                currentBeh.SetDisc(face, true);
+                GetGearBehavior(world.BlockAccessor, gearPos).SetDisc(face, true);
             }
             else
             {
                 Exchange(world, gearPos, multiBlock);
+
                 var beh = GetGearBehavior(world.BlockAccessor, gearPos);
                 if (beh == null) return false;
                 beh.SetDisc(existingOrientation, true);
@@ -160,6 +168,9 @@ namespace Vintagestory.GameContent.Mechanics
             BlockPos axlePos = gearPos.AddCopy(face);
             (world.BlockAccessor.GetBlock(axlePos) as IMechanicalPowerBlock)?.DidConnectAt(world, axlePos, face.Opposite);
             world.BlockAccessor.GetBlockEntity(gearPos)?.GetBehavior<BEBehaviorMPBase>()?.tryConnect(face);
+            GetGearBehavior(world.BlockAccessor, gearPos)?.OnDiscsChanged(face);
+
+            failureCode = null;
 
             if (byPlayer != null && face != requestedFace)
             {
@@ -170,11 +181,16 @@ namespace Vintagestory.GameContent.Mechanics
             return true;
         }
 
+        static void RememberFailure(ref string bestFailure, string candidateFailure)
+        {
+            if (candidateFailure == null) return;
+            if (bestFailure == null || candidateFailure == "axlemusthavesupport") bestFailure = candidateFailure;
+        }
+
         static bool TryGetAddableAxle(IWorldAccessor world, BlockPos gearPos, BlockFacing face, BlockSpurGearMulti multiMech, out BlockEntity axleBe, out string failureCode)
         {
             BlockPos axlePos = gearPos.AddCopy(face);
             axleBe = world.BlockAccessor.GetBlockEntity(axlePos);
-
             if (axleBe?.GetBehavior<BEBehaviorMPAxle>() == null
                 || !(axleBe.Block is BlockMPBase axleBlock)
                 || !axleBlock.HasMechPowerConnectorAt(world, axlePos, face.Opposite, multiMech))
@@ -195,6 +211,7 @@ namespace Vintagestory.GameContent.Mechanics
         internal static void Exchange(IWorldAccessor world, BlockPos pos, Block toBlock)
         {
             world.BlockAccessor.ExchangeBlock(toBlock.BlockId, pos);
+
             BEBehaviorMPBase bemp = world.BlockAccessor.GetBlockEntity(pos)?.GetBehavior<BEBehaviorMPBase>();
             if (bemp != null)
             {
@@ -231,6 +248,7 @@ namespace Vintagestory.GameContent.Mechanics
                 if (!beh.HasDisc(face) || DiscHasConnector(world, pos, face)) continue;
 
                 beh.SetDisc(face, false);
+                beh.OnDiscsChanged(face);
                 removedAny = true;
                 world.SpawnItemEntity(new ItemStack(gearItem), pos.ToVec3d().Add(0.5, 0.5, 0.5));
             }
@@ -238,12 +256,14 @@ namespace Vintagestory.GameContent.Mechanics
             int count = beh.DiscCount;
             if (count == 0)
             {
-                if (removedAny) world.BlockAccessor.BreakBlock(pos, null);
+                if (removedAny)
+                {
+                    world.BlockAccessor.BreakBlock(pos, null);
+                }
                 return;
             }
             if (count > 1) return;
 
-            // One disc left: shrink back to the plain spur gear
             BlockFacing last = null;
             foreach (BlockFacing face in BlockFacing.ALLFACES)
             {

--- a/Systems/MechanicalPower/BlockEntityBehavior/BEBehaviorMPSpurGear.cs
+++ b/Systems/MechanicalPower/BlockEntityBehavior/BEBehaviorMPSpurGear.cs
@@ -15,6 +15,29 @@ namespace Vintagestory.GameContent.Mechanics
         float angleOffset;
         public override float AngleRad => base.AngleRad + angleOffset;
 
+        // --- Multi-disc state (Scope 2) ---
+        // Bitmask: bit N set means a disc is mounted on BlockFacing.ALLFACES[N].
+        int discFaces;
+        public int DiscFaces => discFaces;
+        public int DiscCount
+        {
+            get
+            {
+                int n = 0;
+                for (int i = 0; i < 6; i++) { if ((discFaces & (1 << i)) != 0) n++; }
+                return n;
+            }
+        }
+        public bool HasDisc(BlockFacing face) => (discFaces & (1 << face.Index)) != 0;
+        public void SetDisc(BlockFacing face, bool present)
+        {
+            if (present) discFaces |= (1 << face.Index);
+            else discFaces &= ~(1 << face.Index);
+            Blockentity.MarkDirty(true);
+        }
+
+        internal bool IsMultiBlock => Block is BlockSpurGearMulti;
+
         public BEBehaviorMPSpurGear(BlockEntity blockentity) : base(blockentity)
         {
         }
@@ -50,8 +73,22 @@ namespace Vintagestory.GameContent.Mechanics
             }
         }
 
+        public override void FromTreeAttributes(ITreeAttribute tree, IWorldAccessor worldAccessForResolve)
+        {
+            base.FromTreeAttributes(tree, worldAccessForResolve);
+            discFaces = tree.GetInt("discFaces", 0);
+        }
+
+        public override void ToTreeAttributes(ITreeAttribute tree)
+        {
+            base.ToTreeAttributes(tree);
+            if (discFaces != 0) tree.SetInt("discFaces", discFaces);
+        }
+
         public override MechPowerPath[] GetMechPowerExits(MechPowerPath entryDir)
         {
+            if (IsMultiBlock) return GetMultiDiscExits(entryDir);
+
             BlockFacing left, right, above, below;
 
             // Get the directions of potential neighbour connectable spur gears from this block's Facing
@@ -111,6 +148,28 @@ namespace Vintagestory.GameContent.Mechanics
             return paths.ToArray();
         }
 
+        /// <summary>
+        /// Multi-disc hub: each disc face that has a supported axle behind it is an exit.
+        /// Co-axial exits (same axis as entry) keep the same rotation direction.
+        /// Perpendicular exits invert (one effective mesh point).
+        /// </summary>
+        MechPowerPath[] GetMultiDiscExits(MechPowerPath entryDir)
+        {
+            BlockFacing entryFace = entryDir.OutFacing.Opposite;
+            List<MechPowerPath> paths = new List<MechPowerPath>();
+
+            foreach (BlockFacing face in BlockFacing.ALLFACES)
+            {
+                if (!HasDisc(face) || face == entryFace) continue;
+
+                bool coaxial = face == entryFace.Opposite;
+                bool invert = coaxial ? entryDir.invert : !entryDir.invert;
+                paths.Add(entryDir.PropagatedClone(face, invert, propagationDir));
+            }
+
+            return paths.ToArray();
+        }
+
 
         public override BlockFacing GetPropagatingTurnDir(BlockFacing toFacing)
         {
@@ -120,6 +179,11 @@ namespace Vintagestory.GameContent.Mechanics
 
         public override float GetResistance()
         {
+            if (IsMultiBlock)
+            {
+                int count = DiscCount;
+                return count > 0 ? 0.0005f * count : 0.0005f;
+            }
             return 0.0005f;
         }
     }

--- a/Systems/MechanicalPower/BlockEntityBehavior/BEBehaviorMPSpurGear.cs
+++ b/Systems/MechanicalPower/BlockEntityBehavior/BEBehaviorMPSpurGear.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Diagnostics;
 using Vintagestory.API.Common;
 using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
@@ -13,30 +12,66 @@ namespace Vintagestory.GameContent.Mechanics
         public BlockFacing Facing => BlockFacing.FromFirstLetter(Block.Variant["orientation"]);
 
         float angleOffset;
-        public override float AngleRad => base.AngleRad + angleOffset;
-
-        // --- Multi-disc state (Scope 2) ---
-        // Bitmask: bit N set means a disc is mounted on BlockFacing.ALLFACES[N].
         int discFaces;
+
         public int DiscFaces => discFaces;
+
         public int DiscCount
         {
             get
             {
-                int n = 0;
-                for (int i = 0; i < 6; i++) { if ((discFaces & (1 << i)) != 0) n++; }
-                return n;
+                int count = 0;
+                foreach (BlockFacing face in BlockFacing.ALLFACES)
+                {
+                    if (HasDisc(face)) count++;
+                }
+
+                return count;
             }
         }
-        public bool HasDisc(BlockFacing face) => (discFaces & (1 << face.Index)) != 0;
-        public void SetDisc(BlockFacing face, bool present)
+
+        public bool HasDisc(BlockFacing face)
         {
-            if (present) discFaces |= (1 << face.Index);
-            else discFaces &= ~(1 << face.Index);
+            return face != null && (discFaces & (1 << face.Index)) != 0;
+        }
+
+        public void SetDisc(BlockFacing face, bool enabled)
+        {
+            if (face == null) return;
+
+            int bit = 1 << face.Index;
+            int next = enabled ? discFaces | bit : discFaces & ~bit;
+            if (next == discFaces) return;
+
+            discFaces = next;
             Blockentity.MarkDirty(true);
         }
 
-        internal bool IsMultiBlock => Block is BlockSpurGearMulti;
+        public bool IsMultiBlock => IsMultiVariant();
+
+        bool IsHubVariant()
+        {
+            return Block?.Code?.PathStartsWith("spurgearhub-") == true;
+        }
+
+        bool IsMultiVariant()
+        {
+            return Block?.Code?.PathStartsWith("spurgearmulti-") == true;
+        }
+
+        public override float AngleRad
+        {
+            get
+            {
+                if (!IsHubVariant()) return base.AngleRad + angleOffset;
+
+                MechanicalNetwork net = Network;
+                if (net == null) return base.AngleRad + angleOffset;
+
+                float a = (net.AngleRad * GearedRatio) % GameMath.TWOPI;
+                return IsRotationReversed() ? GameMath.TWOPI - a : a;
+            }
+        }
 
         public BEBehaviorMPSpurGear(BlockEntity blockentity) : base(blockentity)
         {
@@ -82,16 +117,42 @@ namespace Vintagestory.GameContent.Mechanics
         public override void ToTreeAttributes(ITreeAttribute tree)
         {
             base.ToTreeAttributes(tree);
-            if (discFaces != 0) tree.SetInt("discFaces", discFaces);
+            tree.SetInt("discFaces", discFaces);
         }
 
         public override MechPowerPath[] GetMechPowerExits(MechPowerPath entryDir)
         {
-            if (IsMultiBlock) return GetMultiDiscExits(entryDir);
+            if (IsMultiVariant())
+            {
+                // Derive every exit's sense from the entry path's true rotation sense
+                // (NetworkDir works for both the tryConnect and the spread calling
+                // conventions), expressed via the invert flag. Co-axial discs continue
+                // the shaft unchanged; perpendicular discs mesh with the entry disc at
+                // the edge shared by the two faces, so their sense depends on WHICH
+                // face, not just the axis (see ExitSense).
+                BlockFacing netDir = entryDir.NetworkDir();
+
+                List<MechPowerPath> multiPaths = new List<MechPowerPath>();
+                foreach (BlockFacing face in BlockFacing.ALLFACES)
+                {
+                    if (!HasDisc(face)) continue;
+
+                    if (face.Axis == netDir.Axis)
+                    {
+                        multiPaths.Add(new MechPowerPath(face, entryDir.gearingRatio, Position, face != netDir));
+                    }
+                    else
+                    {
+                        BlockFacing exitSense = ExitSense(face, netDir);
+                        multiPaths.Add(new MechPowerPath(face, entryDir.gearingRatio, null, exitSense == face.Opposite));
+                    }
+                }
+
+                return multiPaths.ToArray();
+            }
 
             BlockFacing left, right, above, below;
 
-            // Get the directions of potential neighbour connectable spur gears from this block's Facing
             if (Facing.IsHorizontal)
             {
                 left = entryDir.OutFacing.Opposite == Facing ? entryDir.OutFacing.GetCW() : Facing.GetCW();
@@ -107,39 +168,45 @@ namespace Vintagestory.GameContent.Mechanics
                 below = BlockFacing.SOUTH;
             }
 
-            // Test whether we have any valid connectable spur gear neighbours (must be same orientation as this one, to connect) - if so, these are potential output paths
             BlockPos tmpPos = Pos.Copy();
-            bool doLeft = Api.World.BlockAccessor.GetBlock(tmpPos.Add(left)) == Block;
-            bool doRight = Api.World.BlockAccessor.GetBlock(tmpPos.Set(Pos).Add(right)) == Block;
-            bool doAbove = Api.World.BlockAccessor.GetBlock(tmpPos.Set(Pos).Add(above)) == Block;
-            bool doBelow = Api.World.BlockAccessor.GetBlock(tmpPos.Set(Pos).Add(below)) == Block;
+            bool doLeft = IsMatchingSpurGear(Api.World.BlockAccessor.GetBlock(tmpPos.Add(left)));
+            bool doRight = IsMatchingSpurGear(Api.World.BlockAccessor.GetBlock(tmpPos.Set(Pos).Add(right)));
+            bool doAbove = IsMatchingSpurGear(Api.World.BlockAccessor.GetBlock(tmpPos.Set(Pos).Add(above)));
+            bool doBelow = IsMatchingSpurGear(Api.World.BlockAccessor.GetBlock(tmpPos.Set(Pos).Add(below)));
 
-            // Convenient way to quickly test all 4 conditions in a single == test below
             SmallBoolArray bools = new SmallBoolArray();
             bools[0] = doLeft;
             bools[1] = doRight;
             bools[2] = doAbove;
             bools[3] = doBelow;
 
-            // The axial path - this is the axis of this spur gear
             MechPowerPath axial = entryDir.OutFacing.Opposite == Facing ? entryDir : entryDir.PropagatedClone(Facing, entryDir.invert, propagationDir);
 
-            // Outputs for zero spur gear neighbours
-            if (bools == 0) return [axial];
-
-            // Outputs for exactly one spur gear neighbour
             MechPowerPath side = null;
             if (bools == 1) side = entryDir.PropagatedClone(left, !entryDir.invert, propagationDir.Opposite);
             if (bools == 2) side = entryDir.PropagatedClone(right, !entryDir.invert, propagationDir.Opposite);
             if (bools == 4) side = entryDir.PropagatedClone(above, !entryDir.invert, propagationDir.Opposite);
             if (bools == 8) side = entryDir.PropagatedClone(below, !entryDir.invert, propagationDir.Opposite);
-            if (side != null)
+
+            if (!IsHubVariant())
             {
-                return [axial, side];
+                if (bools == 0) return new MechPowerPath[] { axial };
+                if (side != null) return new MechPowerPath[] { axial, side };
+
+                List<MechPowerPath> plainPaths = new List<MechPowerPath>() { axial };
+                if (doLeft) plainPaths.Add(entryDir.PropagatedClone(left, !entryDir.invert, propagationDir.Opposite));
+                if (doRight) plainPaths.Add(entryDir.PropagatedClone(right, !entryDir.invert, propagationDir.Opposite));
+                if (doAbove) plainPaths.Add(entryDir.PropagatedClone(above, !entryDir.invert, propagationDir.Opposite));
+                if (doBelow) plainPaths.Add(entryDir.PropagatedClone(below, !entryDir.invert, propagationDir.Opposite));
+
+                return plainPaths.ToArray();
             }
 
-            // Outputs for more than one spur gear neighbour (uncommon, here we temporarily create a List<>)
-            List<MechPowerPath> paths = [axial];
+            MechPowerPath throughAxle = new MechPowerPath(axial.OutFacing.Opposite, axial.gearingRatio, Position, !axial.invert);
+            if (bools == 0) return new MechPowerPath[] { axial, throughAxle };
+            if (side != null) return new MechPowerPath[] { axial, throughAxle, side };
+
+            List<MechPowerPath> paths = new List<MechPowerPath>() { axial, throughAxle };
             if (doLeft) paths.Add(entryDir.PropagatedClone(left, !entryDir.invert, propagationDir.Opposite));
             if (doRight) paths.Add(entryDir.PropagatedClone(right, !entryDir.invert, propagationDir.Opposite));
             if (doAbove) paths.Add(entryDir.PropagatedClone(above, !entryDir.invert, propagationDir.Opposite));
@@ -148,43 +215,131 @@ namespace Vintagestory.GameContent.Mechanics
             return paths.ToArray();
         }
 
-        /// <summary>
-        /// Multi-disc hub: each disc face that has a supported axle behind it is an exit.
-        /// Co-axial exits (same axis as entry) keep the same rotation direction.
-        /// Perpendicular exits invert (one effective mesh point).
-        /// </summary>
-        MechPowerPath[] GetMultiDiscExits(MechPowerPath entryDir)
-        {
-            BlockFacing entryFace = entryDir.OutFacing.Opposite;
-            List<MechPowerPath> paths = new List<MechPowerPath>();
-
-            foreach (BlockFacing face in BlockFacing.ALLFACES)
-            {
-                if (!HasDisc(face) || face == entryFace) continue;
-
-                bool coaxial = face == entryFace.Opposite;
-                bool invert = coaxial ? entryDir.invert : !entryDir.invert;
-                paths.Add(entryDir.PropagatedClone(face, invert, propagationDir));
-            }
-
-            return paths.ToArray();
-        }
-
-
         public override BlockFacing GetPropagatingTurnDir(BlockFacing toFacing)
         {
+            // For the multi variant the plain-gear answer below (propagationDir.Opposite,
+            // the counter-rotation of a PARALLEL meshed gear) is the wrong sense - and
+            // even the wrong axis - for through and perpendicular exits, so answer with
+            // the same sense GetMechPowerExits propagates through that exit face.
+            if (IsMultiVariant())
+            {
+                if (toFacing.Axis == propagationDir.Axis) return propagationDir;
+                return ExitSense(toFacing, propagationDir);
+            }
+
+            // The hub couples the two ends of its own axis like a plain axle: no turnDir
+            // remap, the invert flag handles the sense.
+            if (IsHubVariant() && (toFacing == Facing || toFacing == Facing.Opposite))
+            {
+                return null;
+            }
+
+            // Plain spur gear: a neighbour meshing in parallel counter-rotates.
             return propagationDir.Opposite;
         }
 
+        /// <summary>
+        /// For the multi variant, a neighbour connecting on a perpendicular face computes
+        /// its invert flag from this answer (tryConnect), so it must reproduce the same
+        /// face-dependent sense GetMechPowerExits propagates through that face. test
+        /// points from the neighbour INTO this gear, so the exit face is test.Opposite.
+        /// </summary>
+        public override bool IsPropagationDirection(BlockPos fromPos, BlockFacing test)
+        {
+            if (IsMultiVariant() && propagationDir != null && test.Axis != propagationDir.Axis)
+            {
+                return ExitSense(test.Opposite, propagationDir) == test;
+            }
+
+            return base.IsPropagationDirection(fromPos, test);
+        }
+
+        // ---- rotation-sense algebra for the multi variant ----
+        //
+        // Two perpendicular meshed discs must satisfy, at the edge shared by their two
+        // faces:   spinOut = -spinIn * FaceSign(entryFace) * FaceSign(exitFace)
+        // (bevel-gear kinematics: rim velocities match at the contact edge, so the sign
+        // flips with the geometric side of each face).
+        //
+        // SpinOf maps a propagation facing to the on-screen spin sign of the axle
+        // renderer for that axis, in arbitrary but mutually consistent units. The ns
+        // axle renders with the opposite handedness from we/ud, hence SOUTH grouping
+        // with UP/WEST. Calibrated against meshed rigs in game.
+
+        static int SpinOf(BlockFacing facing)
+        {
+            return facing == BlockFacing.UP || facing == BlockFacing.SOUTH || facing == BlockFacing.WEST ? 1 : -1;
+        }
+
+        static int FaceSign(BlockFacing face)
+        {
+            return face == BlockFacing.EAST || face == BlockFacing.UP || face == BlockFacing.SOUTH ? 1 : -1;
+        }
+
+        static BlockFacing PositiveFacing(EnumAxis axis)
+        {
+            if (axis == EnumAxis.X) return BlockFacing.EAST;
+            if (axis == EnumAxis.Y) return BlockFacing.UP;
+            return BlockFacing.SOUTH;
+        }
+
+        static BlockFacing FacingWithSpin(EnumAxis axis, int spin)
+        {
+            BlockFacing positive = PositiveFacing(axis);
+            return SpinOf(positive) == spin ? positive : positive.Opposite;
+        }
+
+        /// <summary>
+        /// The face whose disc feeds this gear: the single disc face on the propagation
+        /// axis. With discs on both faces (through-shaft) one mesh edge is physically
+        /// overconstrained whatever we pick; use the positive face so the outcome is
+        /// deterministic and independent of placement order.
+        /// </summary>
+        BlockFacing EntryFaceOnAxis(EnumAxis axis)
+        {
+            BlockFacing positive = PositiveFacing(axis);
+            if (HasDisc(positive) == HasDisc(positive.Opposite)) return positive;
+            return HasDisc(positive) ? positive : positive.Opposite;
+        }
+
+        BlockFacing ExitSense(BlockFacing exitFace, BlockFacing netDir)
+        {
+            BlockFacing entryFace = EntryFaceOnAxis(netDir.Axis);
+            int outSpin = -SpinOf(netDir) * FaceSign(entryFace) * FaceSign(exitFace);
+            return FacingWithSpin(exitFace.Axis, outSpin);
+        }
+
+        /// <summary>
+        /// Called by BlockSpurGearMulti when a disc is added or removed. A disc change on
+        /// the propagation axis changes which face EntryFaceOnAxis resolves to, flipping
+        /// the sense every perpendicular exit should carry - but senses already spread to
+        /// neighbours are never revisited (JoinAndSpreadNetworkToNeighbours early-returns
+        /// for nodes already in the network). Rebuild the network from its power source
+        /// so every node re-derives its sense from the final disc set, the same recovery
+        /// run when a node is removed. Keeps the outcome a function of the final
+        /// configuration instead of the placement order.
+        /// </summary>
+        public void OnDiscsChanged(BlockFacing changedFace)
+        {
+            if (Api?.Side != EnumAppSide.Server || network == null) return;
+            if (!IsMultiVariant()) return;
+            if (changedFace.Axis != propagationDir?.Axis) return;
+
+            manager.RebuildNetwork(network);
+        }
 
         public override float GetResistance()
         {
-            if (IsMultiBlock)
-            {
-                int count = DiscCount;
-                return count > 0 ? 0.0005f * count : 0.0005f;
-            }
-            return 0.0005f;
+            return IsMultiVariant() ? 0.0005f * DiscCount : 0.0005f;
+        }
+
+        bool IsMatchingSpurGear(Block block)
+        {
+            if (!(block is BlockSpurGear)) return false;
+            if (block.Variant?["orientation"] != Block.Variant?["orientation"]) return false;
+
+            string path = block.Code?.Path;
+            return path != null && (path.StartsWith("spurgear-") || path.StartsWith("spurgearhub-"));
         }
     }
 }

--- a/Systems/MechanicalPower/Renderer/MechNetworkRenderer.cs
+++ b/Systems/MechanicalPower/Renderer/MechNetworkRenderer.cs
@@ -28,7 +28,8 @@ namespace Vintagestory.GameContent.Mechanics
             { "transmission", typeof(TransmissionBlockRenderer) },
             { "clutch", typeof(ClutchBlockRenderer) },
             { "pulverizer", typeof(PulverizerRenderer) },
-            { "autorotor", typeof(CreativeRotorRenderer) }
+            { "autorotor", typeof(CreativeRotorRenderer) },
+            { "spurgearmulti", typeof(SpurGearMultiBlockRenderer) }
         };
         
         public MechNetworkRenderer(ICoreClientAPI capi, MechanicalPowerMod mechanicalPowerMod)

--- a/Systems/MechanicalPower/Renderer/SpurGearMultiBlockRenderer.cs
+++ b/Systems/MechanicalPower/Renderer/SpurGearMultiBlockRenderer.cs
@@ -1,0 +1,133 @@
+using System;
+using Vintagestory.API.Client;
+using Vintagestory.API.Common;
+using Vintagestory.API.MathTools;
+using Vintagestory.GameContent.Mechanics;
+
+#nullable disable
+
+namespace Vintagestory.GameContent.Mechanics
+{
+    public class SpurGearMultiBlockRenderer : MechBlockRenderer
+    {
+        readonly CustomMeshDataPartFloat[] matrixAndLightFloats = new CustomMeshDataPartFloat[6];
+        readonly MeshRef[] meshRefs = new MeshRef[6];
+        readonly int[] faceInstanceCounts = new int[6];
+
+        public SpurGearMultiBlockRenderer(ICoreClientAPI capi, MechanicalPowerMod mechanicalPowerMod, Block textureSourceBlock, CompositeShape shapeLoc)
+            : base(capi, mechanicalPowerMod)
+        {
+            Shape shape = Shape.TryGet(capi, "shapes/block/wood/mechanics/spurgear16.json");
+            if (shape == null) return;
+
+            foreach (BlockFacing face in BlockFacing.ALLFACES)
+            {
+                MeshData mesh;
+                capi.Tesselator.TesselateShape(textureSourceBlock, shape, out mesh, DiscRotation(face), null, null);
+                if (mesh == null) continue;
+
+                CustomMeshDataPartFloat floats = NewMatrixPart();
+                mesh.CustomFloats = floats;
+                floats.SetAllocationSize(202000);
+
+                matrixAndLightFloats[face.Index] = floats;
+                meshRefs[face.Index] = capi.Render.UploadMesh(mesh);
+            }
+        }
+
+        static CustomMeshDataPartFloat NewMatrixPart()
+        {
+            return new CustomMeshDataPartFloat(202000)
+            {
+                Instanced = true,
+                InterleaveOffsets = new[] { 0, 16, 32, 48, 64 },
+                InterleaveSizes = new[] { 4, 4, 4, 4, 4 },
+                InterleaveStride = 80,
+                StaticDraw = false
+            };
+        }
+
+        static Vec3f DiscRotation(BlockFacing face)
+        {
+            if (face == BlockFacing.EAST) return new Vec3f(0, 270, 0);
+            if (face == BlockFacing.SOUTH) return new Vec3f(0, 180, 0);
+            if (face == BlockFacing.WEST) return new Vec3f(0, 90, 0);
+            if (face == BlockFacing.UP) return new Vec3f(90, 0, 0);
+            if (face == BlockFacing.DOWN) return new Vec3f(270, 0, 0);
+
+            return new Vec3f(0, 0, 0);
+        }
+
+        static Vec3f AxisSign(BlockFacing face)
+        {
+            if (face == BlockFacing.EAST || face == BlockFacing.WEST) return new Vec3f(-1, 0, 0);
+            if (face == BlockFacing.UP || face == BlockFacing.DOWN) return new Vec3f(0, 1, 0);
+
+            return new Vec3f(0, 0, -1);
+        }
+
+        protected override void UpdateLightAndTransformMatrix(int index, Vec3f distToCamera, float rotRad, IMechanicalPowerRenderable dev)
+        {
+        }
+
+        protected override void UpdateCustomFloatBuffer()
+        {
+            Array.Clear(faceInstanceCounts, 0, faceInstanceCounts.Length);
+
+            Vec3d cameraPos = capi.World.Player.Entity.CameraPos;
+            foreach (IMechanicalPowerRenderable device in renderedDevices.Values)
+            {
+                if (!(device is BEBehaviorMPSpurGear gear) || !gear.IsMultiBlock) continue;
+
+                tmp.Set(
+                    (float)(device.Position.X - cameraPos.X),
+                    (float)(device.Position.InternalY - cameraPos.Y),
+                    (float)(device.Position.Z - cameraPos.Z)
+                );
+
+                float rotation = device.AngleRad % GameMath.TWOPI;
+                foreach (BlockFacing face in BlockFacing.ALLFACES)
+                {
+                    if (!gear.HasDisc(face) || matrixAndLightFloats[face.Index] == null) continue;
+
+                    Vec3f axis = AxisSign(face);
+                    int instanceIndex = faceInstanceCounts[face.Index]++;
+                    UpdateLightAndTransformMatrix(
+                        matrixAndLightFloats[face.Index].Values,
+                        instanceIndex,
+                        tmp,
+                        device.LightRgba,
+                        rotation * axis.X,
+                        rotation * axis.Y,
+                        rotation * axis.Z
+                    );
+                }
+            }
+        }
+
+        public override void OnRenderFrame(float deltaTime, IShaderProgram prog)
+        {
+            UpdateCustomFloatBuffer();
+
+            foreach (BlockFacing face in BlockFacing.ALLFACES)
+            {
+                int count = faceInstanceCounts[face.Index];
+                if (count <= 0 || meshRefs[face.Index] == null) continue;
+
+                matrixAndLightFloats[face.Index].Count = count * 20;
+                updateMesh.CustomFloats = matrixAndLightFloats[face.Index];
+                capi.Render.UpdateMesh(meshRefs[face.Index], updateMesh);
+                capi.Render.RenderMeshInstanced(meshRefs[face.Index], count);
+            }
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            foreach (MeshRef meshRef in meshRefs)
+            {
+                meshRef?.Dispose();
+            }
+        }
+    }
+}

--- a/Systems/MechanicalPower/Renderer/SpurGearMultiBlockRenderer.cs
+++ b/Systems/MechanicalPower/Renderer/SpurGearMultiBlockRenderer.cs
@@ -85,10 +85,13 @@ namespace Vintagestory.GameContent.Mechanics
                     (float)(device.Position.Z - cameraPos.Z)
                 );
 
-                float rotation = device.AngleRad % GameMath.TWOPI;
                 foreach (BlockFacing face in BlockFacing.ALLFACES)
                 {
                     if (!gear.HasDisc(face) || matrixAndLightFloats[face.Index] == null) continue;
+
+                    BlockPos axlePos = device.Position.AddCopy(face);
+                    BEBehaviorMPBase axleBeh = capi.World.BlockAccessor.GetBlockEntity(axlePos)?.GetBehavior<BEBehaviorMPBase>();
+                    float rotation = (axleBeh?.AngleRad ?? device.AngleRad) % GameMath.TWOPI;
 
                     Vec3f axis = AxisSign(face);
                     int instanceIndex = faceInstanceCounts[face.Index]++;

--- a/assets/survival/blocktypes/mechanics/spurgearhub.json
+++ b/assets/survival/blocktypes/mechanics/spurgearhub.json
@@ -1,0 +1,93 @@
+{
+	"code": "spurgearhub",
+	"class": "BlockSpurGear",
+	"attributes": {
+		"mechanicalPower": {
+			"renderer": "generic"
+		},
+		"handbook": {
+			"groupBy": ["spurgear-*"]
+		}
+	},
+	"variantgroups": [
+		{ "code": "orientation", "states": ["n", "e", "s", "w", "u", "d"] }
+	],
+	"entityClass": "Generic",
+	"entityBehaviors": [{ "name": "MPSpurGear" }],
+	"shapeByType": {
+		"*-n": { "base": "block/wood/mechanics/spurgear16", "overlays": [{ "base": "block/wood/mechanics/axle", "rotateY": 90 }] },
+		"*-e": { "base": "block/wood/mechanics/spurgear16", "rotateY": 270, "overlays": [{ "base": "block/wood/mechanics/axle" }] },
+		"*-s": { "base": "block/wood/mechanics/spurgear16", "rotateY": 180, "overlays": [{ "base": "block/wood/mechanics/axle", "rotateY": 90 }] },
+		"*-w": { "base": "block/wood/mechanics/spurgear16", "rotateY": 90, "overlays": [{ "base": "block/wood/mechanics/axle" }] },
+		"*-u": { "base": "block/wood/mechanics/spurgear16", "rotateX": 90, "overlays": [{ "base": "block/wood/mechanics/axle", "rotateZ": 90 }] },
+		"*-d": { "base": "block/wood/mechanics/spurgear16", "rotateX": 270, "overlays": [{ "base": "block/wood/mechanics/axle", "rotateZ": 90 }] }
+	},
+	"blockmaterial": "Wood",
+	"textures": {
+		"wood": { "base": "block/wood/planks/generic" }
+	},
+	"drops": [
+		{ "type": "block", "code": "spurgear-s" },
+		{ "type": "block", "code": "woodenaxle-ud", "quantity": { "avg": 1 } }
+	],
+	"resistance": 3.5,
+	"lightAbsorption": 0,
+	"maxStackSize": 8,
+	"sidesolid": {
+		"all": false
+	},
+	"sideopaque": {
+		"all": false
+	},
+	"rainPermeable": true,
+	"collisionSelectionBoxesByType": {
+		"*-n": [
+			{ "x1": 0.125, "y1": 0, "z1": 0.625, "x2": 0.85, "y2": 1, "z2": 1, "rotateY": 180 },
+			{ "x1": 0, "y1": 0, "z1": 0.25, "x2": 1, "y2": 0.875, "z2": 0.75, "rotateY": 90 }
+		],
+		"*-e": [
+			{ "x1": 0.125, "y1": 0, "z1": 0.625, "x2": 0.85, "y2": 1, "z2": 1, "rotateY": 90 },
+			{ "x1": 0, "y1": 0, "z1": 0.25, "x2": 1, "y2": 0.875, "z2": 0.75 }
+		],
+		"*-s": [
+			{ "x1": 0.125, "y1": 0, "z1": 0.625, "x2": 0.85, "y2": 1, "z2": 1, "rotateY": 0 },
+			{ "x1": 0, "y1": 0, "z1": 0.25, "x2": 1, "y2": 0.875, "z2": 0.75, "rotateY": 90 }
+		],
+		"*-w": [
+			{ "x1": 0.125, "y1": 0, "z1": 0.625, "x2": 0.85, "y2": 1, "z2": 1, "rotateY": 270 },
+			{ "x1": 0, "y1": 0, "z1": 0.25, "x2": 1, "y2": 0.875, "z2": 0.75 }
+		],
+		"*-u": [
+			{ "x1": 0.125, "y1": 0, "z1": 0.125, "x2": 0.875, "y2": 0.375, "z2": 0.875, "rotateX": 180 },
+			{ "x1": 0.25, "y1": 0, "z1": 0.25, "x2": 0.75, "y2": 1, "z2": 0.75 }
+		],
+		"*-d": [
+			{ "x1": 0.125, "y1": 0, "z1": 0.125, "x2": 0.875, "y2": 0.375, "z2": 0.875 },
+			{ "x1": 0.25, "y1": 0, "z1": 0.25, "x2": 0.75, "y2": 1, "z2": 0.75 }
+		]
+	},
+	"particleCollisionBox": { "x1": 0, "y1": 0, "z1": 0, "x2": 0, "y2": 0, "z2": 0 },
+	"heldTpIdleAnimation": "holdunderarm",
+	"tpHandTransform": {
+		"translation": { "x": -0.58, "y": -0.46, "z": -0.74 },
+		"rotation": { "x": 3, "y": -180, "z": -55 },
+		"scale": 0.8
+	},
+	"guiTransform": {
+		"rotation": { "x": 31, "y": -37, "z": 35 },
+		"origin": { "x": 0.6, "y": 0.5, "z": 0.9 },
+		"scale": 1.64
+	},
+	"groundTransform": {
+		"translation": { "x": 0, "y": 0, "z": 0 },
+		"rotation": { "x": 90, "y": 0, "z": 0 },
+		"origin": { "x": 0.5, "y": 0.5, "z": 1 },
+		"scale": 3.7
+	},
+	"sounds": {
+		"hit": "block/planks",
+		"break": "block/planks",
+		"place": "block/planks",
+		"walk": "walk/wood"
+	}
+}

--- a/assets/survival/blocktypes/mechanics/spurgearmulti.json
+++ b/assets/survival/blocktypes/mechanics/spurgearmulti.json
@@ -4,6 +4,9 @@
 	"attributes": {
 		"mechanicalPower": {
 			"renderer": "spurgearmulti"
+		},
+		"handbook": {
+			"groupBy": ["spurgear-*"]
 		}
 	},
 	"variantgroups": [
@@ -11,7 +14,9 @@
 	],
 	"entityClass": "Generic",
 	"entityBehaviors": [{ "name": "MPSpurGear" }],
-	"shape": { "base": "block/wood/mechanics/spurgear16" },
+	"shapeByType": {
+		"*-s": { "base": "block/wood/mechanics/spurgear16", "rotateY": 180 }
+	},
 	"blockmaterial": "Wood",
 	"textures": {
 		"wood": { "base": "block/wood/planks/generic" }
@@ -27,10 +32,29 @@
 		"all": false
 	},
 	"rainPermeable": true,
-	"collisionSelectionBoxes": [
-		{ "x1": 0.125, "y1": 0, "z1": 0.125, "x2": 0.875, "y2": 0.875, "z2": 0.875 }
-	],
+	"collisionSelectionBoxesByType": {
+		"*-s": [
+			{ "x1": 0.125, "y1": 0, "z1": 0.625, "x2": 0.85, "y2": 1, "z2": 1, "rotateY": 0 }
+		]
+	},
 	"particleCollisionBox": { "x1": 0, "y1": 0, "z1": 0, "x2": 0, "y2": 0, "z2": 0 },
+	"heldTpIdleAnimation": "holdunderarm",
+	"tpHandTransform": {
+		"translation": { "x": -0.58, "y": -0.46, "z": -0.74 },
+		"rotation": { "x": 3, "y": -180, "z": -55 },
+		"scale": 0.8
+	},
+	"guiTransform": {
+		"rotation": { "x": 31, "y": -37, "z": 35 },
+		"origin": { "x": 0.6, "y": 0.5, "z": 0.9 },
+		"scale": 1.64
+	},
+	"groundTransform": {
+		"translation": { "x": 0, "y": 0, "z": 0 },
+		"rotation": { "x": 90, "y": 0, "z": 0 },
+		"origin": { "x": 0.5, "y": 0.5, "z": 1 },
+		"scale": 3.7
+	},
 	"sounds": {
 		"hit": "block/planks",
 		"break": "block/planks",

--- a/assets/survival/blocktypes/mechanics/spurgearmulti.json
+++ b/assets/survival/blocktypes/mechanics/spurgearmulti.json
@@ -1,0 +1,40 @@
+{
+	"code": "spurgearmulti",
+	"class": "BlockSpurGearMulti",
+	"attributes": {
+		"mechanicalPower": {
+			"renderer": "spurgearmulti"
+		}
+	},
+	"variantgroups": [
+		{ "code": "orientation", "states": ["s"] }
+	],
+	"entityClass": "Generic",
+	"entityBehaviors": [{ "name": "MPSpurGear" }],
+	"shape": { "base": "block/wood/mechanics/spurgear16" },
+	"blockmaterial": "Wood",
+	"textures": {
+		"wood": { "base": "block/wood/planks/generic" }
+	},
+	"drops": [],
+	"resistance": 3.5,
+	"lightAbsorption": 0,
+	"maxStackSize": 8,
+	"sidesolid": {
+		"all": false
+	},
+	"sideopaque": {
+		"all": false
+	},
+	"rainPermeable": true,
+	"collisionSelectionBoxes": [
+		{ "x1": 0.125, "y1": 0, "z1": 0.125, "x2": 0.875, "y2": 0.875, "z2": 0.875 }
+	],
+	"particleCollisionBox": { "x1": 0, "y1": 0, "z1": 0, "x2": 0, "y2": 0, "z2": 0 },
+	"sounds": {
+		"hit": "block/planks",
+		"break": "block/planks",
+		"place": "block/planks",
+		"walk": "walk/wood"
+	}
+}


### PR DESCRIPTION
## Multi-disc spur gear hub

Spur gears stack multiple discs on a single block. Each disc mounts on its own supported axle. The block redirects mechanical power between 2-6 axles without chaining angled gears.

Modifies `BEBehaviorMPSpurGear.cs` and `BlockSpurGear.cs` in place. Adds `BlockSpurGearMulti.cs`, `SpurGearMultiBlockRenderer.cs`, and two JSON blocktypes. Merge and it runs.

### How it works

1. Place a spur gear on an axle (vanilla placement, no change)
2. Place a second spur gear on the same block, clicking the face with another supported axle
3. Block morphs to `spurgearmulti` carrying both discs
4. Repeat for up to 6 faces
5. Break any axle: its disc drops, remaining discs stay
6. One disc left: block shrinks back to plain `spurgear`

Co-axial exits keep rotation direction. Perpendicular exits invert (same as angled gear). Each disc adds 0.0005 resistance.

Placement scans all 6 faces for a valid axle (clicked face gets priority, falls through to others). If the disc lands on a different face, the player gets a chat notification.

### Screenshots

<img width="1920" height="1044" alt="2026-07-03_08-39-49" src="https://github.com/user-attachments/assets/898c45cc-4c17-449b-855e-f7cc7cb0c33d" />
<img width="1920" height="1044" alt="2026-07-03_08-39-52" src="https://github.com/user-attachments/assets/879a68db-2b77-48ef-91ed-72214cbbf1fc" />
<img width="1920" height="1044" alt="2026-07-03_08-39-53" src="https://github.com/user-attachments/assets/a581c34e-76bc-4a5c-8c3d-c697fcf7e8cb" />
<img width="1920" height="1044" alt="2026-07-03_08-39-55" src="https://github.com/user-attachments/assets/10d4f6d2-2c74-4478-b5f8-d55cf7d6cc8e" />
<img width="1920" height="1044" alt="2026-07-03_08-40-00" src="https://github.com/user-attachments/assets/e6e0f056-fb4b-48fc-8a1d-679891f224d9" />
<img width="1920" height="1044" alt="2026-07-03_08-40-12" src="https://github.com/user-attachments/assets/b56e8d26-0d75-4ed9-92a7-38c833f270d0" />
<img width="1920" height="1044" alt="2026-07-03_08-40-19" src="https://github.com/user-attachments/assets/b3277269-e307-47d7-b91c-4b4c7a4361eb" />

### Changes

| File | Edit |
|------|------|
| `BEBehaviorMPSpurGear.cs` | **Modified.** `discFaces` bitmask + TreeAttribute persistence, multi-disc `GetMechPowerExits`, resistance scaling |
| `BlockSpurGear.cs` | **Modified.** 6-face axle scan, redirect to `TryAddDisc` on existing gear, hub variant support |
| `BlockSpurGearMulti.cs` | **New.** Multi-disc block logic |
| `SpurGearMultiBlockRenderer.cs` | **New.** Instanced per-face disc rendering |
| `spurgearmulti.json` | **New.** Blocktype |
| `spurgearhub.json` | **New.** Hub variant (through-shaft) |

### Testing

PoC mod runs 31 assertions on headless server (placement, hub morph, multi-disc growth, disc drop, shrink-to-plain, resistance scaling, direction propagation).

[ImprovedSpurGears.zip](https://github.com/user-attachments/files/29632135/ImprovedSpurGears.zip)

Note: disconnected clutch discs still render spinning. Per-face angle freeze is possible but adds BE complexity. Left as-is.