### PR TITLE
Fix crash when rendering pie with an invalid size

### DIFF
--- a/Systems/Cooking/MealMeshCache.cs
+++ b/Systems/Cooking/MealMeshCache.cs
@@ -163,6 +163,7 @@ namespace Vintagestory.GameContent
             contentStacks = nowTesselatingBlock.GetContents(capi!.World, pieStack);
 
             int pieSize = pieStack?.Attributes.GetAsInt("pieSize") ?? 0;
+            if (pieSize <= 0 || pieSize > 4) return null; // Prevent bad array access crash for pies with invalid sizes.
 
 
             // At this spot we have to determine the textures for "dough" and "filling"


### PR DESCRIPTION
Prevents out-of-bounds indexing into `pieShapeBySize`.