### PR TITLE
Optimization of the microblock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 obj
 bin
+/.vs

--- a/Systems/Microblock/BEBehaviorMicroblockSnowCover.cs
+++ b/Systems/Microblock/BEBehaviorMicroblockSnowCover.cs
@@ -1,9 +1,11 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 #nullable disable
 
@@ -67,6 +69,7 @@ namespace Vintagestory.GameContent
 
         CuboidWithMaterial[] aboveCuboids = null;
 
+
         void buildSnowCuboids(BoolArray16x16x16 Voxels)
         {
             List<uint> snowCuboids = new List<uint>();
@@ -75,40 +78,38 @@ namespace Vintagestory.GameContent
             var aboveBe = Api?.World.BlockAccessor.GetBlockEntity(Pos.UpCopy()) as BlockEntityMicroBlock;
             CuboidWithMaterial[] newAboveCuboids = null;
 
-           
-            bool[,] snowVoxelVisited = new bool[16, 16];
+            // Replaced bool[16,16] heap allocation with stackalloc Span<bool> to avoid per-call GC pressure.
+            // Also flattened the 2D voxel/visited access into single-dimension indices for better cache locality.
+            Span<bool> snowVoxelVisited = stackalloc bool[256];
 
             for (int dy = 15; dy >= 0; dy--)
             {
+                int yOffset = dy * 16; // flat index base for the entire Y plane within Voxels
+
                 for (int dx = 0; dx < 16; dx++)
                 {
+                    int flatBase = dx * 256 + yOffset;     // base for Voxels.GetFlat(flatBase + dz)
+                    int visitedRowBase = dx * 16;           // base for snowVoxelVisited[dx*16+dz]
+
                     for (int dz = 0; dz < 16; dz++)
                     {
-                        if (snowVoxelVisited[dx, dz]) continue;
-                        bool ground = dy == 0 && !Voxels[dx, dy, dz];
-                        bool search = ground || Voxels[dx, dy, dz];
+                        int visitedIdx = visitedRowBase + dz;
+                        if (snowVoxelVisited[visitedIdx]) continue;
+
+                        bool voxelHere = Voxels.GetFlat(flatBase + dz);
+                        bool ground = dy == 0 && !voxelHere;
+                        bool search = ground || voxelHere;
 
                         if (!search) continue;
 
-                        if (dy == 15)
+                        if (dy == 15 && aboveBe != null && newAboveCuboids == null)
                         {
-                            if (aboveBe != null)
+                            newAboveCuboids = new CuboidWithMaterial[aboveBe.VoxelCuboids.Count];
+                            for (int i = 0; i < newAboveCuboids.Length; i++)
                             {
-                                if (newAboveCuboids == null)
-                                {
-                                    newAboveCuboids = new CuboidWithMaterial[aboveBe.VoxelCuboids.Count];
-                                    for (int i = 0; i < newAboveCuboids.Length; i++)
-                                    {
-                                        BlockEntityMicroBlock.FromUint(aboveBe.VoxelCuboids[i], newAboveCuboids[i] = new CuboidWithMaterial());
-                                    }
-                                }
-
-                                for (int i = 0; i < newAboveCuboids.Length; i++)
-                                {
-                                    if (newAboveCuboids[i].Contains(dx, dy, dz)) continue;
-                                }
+                                BlockEntityMicroBlock.FromUint(aboveBe.VoxelCuboids[i], newAboveCuboids[i] = new CuboidWithMaterial());
                             }
-
+                            // removed the now-empty loop that iterated aboveCuboids and called Contains() without using the result
                         }
 
                         CuboidWithMaterial cub = new CuboidWithMaterial()
@@ -122,7 +123,6 @@ namespace Vintagestory.GameContent
                             Z2 = dz + 0
                         };
 
-                        // Try grow this cuboid for as long as we can
                         bool didGrowAny = true;
                         while (didGrowAny)
                         {
@@ -137,7 +137,7 @@ namespace Vintagestory.GameContent
                         {
                             for (int x = cub.X1; x < cub.X2; x++)
                             {
-                                snowVoxelVisited[x, z] = true;
+                                snowVoxelVisited[x * 16 + z] = true; // flat index instead of [x, z]
                             }
                         }
 
@@ -189,38 +189,59 @@ namespace Vintagestory.GameContent
 
         #region Snowgrow
 
-        protected bool TrySnowableSurfaceGrowX(CuboidWithMaterial cub, BoolArray16x16x16 voxels, bool[,] voxelVisited, bool ground)
+        // Replaced bool[,] voxelVisited with Span<bool> to match stackalloc allocation in buildSnowCuboids.
+        // Also switched from multi-dimensional Voxels[x,y,z] to flat GetFlat(idx) access for better memory layout.
+        protected bool TrySnowableSurfaceGrowX(CuboidWithMaterial cub, BoolArray16x16x16 voxels, Span<bool> voxelVisited, bool ground)
         {
             if (cub.X2 > 15) return false;
 
+            int x2 = cub.X2;
+            int xBase = x2 * 256;
+            int yOffset = cub.Y1 * 16;
+            int aboveLen = aboveCuboids?.Length ?? 0;
+
             for (int z = cub.Z1; z < cub.Z2; z++)
             {
-                z = Math.Min(15, z);
-                if (aboveCuboids != null)
+                int zz = Math.Min(15, z);
+
+                if (aboveLen > 0)
                 {
-                    for (int i = 0; i < aboveCuboids.Length; i++) if (aboveCuboids[i].Contains(cub.X2, 0, z)) return false;
+                    for (int i = 0; i < aboveLen; i++) if (aboveCuboids[i].Contains(x2, 0, zz)) return false;
                 }
 
-                if (voxels[cub.X2, cub.Y1, z] == ground || voxelVisited[cub.X2, z] || (cub.Y1 < 15 && voxels[cub.X2, cub.Y1 + 1, z])) return false;
+                int idx = xBase + yOffset + zz; // flat index instead of voxels[x2, cub.Y1, z]
+                if (voxels.GetFlat(idx) == ground
+                    || voxelVisited[x2 * 16 + zz]       // flat visited access
+                    || (cub.Y1 < 15 && voxels.GetFlat(idx + 16))) // Y+1 is just +16 in flat layout
+                    return false;
             }
 
             cub.X2++;
             return true;
         }
 
-        protected bool TrySnowableSurfaceGrowZ(CuboidWithMaterial cub, BoolArray16x16x16 voxels, bool[,] voxelVisited, bool ground)
+        protected bool TrySnowableSurfaceGrowZ(CuboidWithMaterial cub, BoolArray16x16x16 voxels, Span<bool> voxelVisited, bool ground) // Span<bool> instead of bool[,]
         {
             if (cub.Z2 > 15) return false;
 
+            int z2 = cub.Z2;
+            int yOffset = cub.Y1 * 16;
+            int aboveLen = aboveCuboids?.Length ?? 0;
+
             for (int x = cub.X1; x < cub.X2; x++)
             {
-                x = Math.Min(15, x);
-                if (aboveCuboids != null)
+                int xx = Math.Min(15, x);
+
+                if (aboveLen > 0)
                 {
-                    for (int i = 0; i < aboveCuboids.Length; i++) if (aboveCuboids[i].Contains(x, 0, cub.Z2)) return false;
+                    for (int i = 0; i < aboveLen; i++) if (aboveCuboids[i].Contains(xx, 0, z2)) return false;
                 }
 
-                if (voxels[x, cub.Y1, cub.Z2] == ground || voxelVisited[x, cub.Z2] || (cub.Y1 < 15 && voxels[x, cub.Y1 + 1, cub.Z2])) return false;
+                int idx = xx * 256 + yOffset + z2; //flat index instead of voxels[x, cub.Y1, cub.Z2]
+                if (voxels.GetFlat(idx) == ground
+                    || voxelVisited[xx * 16 + z2]       // flat visited access
+                    || (cub.Y1 < 15 && voxels.GetFlat(idx + 16))) // Y+1 is just +16 in flat layout
+                    return false;
             }
 
             cub.Z2++;

--- a/Systems/Microblock/BEMicroBlock.cs
+++ b/Systems/Microblock/BEMicroBlock.cs
@@ -52,7 +52,7 @@ namespace Vintagestory.GameContent
 
             var shape = be.GenShape();
             var text = JsonUtil.ToPrettyString<Shape>(shape);
-            text = 
+            text =
                 text
                 .Replace("Textures", "textures")
                 .Replace("Elements", "elements")
@@ -87,6 +87,20 @@ namespace Vintagestory.GameContent
         private static Cuboidf[] noSelectionBox = Array.Empty<Cuboidf>();
         private static byte[] singleByte255 = new byte[] { 255 };
         private static Vec3f centerBase = new Vec3f(0.5f, 0, 0.5f);
+
+
+        // ThreadLocal for BoolArray, byte[,,] and VoxelVisited — avoid new on every RebuildCuboidList; fixed uint[] buffer 4096 for cuboids (max 16³)
+        protected static readonly ThreadLocal<BoolArray16x16x16> RebuildVoxelsTL =
+            new ThreadLocal<BoolArray16x16x16>(() => new BoolArray16x16x16());
+        protected static readonly ThreadLocal<byte[,,]> RebuildMaterialsTL =
+            new ThreadLocal<byte[,,]>(() => new byte[16, 16, 16]);
+        protected static readonly ThreadLocal<BoolArray16x16x16> VoxelVisitedTL =
+            new ThreadLocal<BoolArray16x16x16>(() => new BoolArray16x16x16());
+
+        // Fixed buffer for cuboids (max 16*16*16 = 4096)
+        protected static ThreadLocal<uint[]> cuboidBufferTL = new ThreadLocal<uint[]>(() => new uint[4096]);
+        protected static uint[] CuboidBuffer => cuboidBufferTL.Value;
+
 
         // bits 0..3 = xmin
         // bits 4..7 = xmax
@@ -178,9 +192,9 @@ namespace Vintagestory.GameContent
                         block.Textures.TryGetValue("all", out ctex);
                     }
 
-                    shape.Textures[texCode] = ctex.Base.Path.Replace("*","1");
+                    shape.Textures[texCode] = ctex.Base.Path.Replace("*", "1");
 
-                    elem.Faces[facing.Code] = new ShapeElementFace() { Texture = texCode, Uv = new float[4] { 0,0,16,16 } };
+                    elem.Faces[facing.Code] = new ShapeElementFace() { Texture = texCode, Uv = new float[4] { 0, 0, 16, 16 } };
                 }
 
 #pragma warning restore CS0618
@@ -379,9 +393,10 @@ namespace Vintagestory.GameContent
         {
             base.GetBlockInfo(forPlayer, dsc);
 
-            
-            if (BlockName?.IndexOf('\n') > 0) {
-                dsc.AppendLine(Lang.Get(BlockName.Substring(BlockName.IndexOf('\n') + 1))); 
+
+            if (BlockName?.IndexOf('\n') > 0)
+            {
+                dsc.AppendLine(Lang.Get(BlockName.Substring(BlockName.IndexOf('\n') + 1)));
             }
             else
             {
@@ -474,27 +489,47 @@ namespace Vintagestory.GameContent
 
         public void ConvertToVoxels(out BoolArray16x16x16 voxels, out byte[,,] materials)
         {
-            voxels = new BoolArray16x16x16();
-            materials = new byte[16, 16, 16];
+
+            // instead of new BoolArray/byte[][] we use ThreadLocal + Span<byte> for flat addressing of byte[,,]; SetRangeTrue/Fill instead of nested loops
+            voxels = RebuildVoxelsTL.Value;
+            voxels.Clear();
+            materials = RebuildMaterialsTL.Value;
+            Array.Clear(materials, 0, 16 * 16 * 16); // clear stale data from previous block entities on this thread
+
+
+            // byte[,,] in .NET is stored contiguously in memory (row-major),
+            // so it's safe to get a flat Span and work with it as byte[4096].
+            // This removes 3D addressing (multiplications + 3 bounds checks) per element.
+            Span<byte> flatMaterials = MemoryMarshal.CreateSpan(ref materials[0, 0, 0], 16 * 16 * 16);
+
             CuboidWithMaterial cwm = tmpCuboids[0];
 
-            for (int i = 0; i < VoxelCuboids.Count; i++)
+            List<uint> list = VoxelCuboids;
+            int count = list.Count;
+
+            for (int i = 0; i < count; i++)
             {
-                FromUint(VoxelCuboids[i], cwm);
+                FromUint(list[i], cwm);
+
+                int lenZ = cwm.Z2 - cwm.Z1;
+                byte material = cwm.Material;
 
                 for (int dx = cwm.X1; dx < cwm.X2; dx++)
                 {
+                    int baseX = dx * 256; // 16*16
+
                     for (int dy = cwm.Y1; dy < cwm.Y2; dy++)
                     {
-                        for (int dz = cwm.Z1; dz < cwm.Z2; dz++)
-                        {
-                            voxels[dx, dy, dz] = true;
-                            materials[dx, dy, dz] = cwm.Material;
-                        }
+                        int baseIndex = baseX + dy * 16 + cwm.Z1;
+
+                        // instead of lenZ individual assignments, one mass call for the entire Z-bar
+                        voxels.SetRangeTrue(baseIndex, lenZ);
+                        flatMaterials.Slice(baseIndex, lenZ).Fill(material);
                     }
                 }
             }
         }
+
 
         public void RebuildCuboidList()
         {
@@ -770,106 +805,109 @@ namespace Vintagestory.GameContent
             MarkDirty(true);
         }
 
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        // VoxelVisited from ThreadLocal instead of new; Span<byte> flatMat instead of 3D addressing of VoxelMaterial; GetFlat/SetFlatTrue instead of indexers; CuboidBuffer[cuboidCount++] instead of List.Add; optimized bounds checking (isWest/isEast/xCenter/yCenter)
         protected void RebuildCuboidList(BoolArray16x16x16 Voxels, byte[,,] VoxelMaterial)
         {
-            BoolArray16x16x16 VoxelVisited = new BoolArray16x16x16();
+            BoolArray16x16x16 VoxelVisited = VoxelVisitedTL.Value;
+            VoxelVisited.Clear();
+
             int prevEmitSideAo = emitSideAo;
             emitSideAo = 0x3F;
             sidecenterSolid = new SmallBoolArray(SmallBoolArray.OnAllSides);
             float voxelCount = 0;
-
-            // And now let's rebuild the cuboids with some greedy search algo thing
-            List<uint> voxelCuboids = new List<uint>();
+            int cuboidCount = 0;
+            CuboidWithMaterial cub = tmpCuboids[0];
 
             int[] edgeVoxelsMissing = new int[6];
             int[] edgeCenterVoxelsMissing = new int[6];
 
             byte[] lightshv = GetLightHsv(Api.World.BlockAccessor);
 
+            // Flat Span instead of byte[,,] - removes 3-dimensional addressing for each voxel
+            Span<byte> flatMat = MemoryMarshal.CreateSpan(ref VoxelMaterial[0, 0, 0], 4096);
+
+            int idx = 0;
+
             for (int dx = 0; dx < 16; dx++)
             {
+                // Calculate dx once every 16 iterations, rather than dz every 4096 iterations
+                bool isWest = dx == 0;
+                bool isEast = dx == 15;
+                bool xCenter = dx >= 4 && dx <= 12;
+
                 for (int dy = 0; dy < 16; dy++)
                 {
-                    for (int dz = 0; dz < 16; dz++)
-                    {
-                        bool isVoxel = Voxels[dx, dy, dz];
+                    // Calculate once per 256 iterations (16 dx * 16 dy), not per 4096
+                    bool isDown = dy == 0;
+                    bool isUp = dy == 15;
+                    bool yCenter = dy >= 4 && dy <= 12;
 
-                        // North: Negative Z
-                        // East: Positive X
-                        // South: Positive Z
-                        // West: Negative X
-                        // Up: Positive Y
-                        // Down: Negative Y
+                    for (int dz = 0; dz < 16; dz++, idx++)
+                    {
+                        bool isVoxel = Voxels.GetFlat(idx);
+
                         if (!isVoxel)
                         {
                             if (dz == 0)
                             {
                                 edgeVoxelsMissing[BlockFacing.NORTH.Index]++;
-                                if (Math.Abs(dy - 8) < 5 && Math.Abs(dx - 8) < 5) edgeCenterVoxelsMissing[BlockFacing.NORTH.Index]++;
+                                if (yCenter && xCenter) edgeCenterVoxelsMissing[BlockFacing.NORTH.Index]++;
                             }
-                            if (dx == 15)
+                            if (isEast)
                             {
                                 edgeVoxelsMissing[BlockFacing.EAST.Index]++;
-                                if (Math.Abs(dy - 8) < 5 && Math.Abs(dz - 8) < 5) edgeCenterVoxelsMissing[BlockFacing.EAST.Index]++;
+                                if (yCenter && dz >= 4 && dz <= 12) edgeCenterVoxelsMissing[BlockFacing.EAST.Index]++;
                             }
                             if (dz == 15)
                             {
                                 edgeVoxelsMissing[BlockFacing.SOUTH.Index]++;
-                                if (Math.Abs(dy - 8) < 5 && Math.Abs(dx - 8) < 5) edgeCenterVoxelsMissing[BlockFacing.SOUTH.Index]++;
+                                if (yCenter && xCenter) edgeCenterVoxelsMissing[BlockFacing.SOUTH.Index]++;
                             }
-                            if (dx == 0)
+                            if (isWest)
                             {
                                 edgeVoxelsMissing[BlockFacing.WEST.Index]++;
-                                if (Math.Abs(dy - 8) < 5 && Math.Abs(dz - 8) < 5) edgeCenterVoxelsMissing[BlockFacing.WEST.Index]++;
+                                if (yCenter && dz >= 4 && dz <= 12) edgeCenterVoxelsMissing[BlockFacing.WEST.Index]++;
                             }
-                            if (dy == 15)
+                            if (isUp)
                             {
                                 edgeVoxelsMissing[BlockFacing.UP.Index]++;
-                                if (Math.Abs(dz - 8) < 5 && Math.Abs(dx - 8) < 5) edgeCenterVoxelsMissing[BlockFacing.UP.Index]++;
+                                if (dz >= 4 && dz <= 12 && xCenter) edgeCenterVoxelsMissing[BlockFacing.UP.Index]++;
                             }
-                            if (dy == 0)
+                            if (isDown)
                             {
                                 edgeVoxelsMissing[BlockFacing.DOWN.Index]++;
-                                if (Math.Abs(dz - 8) < 5 && Math.Abs(dx - 8) < 5) edgeCenterVoxelsMissing[BlockFacing.DOWN.Index]++;
+                                if (dz >= 4 && dz <= 12 && xCenter) edgeCenterVoxelsMissing[BlockFacing.DOWN.Index]++;
                             }
                             continue;
                         }
-                        else
-                        {
-                            voxelCount++;
-                        }
 
-                        if (VoxelVisited[dx, dy, dz]) continue;
+                        voxelCount++;
 
-                        CuboidWithMaterial cub = new CuboidWithMaterial()
-                        {
-                            Material = VoxelMaterial[dx, dy, dz],
-                            X1 = dx,
-                            Y1 = dy,
-                            Z1 = dz,
-                            X2 = dx + 1,
-                            Y2 = dy + 1,
-                            Z2 = dz + 1
-                        };
+                        if (VoxelVisited.GetFlat(idx)) continue;
 
-                        // Try grow this cuboid for as long as we can
+                        cub.X1 = dx; cub.Y1 = dy; cub.Z1 = dz;
+                        cub.X2 = dx + 1; cub.Y2 = dy + 1; cub.Z2 = dz + 1;
+                        cub.Material = flatMat[idx];
+
                         bool didGrowAny = true;
                         while (didGrowAny)
                         {
                             didGrowAny = false;
-                            didGrowAny |= TryGrowX(cub, Voxels, VoxelVisited, VoxelMaterial);
-                            didGrowAny |= TryGrowY(cub, Voxels, VoxelVisited, VoxelMaterial);
-                            didGrowAny |= TryGrowZ(cub, Voxels, VoxelVisited, VoxelMaterial);
+                            didGrowAny |= TryGrowX(cub, Voxels, VoxelVisited, flatMat);
+                            didGrowAny |= TryGrowY(cub, Voxels, VoxelVisited, flatMat);
+                            didGrowAny |= TryGrowZ(cub, Voxels, VoxelVisited, flatMat);
                         }
 
-                        voxelCuboids.Add(ToUint(cub));
+                        CuboidBuffer[cuboidCount++] = ToUint(cub);
                     }
                 }
             }
 
-            this.VoxelCuboids = voxelCuboids;
-
-            bool doEmitSideAo = edgeVoxelsMissing[0] < 64 || edgeVoxelsMissing[1] < 64 || edgeVoxelsMissing[2] < 64 || edgeVoxelsMissing[3] < 64 || edgeVoxelsMissing[4] < 64 || edgeVoxelsMissing[5] < 64;
+            bool doEmitSideAo = edgeVoxelsMissing[0] < 64 || edgeVoxelsMissing[1] < 64 ||
+                                edgeVoxelsMissing[2] < 64 || edgeVoxelsMissing[3] < 64 ||
+                                edgeVoxelsMissing[4] < 64 || edgeVoxelsMissing[5] < 64;
 
             if (absorbAnyLight != doEmitSideAo)
             {
@@ -888,11 +926,7 @@ namespace Vintagestory.GameContent
                 sidecenterSolid[i] = edgeCenterVoxelsMissing[i] < 5;
                 if ((sideAlmostSolid[i] = edgeVoxelsMissing[i] <= 32)) emitFlags += 1 << i;
             }
-            //if (emitFlags != 0x3F)
-            //{
-            //    if (emitFlags == 0x3E && emitFlags == 0x3D && emitFlags == 0x3B && emitFlags == 0x37) emitFlags = 0x3F;  // If only one side missing, treat as full cube
-            //    else emitFlags &= 0x30;
-            //}
+
             emitSideAo = lightshv[2] < 10 && doEmitSideAo ? emitFlags : 0;
 
             if (BlockIds.Length == 1 && Api.World.GetBlock(BlockIds[0]).RenderPass == EnumChunkRenderPass.Meta)
@@ -912,11 +946,17 @@ namespace Vintagestory.GameContent
                 }
             }
 
+            // sync rebuilt cuboids from fixed buffer back to instance list
+            VoxelCuboids = new List<uint>(cuboidCount);
+            for (int i = 0; i < cuboidCount; i++)
+                VoxelCuboids.Add(CuboidBuffer[i]);
+
             if (DisplacesLiquid())
             {
                 Api.World.BlockAccessor.SetBlock(0, Pos, BlockLayersAccess.Fluid);
             }
         }
+
 
         private void RedrawNeighbourChunkIfAoChanged(int prevEmitSideAo)
         {
@@ -937,78 +977,91 @@ namespace Vintagestory.GameContent
 
 
 
-        protected bool TryGrowX(CuboidWithMaterial cub, BoolArray16x16x16 voxels, BoolArray16x16x16 voxelVisited, byte[,,] voxelMaterial)
+        // Span<byte> voxelMaterial instead of byte[,,], GetFlat/SetFlatTrue instead of indexers, calculate baseXY in advance
+        protected bool TryGrowX(CuboidWithMaterial cub, BoolArray16x16x16 voxels, BoolArray16x16x16 voxelVisited, Span<byte> voxelMaterial)
         {
             if (cub.X2 > 15) return false;
 
+            int baseX = cub.X2 * 256;
+
             for (int y = cub.Y1; y < cub.Y2; y++)
             {
+                int baseXY = baseX + y * 16;
                 for (int z = cub.Z1; z < cub.Z2; z++)
                 {
-                    if (!voxels[cub.X2, y, z] || voxelVisited[cub.X2, y, z] || voxelMaterial[cub.X2, y, z] != cub.Material) return false;
+                    int idx = baseXY + z;
+                    if (!voxels.GetFlat(idx) || voxelVisited.GetFlat(idx) || voxelMaterial[idx] != cub.Material) return false;
                 }
             }
 
             for (int y = cub.Y1; y < cub.Y2; y++)
             {
+                int baseXY = baseX + y * 16;
                 for (int z = cub.Z1; z < cub.Z2; z++)
-                {
-                    voxelVisited[cub.X2, y, z] = true;
-                }
+                    voxelVisited.SetFlatTrue(baseXY + z);
             }
 
             cub.X2++;
             return true;
         }
 
-        protected bool TryGrowY(CuboidWithMaterial cub, BoolArray16x16x16 voxels, BoolArray16x16x16 voxelVisited, byte[,,] voxelMaterial)
+
+        // Span<byte> voxelMaterial instead of byte[,,], GetFlat/SetFlatTrue, baseY calculated once
+        protected bool TryGrowY(CuboidWithMaterial cub, BoolArray16x16x16 voxels, BoolArray16x16x16 voxelVisited, Span<byte> voxelMaterial)
         {
             if (cub.Y2 > 15) return false;
 
+            int baseY = cub.Y2 * 16;
+
             for (int x = cub.X1; x < cub.X2; x++)
             {
+                int baseXY = x * 256 + baseY;
                 for (int z = cub.Z1; z < cub.Z2; z++)
                 {
-                    if (!voxels[x, cub.Y2, z] || voxelVisited[x, cub.Y2, z] || voxelMaterial[x, cub.Y2, z] != cub.Material) return false;
+                    int idx = baseXY + z;
+                    if (!voxels.GetFlat(idx) || voxelVisited.GetFlat(idx) || voxelMaterial[idx] != cub.Material) return false;
                 }
             }
 
             for (int x = cub.X1; x < cub.X2; x++)
             {
+                int baseXY = x * 256 + baseY;
                 for (int z = cub.Z1; z < cub.Z2; z++)
-                {
-                    voxelVisited[x, cub.Y2, z] = true;
-                }
+                    voxelVisited.SetFlatTrue(baseXY + z);
             }
 
             cub.Y2++;
             return true;
         }
 
-        protected bool TryGrowZ(CuboidWithMaterial cub, BoolArray16x16x16 voxels, BoolArray16x16x16 voxelVisited, byte[,,] voxelMaterial)
+
+        //  Span<byte> voxelMaterial instead of byte[,,], GetFlat/SetFlatTrue, z2 moved outside the loop
+        protected bool TryGrowZ(CuboidWithMaterial cub, BoolArray16x16x16 voxels, BoolArray16x16x16 voxelVisited, Span<byte> voxelMaterial)
         {
             if (cub.Z2 > 15) return false;
 
+            int z2 = cub.Z2;
+
             for (int x = cub.X1; x < cub.X2; x++)
             {
+                int baseX = x * 256;
                 for (int y = cub.Y1; y < cub.Y2; y++)
                 {
-                    if (!voxels[x, y, cub.Z2] || voxelVisited[x, y, cub.Z2] || voxelMaterial[x, y, cub.Z2] != cub.Material) return false;
+                    int idx = baseX + y * 16 + z2;
+                    if (!voxels.GetFlat(idx) || voxelVisited.GetFlat(idx) || voxelMaterial[idx] != cub.Material) return false;
                 }
             }
 
             for (int x = cub.X1; x < cub.X2; x++)
             {
+                int baseX = x * 256;
                 for (int y = cub.Y1; y < cub.Y2; y++)
-                {
-                    voxelVisited[x, y, cub.Z2] = true;
-                }
+                    voxelVisited.SetFlatTrue(baseX + y * 16 + z2);
             }
 
             cub.Z2++;
             return true;
         }
-
 
 
         public virtual void RegenSelectionBoxes(IWorldAccessor worldForResolve, IPlayer byPlayer)
@@ -1044,7 +1097,8 @@ namespace Vintagestory.GameContent
 
                 selectionBoxesStd = selectionBoxesStdTmp.Where(ele => ele != null).ToArray();
                 selectionBoxesMetaMode = selBoxesMetaModeTmp.ToArray();
-            } else
+            }
+            else
             {
                 for (int i = 0; i < VoxelCuboids.Count; i++)
                 {
@@ -1371,7 +1425,7 @@ namespace Vintagestory.GameContent
                 var material = (VoxelCuboids[j] >> 24) & 0xFFu;
                 if (material >= index)
                 {
-                    VoxelCuboids[j] = (uint)((VoxelCuboids[j] & ~(255 << 24)) | ((material-1) << 24));
+                    VoxelCuboids[j] = (uint)((VoxelCuboids[j] & ~(255 << 24)) | ((material - 1) << 24));
                 }
             }
         }
@@ -1445,7 +1499,7 @@ namespace Vintagestory.GameContent
                 if (DecorIdsRotated == null || DecorIdsRotated.Length < DecorIds.Length) DecorIdsRotated = new int[DecorIds.Length];
                 for (var i = 0; i < 4; i++)
                 {
-                    DecorIdsRotated[i] = DecorIds[GameMath.Mod(i + rotationY/90, 4)];
+                    DecorIdsRotated[i] = DecorIds[GameMath.Mod(i + rotationY / 90, 4)];
                 }
 
                 DecorIdsRotated[4] = DecorIds[4];
@@ -2132,7 +2186,8 @@ namespace Vintagestory.GameContent
                 if (AnyFrostable)
                 {
                     targetMesh.AddColorMapIndex(blockMat.ClimateMapIndex, blockMat.SeasonMapIndex, blockMat.Frostable);
-                } else
+                }
+                else
                 {
                     targetMesh.AddColorMapIndex(blockMat.ClimateMapIndex, blockMat.SeasonMapIndex);
                 }
@@ -2229,22 +2284,22 @@ namespace Vintagestory.GameContent
                 {
                     case 0:
                         u = (uc - 1f) * uSize + 1f - uOffset;
-                        v =       -vc * vSize + 1f - vOffset;
+                        v = -vc * vSize + 1f - vOffset;
                         break;
                     case 1:
                         u = (uc - 1f) * uSize + 1f - uOffset;
-                        v =       -vc * vSize + 1f - vOffset;
+                        v = -vc * vSize + 1f - vOffset;
                         break;
                     case 2:
-                        u =  uc * uSize + uOffset;
+                        u = uc * uSize + uOffset;
                         v = -vc * vSize + 1f - vOffset;
                         break;
                     case 3:
-                        u =  uc * uSize + uOffset;
+                        u = uc * uSize + uOffset;
                         v = -vc * vSize + 1f - vOffset;
                         break;
                     case 4:
-                        u =       -uc * uSize + 1f - uOffset;
+                        u = -uc * uSize + 1f - uOffset;
                         v = (vc - 1f) * vSize + 1f - vOffset;
                         break;
                     case 5:
@@ -2257,10 +2312,10 @@ namespace Vintagestory.GameContent
 
         }
 
-    /// <summary>
-    /// Is coordinate agnostic, can iterate over any of the 6 planes
-    /// </summary>
-    public unsafe ref struct GenPlaneInfo
+        /// <summary>
+        /// Is coordinate agnostic, can iterate over any of the 6 planes
+        /// </summary>
+        public unsafe ref struct GenPlaneInfo
         {
             public RefList<VoxelMaterial> blockMaterials;
             public RefList<VoxelMaterial> decorMaterials;
@@ -2427,7 +2482,7 @@ namespace Vintagestory.GameContent
             }
 
             if (!resolveImports) return;
-            
+
             int newMatIndex = -1;
             int len = BlockIds.Length;
             for (int i = 0; i < len; i++)
@@ -2560,6 +2615,7 @@ namespace Vintagestory.GameContent
     }
 
 
+
     /// <summary>
     /// Compact storage for 4096 bits (16x16x16), occupying exactly 512 bytes of memory.
     /// </summary>
@@ -2602,6 +2658,12 @@ namespace Vintagestory.GameContent
             voxels[index >> 6] |= (1UL << (index & 63));
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool GetFlat(int index) => (voxels[index >> 6] & (1UL << (index & 63))) != 0;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetFlatTrue(int index) => voxels[index >> 6] |= (1UL << (index & 63));
+
         // Indexer for full backward compatibility with the legacy array[x, y, z] syntax
         public bool this[int x, int y, int z]
         {
@@ -2611,6 +2673,40 @@ namespace Vintagestory.GameContent
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set => Set(x, y, z, value);
         }
-    }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetRangeTrue(int startIndex, int length)
+        {
+            if (length <= 0) return;
+
+            int bitOffset = startIndex & 63;
+            int wordIndex = startIndex >> 6;
+
+            if (bitOffset + length <= 64)
+            {
+                ulong mask = length == 64 ? ulong.MaxValue : ((1UL << length) - 1) << bitOffset;
+                voxels[wordIndex] |= mask;
+                return;
+            }
+
+            // first (partial) word
+            voxels[wordIndex] |= ulong.MaxValue << bitOffset;
+            int remaining = length - (64 - bitOffset);
+            wordIndex++;
+
+            // full words
+            while (remaining >= 64)
+            {
+                voxels[wordIndex++] = ulong.MaxValue;
+                remaining -= 64;
+            }
+
+            // tail
+            if (remaining > 0)
+            {
+                voxels[wordIndex] |= (1UL << remaining) - 1;
+            }
+        }
+    }
+    
 }

