### PR TITLE
fix water deleting source blocks when spreading

### DIFF
--- a/BlockBehavior/BehaviorFiniteSpreadingLiquid.cs
+++ b/BlockBehavior/BehaviorFiniteSpreadingLiquid.cs
@@ -911,6 +911,8 @@ namespace Vintagestory.GameContent
             // If the same liquids, we can replace if the neighbour liquid is at a lower level
             if (IsSameLiquid(ourblock, neighborLiquid))
             {
+                if (IsLiquidSourceBlock(neighborLiquid)) return false;
+
                 if (!IsLiquidSourceBlock(ourblock) && neighborLiquid is IBlockFlowing neighborFlowing && ourblock is IBlockFlowing ourFlowing)
                 {
                     float neibFlow = neighborFlowing.FlowRate(npos);


### PR DESCRIPTION
when water tries to spread downward it deletes full water source blocks beneath it to create flowing water. this deletes all the water in a column. it should stop spreading when it hits a source.