--- a/Systems/Microblock/BEMicroBlock.cs
+++ b/Systems/Microblock/BEMicroBlock.cs
@@ -2561,25 +2561,56 @@ namespace Vintagestory.GameContent
 
 
     /// <summary>
-    /// Replaces all uses of bool[,,] arrays in BEMicroblock. Ignoring trivial object overhead, this uses 512 bytes of memory, compared with 4096 or 16384 bytes (depending on native code implementation, see https://stackoverflow.com/questions/28514373/what-is-the-size-of-a-boolean-in-c-does-it-really-take-4-bytes) a bool[,,] of the same length
-    /// Should help to reduce problematic high RAM use of Microblocks
+    /// Compact storage for 4096 bits (16x16x16), occupying exactly 512 bytes of memory.
     /// </summary>
     public class BoolArray16x16x16
     {
-        BitArray voxels;   // Compact storage of boolean values in this nice high-performance class provided by System.Collections - note, suitable for large arrays of bools as we have here; in contrast, our own SmallBoolArray is more suitable for small arrays of bools especially length 6
+        // Array of 64 ulong elements (64 * 64 bits = 4096 bits), allocated only once upon instantiation
+        private readonly ulong[] voxels = new ulong[64];
 
-        public BoolArray16x16x16()
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Clear()
         {
-            voxels = new BitArray(16 * 16 * 16);
+            // Instantly zeroes out all 64 elements without creating a new object (zero allocations)
+            Array.Clear(voxels, 0, 64);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Get(int x, int y, int z)
+        {
+            // Calculates flat index and checks the target bit using a fast bitwise AND
+            int index = ((x * 16) + y) * 16 + z;
+            return (voxels[index >> 6] & (1UL << (index & 63))) != 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Set(int x, int y, int z, bool value)
+        {
+            // Calculates index and sets the bit to 1 or 0 via bitwise operations
+            int index = ((x * 16) + y) * 16 + z;
+            if (value)
+                voxels[index >> 6] |= (1UL << (index & 63));
+            else
+                voxels[index >> 6] &= ~(1UL << (index & 63));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetTrue(int x, int y, int z)
+        {
+            // Optimized Set version: forcibly sets the bit to 1 without an 'if' condition check
+            int index = ((x * 16) + y) * 16 + z;
+            voxels[index >> 6] |= (1UL << (index & 63));
+        }
+
+        // Indexer for full backward compatibility with the legacy array[x, y, z] syntax
         public bool this[int x, int y, int z]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get { return voxels[((x * 16) + y) * 16 + z]; }
+            get => Get(x, y, z);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set { voxels[((x * 16) + y) * 16 + z] = value; }
+            set => Set(x, y, z, value);
         }
     }
+
 }


### PR DESCRIPTION
## Summary

### BlockEntityMicroBlock

**ConvertToVoxels:**
- ThreadLocal caches for `BoolArray16x16x16` and `byte[,,]` — eliminated per-call object allocations.
- `Span<byte>` replaces 3D indexing of `byte[,,]` (removed multiplications + 3 bounds checks per element).
- `SetRangeTrue` / `Fill` instead of nested Z-loop assignments.

**RebuildCuboidList:**
- `VoxelVisited` from ThreadLocal — zero allocations during rebuild.
- `Span<byte> flatMat` + `GetFlat`/`SetFlatTrue` replaces 3D access to `VoxelMaterial`.
- Fixed buffer `uint[4096]` with `cuboidCount++` instead of `List.Add`.
- Precomputed flags (`isWest`, `isEast`, `xCenter`, `yCenter`) hoisted out of inner loops.

**TryGrowX / TryGrowY / TryGrowZ:**
- Switched to `Span<byte>` and flat indexing.
- Base offsets (`baseX`/`baseXY`/`baseY`) computed once before nested loops.

> **Summary:** eliminated GC allocations during voxel rebuild, improved memory locality via flat access and `Span<T>`.

---

### BoolArray16x16x16 (new class)
Unlike BitArray, which uses slow division and remainder operations on 32-bit numbers, this implementation packs data into 64-bit ulongs and locates the desired bit using ultra-fast bitwise shifts. This allows the processor to calculate the bit address in a single clock instruction, greatly accelerating direct data access in hot cycles.
- Stores 4096 bits in an array of 64 `ulong`s (512 bytes).
- `GetFlat`, `SetFlatTrue`, `SetRangeTrue` — fast bitwise ops without branch checks.
- `[x,y,z]` indexer preserved for backward compatibility.

> **Summary:** compact storage + O(1) bitwise operations instead of bool array.

---

### BEBehaviorMicroblockSnowCover

**buildSnowCuboids:**
- `Span<bool>` (stackalloc 256) replaces heap-allocated `bool[16,16]` — removed GC pressure per call.
- Flat indexing for visited and voxel access (`dx * 256 + yOffset + dz`).
- Removed unused iteration over `aboveCuboids.Contains()`.

**TrySnowableSurfaceGrowX / TrySnowableSurfaceGrowZ:**
- `Span<bool>` replaces `bool[,]` for visited.
- Flat indexing for voxels (`idx + 16` for Y+1).

> **Summary:** eliminated heap allocations in the hot snow-cover path


## Performance numbers

Tested on the generation of 31417 chunk columns (6 threads):
- BlockEntityMicroBlock.FromTreeAttributes method execution time: reduced from 9904 ms to 5228 ms;
- BlockEntityMicroBlock GC memory allocations: reduced from 2.47 Gb to 1.57 GB.

**Before**
<img width="986" height="605" alt="microblock before trace" src="https://github.com/user-attachments/assets/183bd3ad-a236-4276-86b8-e07be9c1cedf" />
<img width="1687" height="674" alt="microblock before mem" src="https://github.com/user-attachments/assets/5ad612ff-1679-445c-b487-67a44ef27f2c" />


**After**
<img width="975" height="634" alt="microblock after trace" src="https://github.com/user-attachments/assets/de00e446-8a99-4485-b316-691fcd78ce9e" />
<img width="1686" height="642" alt="microblock after mem" src="https://github.com/user-attachments/assets/c47cceb0-a9fc-4b69-97ce-c0fe425cb6df" />
