### PR TITLE
Rework: Tweaks, fixes and refactoring to ground storage and pit kilns

### DIFF
--- a/Block/BlockGroundStorage.cs
+++ b/Block/BlockGroundStorage.cs
@@ -25,6 +25,7 @@ namespace Vintagestory.GameContent
         public ModelTransform[] Messy12Transforms;
 
         public static bool IsUsingContainedBlock; // This value is only relevant (and correct) client side
+        private int lastLookedAtSlotId = 0; // used to determine which block to pick in OnPickBlock()
 
         public override void OnLoaded(ICoreAPI api)
         {
@@ -428,12 +429,24 @@ namespace Vintagestory.GameContent
             else return OnPickBlock(world, pos)?.GetName();
         }
 
+        public override void OnBeingLookedAt(IPlayer byPlayer, BlockSelection blockSel, bool firstTick)
+        {
+            // seems like it has to be done every frame so that it switches when hovering over a different slot
+            if (blockSel.Block.GetBlockEntity<BlockEntityGroundStorage>(blockSel) is BlockEntityGroundStorage beg)
+            {
+                lastLookedAtSlotId = beg.GetSlotIdAt(blockSel);
+            }
+
+            base.OnBeingLookedAt(byPlayer, blockSel, firstTick);
+        }
+
         public override ItemStack OnPickBlock(IWorldAccessor world, BlockPos pos)
         {
-            var beg = world.BlockAccessor.GetBlockEntity(pos) as BlockEntityGroundStorage;
-            if (beg != null)
+            BlockEntity be = world.BlockAccessor.GetBlockEntity(pos);
+            if (be is BlockEntityGroundStorage beg)
             {
-                return beg.Inventory.FirstNonEmptySlot?.Itemstack.Clone();
+                ItemSlot slot = beg.Inventory[lastLookedAtSlotId];
+                return slot?.Itemstack?.Clone() ?? beg.Inventory.FirstNonEmptySlot?.Itemstack.Clone();
             }
 
             return null;

--- a/Block/BlockGroundStorage.cs
+++ b/Block/BlockGroundStorage.cs
@@ -315,19 +315,6 @@ namespace Vintagestory.GameContent
                 beg.OnPlayerInteractStart(player, blockSel);
             }
 
-            if (CollisionTester.AabbIntersect(
-                GetCollisionBoxes(world.BlockAccessor, pos)[0],
-                pos.X, pos.Y, pos.Z,
-                player.Entity.SelectionBox,
-                player.Entity.Pos.XYZ
-            ))
-            {
-                player.Entity.Pos.Y += GetCollisionBoxes(world.BlockAccessor, pos)[0].Y2;
-            }
-
-            (player as IClientPlayer)?.TriggerFpAnimation(EnumHandInteract.HeldItemInteract);
-
-
             return true;
         }
 
@@ -478,9 +465,9 @@ namespace Vintagestory.GameContent
 
                 switch (beg.StorageProps.Layout)
                 {
-                    case EnumGroundStorageLayout.Stacking or EnumGroundStorageLayout.Messy12 when !beg.Inventory.Empty:
+                    case EnumGroundStorageLayout.Stacking or EnumGroundStorageLayout.Messy12:
                     {
-                        var collObj = beg.Inventory[0]?.Itemstack?.Collectible;
+                        var collObj = beg.Inventory?[0]?.Itemstack?.Collectible;
                         if (collObj == null) break;
 
                         var canIgniteStacks = BlockBehaviorCanIgnite.CanIgniteStacks(api, true).ToArray();
@@ -493,7 +480,7 @@ namespace Vintagestory.GameContent
                             Itemstacks = canIgniteStacks,
                             GetMatchingStacks = (wi, bs, es) => {
                                 var begs = api.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityGroundStorage;
-                                if (begs?.IsBurning == false && begs?.CanIgnite == true)
+                                if (begs != null && !begs.Inventory.Empty && !begs.IsBurning && begs.CanIgnite)
                                 {
                                     return wi.Itemstacks;
                                 }
@@ -567,7 +554,7 @@ namespace Vintagestory.GameContent
                             Itemstacks = groundStorablesMixableByLayout[beg.StorageProps.Layout],
                             GetMatchingStacks = (wi, bs, es) => {
                                 var begs = api.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityGroundStorage;
-                                if (begs?.IsFull == false) // (begs?.GetSlotAt(bs).Empty == true) only updated when initially moving the mouse onto the block
+                                if (begs?.GetSlotAt(bs).Empty == true)
                                 {
                                     return wi.Itemstacks;
                                 }

--- a/Block/BlockGroundStorage.cs
+++ b/Block/BlockGroundStorage.cs
@@ -21,8 +21,7 @@ namespace Vintagestory.GameContent
 
     public class BlockGroundStorage : Block, ICombustible, IIgnitable
     {
-        protected ItemStack[] groundStorablesQuadrants;
-        protected ItemStack[] groundStorablesHalves;
+        protected Dictionary<EnumGroundStorageLayout, ItemStack[]> groundStorablesMixableByLayout;
         public ModelTransform[] Messy12Transforms;
 
         public static bool IsUsingContainedBlock; // This value is only relevant (and correct) client side
@@ -60,6 +59,7 @@ namespace Vintagestory.GameContent
             {
                 List<ItemStack> qstacks = new List<ItemStack>();
                 List<ItemStack> hstacks = new List<ItemStack>();
+                List<ItemStack> whstacks = new List<ItemStack>();
 
                 foreach (CollectibleObject obj in api.World.Collectibles)
                 {
@@ -72,13 +72,20 @@ namespace Vintagestory.GameContent
                     {
                         hstacks.Add(new ItemStack(obj));
                     }
+                    if (storableBh?.StorageProps.Layout == EnumGroundStorageLayout.WallHalves)
+                    {
+                        whstacks.Add(new ItemStack(obj));
+                    }
                 }
 
-                return new ItemStack[][] { qstacks.ToArray(), hstacks.ToArray() };
+                return new ItemStack[][] { qstacks.ToArray(), hstacks.ToArray(), whstacks.ToArray() };
             });
 
-            groundStorablesQuadrants = stacks[0];
-            groundStorablesHalves = stacks[1];
+            groundStorablesMixableByLayout = new() {
+                { EnumGroundStorageLayout.Quadrants, stacks[0] },
+                { EnumGroundStorageLayout.Halves, stacks[1] },
+                { EnumGroundStorageLayout.WallHalves, stacks[2] },
+            };
 
             if (api.Side == EnumAppSide.Client)
             {
@@ -548,6 +555,7 @@ namespace Vintagestory.GameContent
                         break;
                     }
 
+                    case EnumGroundStorageLayout.WallHalves:
                     case EnumGroundStorageLayout.Halves:
                     case EnumGroundStorageLayout.Quadrants:
                     {
@@ -555,8 +563,8 @@ namespace Vintagestory.GameContent
                         {
                             ActionLangCode = "blockhelp-groundstorage-add",
                             MouseButton = EnumMouseButton.Right,
-                            HotKeyCode = "shift",
-                            Itemstacks = beg.StorageProps.Layout == EnumGroundStorageLayout.Halves ? groundStorablesHalves : groundStorablesQuadrants,
+                            HotKeyCodes = beg.StorageProps.CtrlKey ? ["ctrl", "shift"] : ["shift"],
+                            Itemstacks = groundStorablesMixableByLayout[beg.StorageProps.Layout],
                             GetMatchingStacks = (wi, bs, es) => {
                                 var begs = api.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityGroundStorage;
                                 if (begs?.IsFull == false) // (begs?.GetSlotAt(bs).Empty == true) only updated when initially moving the mouse onto the block

--- a/Block/BlockGroundStorage.cs
+++ b/Block/BlockGroundStorage.cs
@@ -451,21 +451,34 @@ namespace Vintagestory.GameContent
             var beg = world.BlockAccessor.GetBlockEntity(selection.Position) as BlockEntityGroundStorage;
             if (beg?.StorageProps != null)
             {
-                var selSlot = beg.GetSlotAt(selection);
-                var containedInteractions = selSlot?.Itemstack?.Collectible.GetCollectibleInterface<IContainedInteractable>()?.GetContainedInteractionHelp(beg, selSlot, forPlayer, selection) ?? [];
-
                 int bulkquantity = beg.StorageProps.BulkTransferQuantity;
 
-                if (beg.StorageProps.Layout == EnumGroundStorageLayout.Stacking && !beg.Inventory.Empty)
+                List<WorldInteraction> interactions = [];
+
+                if (beg.IsSuitableForKiln(false))
                 {
-                    var canIgniteStacks = BlockBehaviorCanIgnite.CanIgniteStacks(api, true).ToArray();
+                    BlockPitkiln blockpk = world.GetBlock(new AssetLocation("pitkiln")) as BlockPitkiln;
+                    blockpk.TryGetBuildStagesForGroundStorage(beg, out BuildStage[] buildStages);
 
-                    var collObj = beg.Inventory[0].Itemstack?.Collectible;
-                    if (collObj == null) return base.GetPlacedBlockInteractionHelp(world, selection, forPlayer);
+                    interactions.Add(new WorldInteraction()
+                    {
+                        ActionLangCode = "blockhelp-pitkiln-build",
+                        MouseButton = EnumMouseButton.Right,
+                        HotKeyCode = "shift",
+                        Itemstacks = [buildStages[0].Materials[0].ItemStack]
+                    });
+                }
 
-                    return
-                    [
-                        new()
+                switch (beg.StorageProps.Layout)
+                {
+                    case EnumGroundStorageLayout.Stacking when !beg.Inventory.Empty:
+                    {
+                        var collObj = beg.Inventory[0]?.Itemstack?.Collectible;
+                        if (collObj == null) break;
+
+                        var canIgniteStacks = BlockBehaviorCanIgnite.CanIgniteStacks(api, true).ToArray();
+
+                        interactions.Add(new()
                         {
                             ActionLangCode = "blockhelp-firepit-ignite",
                             MouseButton = EnumMouseButton.Right,
@@ -479,76 +492,72 @@ namespace Vintagestory.GameContent
                                 }
                                 return null;
                             }
-                        },
-                        new()
+                        });
+                        interactions.Add(new()
                         {
                             ActionLangCode = "blockhelp-groundstorage-addone",
                             MouseButton = EnumMouseButton.Right,
                             HotKeyCode = "shift",
                             Itemstacks = [new (collObj, 1)]
-                        },
-                        new()
+                        });
+                        interactions.Add(new()
                         {
                             ActionLangCode = "blockhelp-groundstorage-removeone",
                             MouseButton = EnumMouseButton.Right,
                             HotKeyCode = null
-                        },
-
-                        new()
+                        });
+                        interactions.Add(new()
                         {
                             ActionLangCode = "blockhelp-groundstorage-addbulk",
                             MouseButton = EnumMouseButton.Right,
                             HotKeyCodes = ["ctrl", "shift"],
                             Itemstacks = [new (collObj, bulkquantity)]
-                        },
-                        new()
+                        });
+                        interactions.Add(new()
                         {
                             ActionLangCode = "blockhelp-groundstorage-removebulk",
                             HotKeyCode = "ctrl",
                             MouseButton = EnumMouseButton.Right
-                        },
-                        ..containedInteractions,
-                        ..base.GetPlacedBlockInteractionHelp(world, selection, forPlayer)
-                    ];
-                }
+                        });
+                        break;
+                    }
 
-                if (beg.StorageProps.Layout == EnumGroundStorageLayout.SingleCenter)
-                {
-                    return
-                    [
-                        new WorldInteraction()
+                    case EnumGroundStorageLayout.SingleCenter:
+                    {
+                        interactions.Add(new()
                         {
                             ActionLangCode = "blockhelp-behavior-rightclickpickup",
                             MouseButton = EnumMouseButton.Right
-                        },
-                        ..containedInteractions,
-                        ..base.GetPlacedBlockInteractionHelp(world, selection, forPlayer)
-                    ];
-                }
+                        });
+                        break;
+                    }
 
-                if (beg.StorageProps.Layout == EnumGroundStorageLayout.Halves || beg.StorageProps.Layout == EnumGroundStorageLayout.Quadrants)
-                {
-                    return
-                    [
-                        new WorldInteraction()
+                    case EnumGroundStorageLayout.Halves:
+                    case EnumGroundStorageLayout.Quadrants:
+                    {
+                        interactions.Add(new()
                         {
                             ActionLangCode = "blockhelp-groundstorage-add",
                             MouseButton = EnumMouseButton.Right,
                             HotKeyCode = "shift",
                             Itemstacks = beg.StorageProps.Layout == EnumGroundStorageLayout.Halves ? groundStorablesHalves : groundStorablesQuadrants
-                        },
-                        new WorldInteraction()
+                        });
+                        interactions.Add(new()
                         {
                             ActionLangCode = "blockhelp-groundstorage-remove",
                             MouseButton = EnumMouseButton.Right,
                             HotKeyCode = null
-                        },
-                        ..containedInteractions,
-                        ..base.GetPlacedBlockInteractionHelp(world, selection, forPlayer)
-                    ];
+                        });
+                        break;
+                    }
+
+                    default: break;
                 }
 
-                return [.. containedInteractions, .. base.GetPlacedBlockInteractionHelp(world, selection, forPlayer)];
+                var selSlot = beg.GetSlotAt(selection);
+                var containedInteractions = selSlot?.Itemstack?.Collectible.GetCollectibleInterface<IContainedInteractable>()?.GetContainedInteractionHelp(beg, selSlot, forPlayer, selection) ?? [];
+
+                return [.. interactions, .. containedInteractions, .. base.GetPlacedBlockInteractionHelp(world, selection, forPlayer)];
             }
 
             return base.GetPlacedBlockInteractionHelp(world, selection, forPlayer);

--- a/Block/BlockGroundStorage.cs
+++ b/Block/BlockGroundStorage.cs
@@ -471,7 +471,7 @@ namespace Vintagestory.GameContent
 
                 switch (beg.StorageProps.Layout)
                 {
-                    case EnumGroundStorageLayout.Stacking when !beg.Inventory.Empty:
+                    case EnumGroundStorageLayout.Stacking or EnumGroundStorageLayout.Messy12 when !beg.Inventory.Empty:
                     {
                         var collObj = beg.Inventory[0]?.Itemstack?.Collectible;
                         if (collObj == null) break;

--- a/Block/BlockGroundStorage.cs
+++ b/Block/BlockGroundStorage.cs
@@ -8,8 +8,6 @@ using Vintagestory.API.Config;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Util;
 
-#nullable disable
-
 namespace Vintagestory.GameContent
 
 {
@@ -21,8 +19,8 @@ namespace Vintagestory.GameContent
 
     public class BlockGroundStorage : Block, ICombustible, IIgnitable
     {
-        protected Dictionary<EnumGroundStorageLayout, ItemStack[]> groundStorablesMixableByLayout;
-        public ModelTransform[] Messy12Transforms;
+        protected Dictionary<EnumGroundStorageLayout, ItemStack[]> groundStorablesMixableByLayout = [];
+        public ModelTransform[] Messy12Transforms = new ModelTransform[12];
 
         public static bool IsUsingContainedBlock; // This value is only relevant (and correct) client side
         private int lastLookedAtSlotId = 0; // used to determine which block to pick in OnPickBlock()
@@ -35,8 +33,7 @@ namespace Vintagestory.GameContent
 
             var positions = Attributes?["messy12Position"].AsObject<Vec3f[]>();
 
-            Messy12Transforms = new ModelTransform[12];
-            Random rnd = new Random(0);
+            Random rnd = new(0);
 
             for (int i = 0; i < 12; i++)
             {
@@ -58,9 +55,9 @@ namespace Vintagestory.GameContent
 
             ItemStack[][] stacks = ObjectCacheUtil.GetOrCreate(api, "groundStorablesQuadrands", () =>
             {
-                List<ItemStack> qstacks = new List<ItemStack>();
-                List<ItemStack> hstacks = new List<ItemStack>();
-                List<ItemStack> whstacks = new List<ItemStack>();
+                List<ItemStack> qstacks = [];
+                List<ItemStack> hstacks = [];
+                List<ItemStack> whstacks = [];
 
                 foreach (CollectibleObject obj in api.World.Collectibles)
                 {
@@ -90,7 +87,7 @@ namespace Vintagestory.GameContent
 
             if (api.Side == EnumAppSide.Client)
             {
-                ICoreClientAPI capi = api as ICoreClientAPI;
+                ICoreClientAPI capi = (api as ICoreClientAPI)!;
                 capi.Event.MouseUp += Event_MouseUp;
             }
 
@@ -134,7 +131,7 @@ namespace Vintagestory.GameContent
             return base.GetSelectionBoxes(blockAccessor, pos);
         }
 
-        public override bool CanAttachBlockAt(IBlockAccessor blockAccessor, Block block, BlockPos pos, BlockFacing blockFace, Cuboidi attachmentArea = null)
+        public override bool CanAttachBlockAt(IBlockAccessor blockAccessor, Block block, BlockPos pos, BlockFacing blockFace, Cuboidi? attachmentArea = null)
         {
             var be = blockAccessor.GetBlockEntity<BlockEntityGroundStorage>(pos);
             if (be != null)
@@ -197,7 +194,7 @@ namespace Vintagestory.GameContent
             return base.OnBlockInteractCancel(secondsUsed, world, byPlayer, blockSel, cancelReason);
         }
 
-        public override EnumBlockMaterial GetBlockMaterial(IBlockAccessor blockAccessor, BlockPos pos, ItemStack stack = null)
+        public override EnumBlockMaterial GetBlockMaterial(IBlockAccessor blockAccessor, BlockPos pos, ItemStack? stack = null)
         {
             return base.GetBlockMaterial(blockAccessor, pos, stack);
         }
@@ -208,14 +205,14 @@ namespace Vintagestory.GameContent
             BlockEntity be = world.BlockAccessor.GetBlockEntity(pos);
             if (be is BlockEntityGroundStorage beg)
             {
-                List<ItemStack> stacks = new List<ItemStack>();
+                List<ItemStack> stacks = [];
                 foreach (var slot in beg.Inventory)
                 {
                     if (slot.Empty) continue;
                     stacks.Add(slot.Itemstack);
                 }
 
-                return stacks.ToArray();
+                return [.. stacks];
             }
 
             return base.GetDrops(world, pos, byPlayer, dropQuantityMultiplier);
@@ -243,18 +240,16 @@ namespace Vintagestory.GameContent
             }
 
             BlockPos pos = blockSel.Position;
-            if (blockSel.Face != null)
-            {
-                pos = pos.AddCopy(blockSel.Face);
-            }
+            blockSel.Face ??= BlockFacing.UP;
+            pos = pos.AddCopy(blockSel.Face);
 
             if (pos.Y >= api.World.BlockAccessor.MapSizeY) return false;
             BlockPos posBelow = pos.DownCopy();
             Block belowBlock = world.BlockAccessor.GetBlock(posBelow);
             if (!belowBlock.CanAttachBlockAt(world.BlockAccessor, this, posBelow, BlockFacing.UP)) return false;
 
-            var storageProps = player.InventoryManager.ActiveHotbarSlot.Itemstack.Collectible.GetBehavior<CollectibleBehaviorGroundStorable>()?.StorageProps;
-            if (storageProps != null && storageProps.CtrlKey && !player.Entity.Controls.CtrlKey)
+            GroundStorageProperties? storageProps = player.InventoryManager.ActiveHotbarSlot.Itemstack?.Collectible.GetBehavior<CollectibleBehaviorGroundStorable>()?.StorageProps;
+            if (storageProps == null || (storageProps.CtrlKey && !player.Entity.Controls.CtrlKey))
             {
                 return false;
             }
@@ -266,7 +261,7 @@ namespace Vintagestory.GameContent
 
             float deg90 = GameMath.PIHALF;
             float roundRad = ((int)Math.Round(angleHor / deg90)) * deg90;
-            BlockFacing attachFace = null;
+            BlockFacing? attachFace = null;
 
             if (storageProps.Layout == EnumGroundStorageLayout.WallHalves)
             {
@@ -311,7 +306,7 @@ namespace Vintagestory.GameContent
             if (be is BlockEntityGroundStorage beg)
             {
                 beg.MeshAngle = roundRad;
-                beg.AttachFace = attachFace;
+                beg.AttachFace = attachFace ?? BlockFacing.DOWN;
                 beg.clientsideFirstPlacement = (world.Side == EnumAppSide.Client);
                 beg.OnPlayerInteractStart(player, blockSel);
             }
@@ -321,13 +316,29 @@ namespace Vintagestory.GameContent
 
         public override void OnNeighbourBlockChange(IWorldAccessor world, BlockPos pos, BlockPos neibpos)
         {
-            BlockEntityGroundStorage beg = world.BlockAccessor.GetBlockEntity(pos) as BlockEntityGroundStorage;
-            bool isWallHalves = beg?.StorageProps != null && beg.StorageProps.Layout == EnumGroundStorageLayout.WallHalves;
+            BlockEntityGroundStorage? begs = world.BlockAccessor.GetBlockEntity(pos) as BlockEntityGroundStorage;
 
-            if (isWallHalves)
+            if (begs?.IsBurning == true)
             {
-                var facing = beg.AttachFace;
-                var bpos = pos.AddCopy(facing.Normali.X, beg.StorageProps.WallOffY - 1, facing.Normali.Z);
+                var neibBlock = world.BlockAccessor.GetBlock(neibpos);
+                var neibliqBlock = world.BlockAccessor.GetBlock(neibpos, BlockLayersAccess.Fluid);
+                if (neibBlock.Attributes?.IsTrue("smothersFire") == true || neibliqBlock.Attributes?.IsTrue("smothersFire") == true)
+                {
+                    begs?.Extinguish();
+                }
+            }
+
+            var belowBlock = world.BlockAccessor.GetBlock(pos.DownCopy());
+            if (!belowBlock.CanAttachBlockAt(world.BlockAccessor, this, pos.DownCopy(), BlockFacing.UP))
+            {
+                world.BlockAccessor.BreakBlock(pos, null);
+                return;
+            }
+
+            if (begs?.StorageProps?.Layout == EnumGroundStorageLayout.WallHalves)
+            {
+                var facing = begs.AttachFace;
+                var bpos = pos.AddCopy(facing.Normali.X, begs.StorageProps.WallOffY - 1, facing.Normali.Z);
                 var block = world.BlockAccessor.GetBlock(bpos);
 
                 if (!block.CanAttachBlockAt(world.BlockAccessor, this, bpos, facing.Opposite))
@@ -335,46 +346,21 @@ namespace Vintagestory.GameContent
                     world.BlockAccessor.BreakBlock(pos, null);
                 }
 
-                var belowBlock = world.BlockAccessor.GetBlock(pos.DownCopy());
-                if (!belowBlock.CanAttachBlockAt(world.BlockAccessor, this, pos.DownCopy(), BlockFacing.UP))
-                {
-                    world.BlockAccessor.BreakBlock(pos, null);
-                    return;
-                }
-            } else
-            {
-
-                var begs = api.World.BlockAccessor.GetBlockEntity(pos) as BlockEntityGroundStorage;
-                if (begs?.IsBurning == true)
-                {
-                    var belowBlock = world.BlockAccessor.GetBlock(pos.DownCopy());
-                    if (!belowBlock.CanAttachBlockAt(world.BlockAccessor, this, pos.DownCopy(), BlockFacing.UP))
-                    {
-                        world.BlockAccessor.BreakBlock(pos, null);
-                        return;
-                    }
-
-                    var neibBlock = world.BlockAccessor.GetBlock(neibpos);
-                    var neibliqBlock = world.BlockAccessor.GetBlock(neibpos, BlockLayersAccess.Fluid);
-                    if (neibBlock.Attributes?.IsTrue("smothersFire") == true || neibliqBlock.Attributes?.IsTrue("smothersFire") == true)
-                    {
-                        begs?.Extinguish();
-                    }
-                }
                 // Don't run falling behavior for wall halves
-                base.OnNeighbourBlockChange(world, pos, neibpos);
+                return;
             }
+
+            base.OnNeighbourBlockChange(world, pos, neibpos);
         }
 
 
-        public override byte[] GetLightHsv(IBlockAccessor blockAccessor, BlockPos pos, ItemStack stack = null)
+        public override byte[] GetLightHsv(IBlockAccessor blockAccessor, BlockPos pos, ItemStack? stack = null)
         {
             if (pos != null)
             {
-                BlockEntity be = blockAccessor.GetBlockEntity(pos);
-                if (be is BlockEntityGroundStorage beg)
+                if (blockAccessor.GetBlockEntity(pos) is BlockEntityGroundStorage begs)
                 {
-                    return beg.GetLightHsv();
+                    return begs.GetLightHsv();
                 }
             }
 
@@ -383,35 +369,16 @@ namespace Vintagestory.GameContent
 
         public override int GetColorWithoutTint(ICoreClientAPI capi, BlockPos pos)
         {
-            BlockEntity be = capi.World.BlockAccessor.GetBlockEntity(pos);
-            if (be is BlockEntityGroundStorage beg)
-            {
-                ItemSlot slot = beg.Inventory.ToArray().Shuffle(capi.World.Rand).FirstOrDefault(s => !s.Empty);
-                if (slot != null)
-                {
-                    return slot.Itemstack.Collectible.GetRandomColor(capi, slot.Itemstack);
-                }
-            }
-
-            return base.GetColorWithoutTint(capi, pos);
+            BlockEntityGroundStorage begs = capi.World.BlockAccessor.GetBlockEntity<BlockEntityGroundStorage>(pos);
+            ItemSlot? slot = begs?.Inventory.ToArray().Shuffle(capi.World.Rand).FirstOrDefault(s => !s.Empty);
+            return slot?.Itemstack?.Collectible.GetRandomColor(capi, slot.Itemstack) ?? base.GetColorWithoutTint(capi, pos);
         }
 
         public override int GetRandomColor(ICoreClientAPI capi, BlockPos pos, BlockFacing facing, int rndIndex = -1)
         {
-            BlockEntity be = capi.World.BlockAccessor.GetBlockEntity(pos);
-            if (be is BlockEntityGroundStorage beg)
-            {
-                ItemSlot slot = beg.Inventory.ToArray().Shuffle(capi.World.Rand).FirstOrDefault(s => !s.Empty);
-                if (slot != null)
-                {
-                    return slot.Itemstack.Collectible.GetRandomColor(capi, slot.Itemstack);
-                } else
-                {
-                    return 0;
-                }
-            }
-
-            return base.GetRandomColor(capi, pos, facing, rndIndex);
+            BlockEntityGroundStorage? begs = capi.World.BlockAccessor.GetBlockEntity<BlockEntityGroundStorage>(pos);
+            ItemSlot? slot = begs?.Inventory.ToArray().Shuffle(capi.World.Rand).FirstOrDefault(s => !s.Empty);
+            return slot == null ? base.GetRandomColor(capi, pos, facing, rndIndex) : slot.Itemstack?.Collectible.GetRandomColor(capi, slot.Itemstack) ?? 0;
         }
 
         public override int GetRandomColor(ICoreClientAPI capi, ItemStack stack)
@@ -426,7 +393,7 @@ namespace Vintagestory.GameContent
             {
                 return beg.GetBlockName();
             }
-            else return OnPickBlock(world, pos)?.GetName();
+            else return OnPickBlock(world, pos)?.GetName() ?? Lang.Get("Ground Storage");
         }
 
         public override void OnBeingLookedAt(IPlayer byPlayer, BlockSelection blockSel, bool firstTick)
@@ -440,13 +407,13 @@ namespace Vintagestory.GameContent
             base.OnBeingLookedAt(byPlayer, blockSel, firstTick);
         }
 
-        public override ItemStack OnPickBlock(IWorldAccessor world, BlockPos pos)
+        public override ItemStack? OnPickBlock(IWorldAccessor world, BlockPos pos)
         {
             BlockEntity be = world.BlockAccessor.GetBlockEntity(pos);
             if (be is BlockEntityGroundStorage beg)
             {
                 ItemSlot slot = beg.Inventory[lastLookedAtSlotId];
-                return slot?.Itemstack?.Clone() ?? beg.Inventory.FirstNonEmptySlot?.Itemstack.Clone();
+                return slot?.Itemstack?.Clone() ?? beg.Inventory.FirstNonEmptySlot?.Itemstack?.Clone();
             }
 
             return null;
@@ -464,16 +431,17 @@ namespace Vintagestory.GameContent
 
                 if (beg.IsSuitableForKiln(false))
                 {
-                    BlockPitkiln blockpk = world.GetBlock(new AssetLocation("pitkiln")) as BlockPitkiln;
-                    blockpk.TryGetBuildStagesForGroundStorage(beg, out BuildStage[] buildStages);
-
-                    interactions.Add(new WorldInteraction()
+                    BlockPitkiln? blockpk = world.GetBlock(new AssetLocation("pitkiln")) as BlockPitkiln;
+                    if (blockpk?.TryGetBuildStagesForGroundStorage(beg, out BuildStage[] buildStages) == true)
                     {
-                        ActionLangCode = "blockhelp-pitkiln-build",
-                        MouseButton = EnumMouseButton.Right,
-                        HotKeyCode = "shift",
-                        Itemstacks = [buildStages[0].Materials[0].ItemStack]
-                    });
+                        interactions.Add(new WorldInteraction()
+                        {
+                            ActionLangCode = "blockhelp-pitkiln-build",
+                            MouseButton = EnumMouseButton.Right,
+                            HotKeyCode = "shift",
+                            Itemstacks = [buildStages[0].Materials[0].ItemStack]
+                        });
+                    }
                 }
 
                 switch (beg.StorageProps.Layout)
@@ -637,9 +605,7 @@ namespace Vintagestory.GameContent
 
         public EnumIgniteState OnTryIgniteBlock(EntityAgent byEntity, BlockPos pos, float secondsIgniting)
         {
-            var bea = byEntity.World.BlockAccessor.GetBlockEntity(pos) as BlockEntityGroundStorage;
-
-            if (bea == null || !bea.CanIgnite)
+            if (byEntity.World.BlockAccessor.GetBlockEntity(pos) is not BlockEntityGroundStorage bea || !bea.CanIgnite)
             {
                 return EnumIgniteState.NotIgnitablePreventDefault;
             }
@@ -649,14 +615,14 @@ namespace Vintagestory.GameContent
                 Random rand = byEntity.World.Rand;
                 Vec3d dpos = new Vec3d(pos.X + 2 / 8f + 4 / 8f * rand.NextDouble(), pos.InternalY + 7 / 8f, pos.Z + 2 / 8f + 4 / 8f * rand.NextDouble());
 
-                Block blockFire = byEntity.World.GetBlock(new AssetLocation("fire"));
+                if (byEntity.World.GetBlock(new AssetLocation("fire")) is not Block blockFire) return EnumIgniteState.Ignitable;
 
-                AdvancedParticleProperties props = blockFire.ParticleProperties[blockFire.ParticleProperties.Length - 1];
+                AdvancedParticleProperties props = blockFire.ParticleProperties[^1];
                 props.basePos = dpos;
                 props.Quantity.avg = 1;
 
-                IPlayer byPlayer = null;
-                if (byEntity is EntityPlayer) byPlayer = byEntity.World.PlayerByUid(((EntityPlayer)byEntity).PlayerUID);
+                IPlayer? byPlayer = null;
+                if (byEntity is EntityPlayer player) byPlayer = byEntity.World.PlayerByUid(player.PlayerUID);
 
                 byEntity.World.SpawnParticles(props, byPlayer);
 
@@ -677,8 +643,8 @@ namespace Vintagestory.GameContent
 
             handling = EnumHandling.PreventDefault;
 
-            IPlayer byPlayer = null;
-            if (byEntity is EntityPlayer) byPlayer = byEntity.World.PlayerByUid(((EntityPlayer)byEntity).PlayerUID);
+            IPlayer? byPlayer = null;
+            if (byEntity is EntityPlayer player) byPlayer = byEntity.World.PlayerByUid(player.PlayerUID);
             if (byPlayer == null) return;
 
             var bea = byEntity.World.BlockAccessor.GetBlockEntity(pos) as BlockEntityGroundStorage;

--- a/Block/BlockGroundStorage.cs
+++ b/Block/BlockGroundStorage.cs
@@ -498,7 +498,15 @@ namespace Vintagestory.GameContent
                             ActionLangCode = "blockhelp-groundstorage-addone",
                             MouseButton = EnumMouseButton.Right,
                             HotKeyCode = "shift",
-                            Itemstacks = [new (collObj, 1)]
+                            Itemstacks = [new (collObj, 1)],
+                            GetMatchingStacks = (wi, bs, es) => {
+                                var begs = api.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityGroundStorage;
+                                if (begs?.IsFull == false)
+                                {
+                                    return wi.Itemstacks;
+                                }
+                                return null;
+                            }
                         });
                         interactions.Add(new()
                         {
@@ -511,7 +519,15 @@ namespace Vintagestory.GameContent
                             ActionLangCode = "blockhelp-groundstorage-addbulk",
                             MouseButton = EnumMouseButton.Right,
                             HotKeyCodes = ["ctrl", "shift"],
-                            Itemstacks = [new (collObj, bulkquantity)]
+                            Itemstacks = [new (collObj, bulkquantity)],
+                            GetMatchingStacks = (wi, bs, es) => {
+                                var begs = api.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityGroundStorage;
+                                if (begs?.IsFull == false)
+                                {
+                                    return wi.Itemstacks;
+                                }
+                                return null;
+                            }
                         });
                         interactions.Add(new()
                         {
@@ -540,7 +556,15 @@ namespace Vintagestory.GameContent
                             ActionLangCode = "blockhelp-groundstorage-add",
                             MouseButton = EnumMouseButton.Right,
                             HotKeyCode = "shift",
-                            Itemstacks = beg.StorageProps.Layout == EnumGroundStorageLayout.Halves ? groundStorablesHalves : groundStorablesQuadrants
+                            Itemstacks = beg.StorageProps.Layout == EnumGroundStorageLayout.Halves ? groundStorablesHalves : groundStorablesQuadrants,
+                            GetMatchingStacks = (wi, bs, es) => {
+                                var begs = api.World.BlockAccessor.GetBlockEntity(bs.Position) as BlockEntityGroundStorage;
+                                if (begs?.IsFull == false) // (begs?.GetSlotAt(bs).Empty == true) only updated when initially moving the mouse onto the block
+                                {
+                                    return wi.Itemstacks;
+                                }
+                                return null;
+                            }
                         });
                         interactions.Add(new()
                         {

--- a/Block/BlockGroundStorage.cs
+++ b/Block/BlockGroundStorage.cs
@@ -517,12 +517,6 @@ namespace Vintagestory.GameContent
                         });
                         interactions.Add(new()
                         {
-                            ActionLangCode = "blockhelp-groundstorage-removeone",
-                            MouseButton = EnumMouseButton.Right,
-                            HotKeyCode = null
-                        });
-                        interactions.Add(new()
-                        {
                             ActionLangCode = "blockhelp-groundstorage-addbulk",
                             MouseButton = EnumMouseButton.Right,
                             HotKeyCodes = ["ctrl", "shift"],
@@ -535,6 +529,12 @@ namespace Vintagestory.GameContent
                                 }
                                 return null;
                             }
+                        });
+                        interactions.Add(new()
+                        {
+                            ActionLangCode = "blockhelp-groundstorage-removeone",
+                            MouseButton = EnumMouseButton.Right,
+                            HotKeyCode = null
                         });
                         interactions.Add(new()
                         {

--- a/Block/BlockPitkiln.cs
+++ b/Block/BlockPitkiln.cs
@@ -165,6 +165,26 @@ namespace Vintagestory.GameContent
             return GetBlockEntity<BlockEntityGroundStorage>(blockSel.Position)?.OnPlayerInteractStart(byPlayer, blockSel) ?? false;
         }
 
+        public bool TryGetBuildStagesForGroundStorage(BlockEntityGroundStorage beg, out BuildStage[] buildStages)
+        {
+            bool found = false;
+            foreach (var val in BuildStagesByBlock)
+            {
+                if (!beg.Inventory[0].Empty && WildcardUtil.Match(new AssetLocation(val.Key), beg.Inventory[0].Itemstack.Collectible.Code))
+                {
+                    buildStages = val.Value;
+                    found = true;
+                    return true;
+                }
+            }
+            if (!found)
+            {
+                return BuildStagesByBlock.TryGetValue("*", out buildStages);
+            }
+            buildStages = null;
+            return false;
+        }
+
         public bool TryCreateKiln(IWorldAccessor world, IPlayer byPlayer, BlockPos pos)
         {
             ItemSlot hotbarSlot = byPlayer.InventoryManager.ActiveHotbarSlot;
@@ -217,22 +237,7 @@ namespace Vintagestory.GameContent
                 if (!ok) return false;
 
 
-                BuildStage[] buildStages = null;
-                bool found = false;
-                foreach (var val in BuildStagesByBlock)
-                {
-                    if (!beg.Inventory[0].Empty && WildcardUtil.Match(new AssetLocation(val.Key), beg.Inventory[0].Itemstack.Collectible.Code))
-                    {
-                        buildStages = val.Value;
-                        found = true;
-                        break;
-                    }
-                }
-                if (!found)
-                {
-                    BuildStagesByBlock.TryGetValue("*", out buildStages);
-                }
-
+                TryGetBuildStagesForGroundStorage(beg, out BuildStage[] buildStages);
                 if (buildStages == null) return false;
                 if (!hotbarSlot.Itemstack.Equals(world, buildStages[0].Materials[0].ItemStack, GlobalConstants.IgnoredStackAttributes) || hotbarSlot.StackSize < buildStages[0].Materials[0].ItemStack.StackSize) return false;
 
@@ -297,7 +302,7 @@ namespace Vintagestory.GameContent
                     return new WorldInteraction[] { new WorldInteraction() {
                         ActionLangCode = "blockhelp-pitkiln-build",
                         MouseButton = EnumMouseButton.Right,
-                        HotKeyCode = "shift",
+                        HotKeyCode = null,
                         Itemstacks = stacks.ToArray(),
                         GetMatchingStacks = (wi, bs, es) => {
                             return stacks;

--- a/BlockEntity/BEGroundStorage.cs
+++ b/BlockEntity/BEGroundStorage.cs
@@ -1240,6 +1240,8 @@ namespace Vintagestory.GameContent
             if (Api != null)
             {
                 DetermineStorageProperties(null);
+
+                LightUpdate();
             }
 
             MeshAngle = tree.GetFloat("meshAngle");

--- a/BlockEntity/BEGroundStorage.cs
+++ b/BlockEntity/BEGroundStorage.cs
@@ -1068,27 +1068,33 @@ namespace Vintagestory.GameContent
 
         public bool putOrGetItemSingle(ItemSlot ourSlot, IPlayer player, BlockSelection bs)
         {
-            ItemSlot hotbarSlot = player.InventoryManager.ActiveHotbarSlot;
-
-            if (!hotbarSlot.Empty && !inventory.Empty)
-            {
-                var hotbarlayout = hotbarSlot.Itemstack.Collectible.GetBehavior<CollectibleBehaviorGroundStorable>()?.StorageProps.Layout;
-                bool layoutEqual = StorageProps.Layout == hotbarlayout;
-
-                if (StorageProps.Layout == EnumGroundStorageLayout.Quadrants && hotbarlayout == EnumGroundStorageLayout.Messy12)
-                {
-                    layoutEqual = true;
-                    overrideLayout = EnumGroundStorageLayout.Quadrants;
-                }
-
-                if (!layoutEqual) return false;
-            }
-
             lock (inventoryLock)
             {
                 if (ourSlot.Empty)
                 {
+                    ItemSlot hotbarSlot = player.InventoryManager.ActiveHotbarSlot;
+
                     if (hotbarSlot.Empty || !player.Entity.Controls.ShiftKey) return false;
+
+                    if (!inventory.Empty)
+                    {
+                        var hotbarlayout = hotbarSlot.Itemstack.Collectible.GetBehavior<CollectibleBehaviorGroundStorable>()?.StorageProps.Layout;
+                        bool layoutEqual = StorageProps.Layout == hotbarlayout;
+
+                        if (StorageProps.Layout == EnumGroundStorageLayout.Quadrants && hotbarlayout == EnumGroundStorageLayout.Messy12)
+                        {
+                            layoutEqual = true;
+                            overrideLayout = EnumGroundStorageLayout.Quadrants;
+                        }
+
+                        // allows picking up Quadrants-layout items placed in SingleCenter while having an item in hand
+                        if (StorageProps.Layout == EnumGroundStorageLayout.SingleCenter && hotbarlayout == EnumGroundStorageLayout.Quadrants)
+                        {
+                            layoutEqual = true;
+                        }
+
+                        if (!layoutEqual) return false;
+                    }
 
                     if (player.WorldData.CurrentGameMode == EnumGameMode.Creative)
                     {

--- a/BlockEntity/BEGroundStorage.cs
+++ b/BlockEntity/BEGroundStorage.cs
@@ -150,6 +150,48 @@ namespace Vintagestory.GameContent
             }
         }
 
+        public bool IsFull
+        {
+            get
+            {
+                if (StorageProps == null) return false;
+                for (int slotId = 0; slotId < UsableSlots(StorageProps.Layout); slotId++)
+                {
+                    if (inventory[slotId].Empty) return false;
+                }
+                switch (StorageProps.Layout)
+                {
+                    case EnumGroundStorageLayout.SingleCenter:
+                    case EnumGroundStorageLayout.Halves:
+                    case EnumGroundStorageLayout.WallHalves:
+                    case EnumGroundStorageLayout.Quadrants: return true;
+                    case EnumGroundStorageLayout.Messy12: return inventory[0].StackSize >= 12;
+                    case EnumGroundStorageLayout.Stacking:
+                    {
+                        if (TotalStackSize >= Capacity)
+                        {
+                            BlockPos abovePos = Pos.UpCopy();
+                            var beg = Block.GetBlockEntity<BlockEntityGroundStorage>(abovePos);
+                            if (StorageProps.UpSolid && beg != null && beg.StorageProps.Layout == EnumGroundStorageLayout.Stacking &&
+                                beg.inventory[0].Itemstack?.Equals(Api.World, inventory[0].Itemstack, GlobalConstants.IgnoredStackAttributes) == true)
+                            {
+                                return beg.IsFull;
+                            }
+
+                            if (StorageProps.MaxStackingHeight > 0)
+                            {
+                                return StackHeight >= StorageProps.MaxStackingHeight;
+                            }
+
+                            return true;
+                        }
+                        return false;
+                    }
+                    default: return false;
+                }
+            }
+        }
+
         public int StackHeight
         {
             get

--- a/BlockEntity/BEGroundStorage.cs
+++ b/BlockEntity/BEGroundStorage.cs
@@ -339,11 +339,20 @@ namespace Vintagestory.GameContent
 
         public override void CheckInventoryClearedMidTick()
         {
-            if (Inventory.Empty)
+            removeIfEmpty();
+        }
+
+        private bool removeIfEmpty()
+        {
+            if (!clientsideFirstPlacement && Inventory.Empty)
             {
                 // all slots are null, we need to destroy this GroundStorage BlockEntity
                 Api.World.BlockAccessor.SetBlock(0, Pos);
+                Api.World.BlockAccessor.TriggerNeighbourBlockUpdate(Pos);
+                return true;
             }
+
+            return false;
         }
 
         public void CoolNow(float amountRel, OnStackToCool onStackToCoolCallback)
@@ -523,6 +532,7 @@ namespace Vintagestory.GameContent
 
         public virtual bool OnPlayerInteractStart(IPlayer player, BlockSelection bs)
         {
+            isUsingSlot = null;
             int targetSlotId = GetSlotIdAt(bs);
             if (inventory[targetSlotId] is ItemSlot ourSlot && !ourSlot.Empty)
             {
@@ -543,7 +553,7 @@ namespace Vintagestory.GameContent
 
             DetermineStorageProperties(hotbarSlot);
 
-            bool ok = false;
+            bool didMoveItems = false;
 
             if (StorageProps != null)
             {
@@ -579,23 +589,25 @@ namespace Vintagestory.GameContent
                     case EnumGroundStorageLayout.Messy12:
                     case EnumGroundStorageLayout.Stacking:
                     {
-                        ok = putOrGetItemStacking(player, bs);
+                        didMoveItems = putOrGetItemStacking(player, bs);
                         break;
                     }
                     default:
                     {
-                        ok = putOrGetItemSingle(GetSlotAt(bs), player, bs);
+                        didMoveItems = putOrGetItemSingle(targetSlot, player, bs);
                         break;
                     }
                 }
             }
-            UpdateIgnitable();
-            renderer?.UpdateTemps();
 
-            if (ok)
-            {
-                MarkDirty();    // Don't re-draw on client yet, that will be handled in FromTreeAttributes after we receive an updating packet from the server  (updating meshes here would have the wrong inventory contents, and also create a potential race condition)
-            }
+            if (!didMoveItems) return false;
+
+            Api.World.BlockAccessor.TriggerNeighbourBlockUpdate(Pos);
+            Api.World.PlaySoundAt(StorageProps.PlaceRemoveSound, Pos.X + 0.5, Pos.InternalY, Pos.Z + 0.5, player, 0.88f + (float)Api.World.Rand.NextDouble() * 0.24f, 16);
+
+            // Don't re-draw on client yet, that will be handled in FromTreeAttributes after we receive an updating packet from the server,
+            // Updating meshes here would have the wrong inventory contents, and also create a potential race condition
+            MarkDirty();
 
             Cuboidf colBox = colBoxes[colBoxes.Length > targetSlotId ? targetSlotId : 0];
             if (CollisionTester.AabbIntersect(
@@ -610,24 +622,20 @@ namespace Vintagestory.GameContent
 
             (player as IClientPlayer)?.TriggerFpAnimation(EnumHandInteract.HeldItemInteract);
 
-            if (inventory.Empty && !clientsideFirstPlacement)
+            if (removeIfEmpty()) return true;
+
+            regenCollisionSelectionBox();
+
+            UpdateIgnitable();
+            renderer?.UpdateTemps();
+
+            var lshv = GetLightHsv();
+            if ((lastLightHsv != null && lastLightHsv[2] > 0) && (lshv == null || lshv[2] == 0))
             {
-                Api.World.BlockAccessor.SetBlock(0, Pos);
-                Api.World.BlockAccessor.TriggerNeighbourBlockUpdate(Pos);
-                if (lastLightHsv != null && lastLightHsv[2] > 0)
-                {
-                    Api.World.BlockAccessor.RemoveBlockLight((byte[])lastLightHsv.Clone(), Pos);
-                }
-            } else
-            {
-                var lshv = GetLightHsv();
-                if ((lastLightHsv != null && lastLightHsv[2] > 0) && (lshv == null || lshv[2] == 0))
-                {
-                    Api.World.BlockAccessor.RemoveBlockLight((byte[])lastLightHsv.Clone(), Pos);
-                }
+                Api.World.BlockAccessor.RemoveBlockLight((byte[])lastLightHsv.Clone(), Pos);
             }
 
-            return ok;
+            return true;
         }
 
         public bool OnPlayerInteractStep(float secondsUsed, IPlayer byPlayer, BlockSelection blockSel)
@@ -737,8 +745,6 @@ namespace Vintagestory.GameContent
 
             if (StorageProps == null) return;  // Seems necessary to avoid crash with certain items placed in game version 1.15-pre.1?
 
-            regenCollisionSelectionBox();
-
             UpdateLegacyStorageLayouts();
 
             if (overrideLayout != null)
@@ -746,6 +752,8 @@ namespace Vintagestory.GameContent
                 this.StorageProps = StorageProps.Clone();
                 this.StorageProps.Layout = (EnumGroundStorageLayout)overrideLayout;
             }
+
+            regenCollisionSelectionBox();
         }
 
         private void regenCollisionSelectionBox()
@@ -753,7 +761,7 @@ namespace Vintagestory.GameContent
             List<Cuboidf> auxColBoxes = [];
             List<Cuboidf> auxSelBoxes = [];
 
-            float meshAngleDegRounded = MathF.Round(MeshAngle / GameMath.PIHALF) * 90;
+            float meshAngleDegRounded = MathF.Round(MeshAngle / GameMath.PIHALF) * 90; // ideally, instead of rounding angle, boxes should be rotated and downscaled
             Vec3d centerOrigin = new(0.5, 0.5, 0.5);
 
             for (int slotId = 0; slotId < UsableSlots(StorageProps.Layout); slotId++)
@@ -933,17 +941,13 @@ namespace Vintagestory.GameContent
 
         protected bool putOrGetItemStacking(IPlayer byPlayer, BlockSelection bs)
         {
-            if (Api.Side == EnumAppSide.Client)
-            {
-                (byPlayer as IClientPlayer)?.TriggerFpAnimation(EnumHandInteract.HeldItemInteract);
-                return true;
-            }
+            bool newStorage = inventory[0].Empty;
 
             ItemSlot hotbarSlot = byPlayer.InventoryManager.ActiveHotbarSlot;
 
             bool sneaking = byPlayer.Entity.Controls.ShiftKey;
 
-            bool equalStack = inventory[0].Empty || !sneaking || (hotbarSlot.Itemstack != null && hotbarSlot.Itemstack.Equals(Api.World, inventory[0].Itemstack, GlobalConstants.IgnoredStackAttributes));
+            bool equalStack = newStorage || !sneaking || (hotbarSlot.Itemstack != null && hotbarSlot.Itemstack.Equals(Api.World, inventory[0].Itemstack, GlobalConstants.IgnoredStackAttributes));
 
             BlockPos abovePos = Pos.UpCopy();
             var beg = Block.GetBlockEntity<BlockEntityGroundStorage>(abovePos);
@@ -985,6 +989,29 @@ namespace Vintagestory.GameContent
                 return false;
             }
 
+            // @MKMoose 04.08.2026
+            // Frankly I don't know why this function returned early
+            // It caused animations and other stuff to run when no items were actually being moved
+            // But if it is actually needed to return early, then predicting whether anything can be done seems better than a blanket true return
+            // Also added auditing instead of a silent return
+
+            // if (Api.Side == EnumAppSide.Client)
+            // {
+            //     // try to predict whether anything can be added or taken to trigger sounds and animations more correctly
+            //     // better to return a false positive than a false negative here, as a false negative prevents the client from doing anything
+            //     bool canMoveItems = (!IsFull && sneaking) || (!newStorage && !sneaking);
+
+            //     if (canMoveItems)
+            //     {
+            //         Api.World.Logger.Audit("{0} Tried interacting with existing Ground storage at {1} - client side returns early here.",
+            //             byPlayer.PlayerName,
+            //             Pos
+            //         );
+            //     }
+
+            //     return canMoveItems;
+            // }
+
             lock (inventoryLock)
             {
                 if (sneaking)
@@ -1008,75 +1035,24 @@ namespace Vintagestory.GameContent
 
             ItemSlot invSlot = inventory[0];
 
-            if (invSlot.Empty)
-            {
-                bool putBulk = player.Entity.Controls.CtrlKey;
+            ItemSlot sourceSlot = player.WorldData.CurrentGameMode == EnumGameMode.Creative ? new DummySlot(hotbarSlot.Itemstack.Clone()) : hotbarSlot;
 
-                if (hotbarSlot.TryPutInto(Api.World, invSlot, putBulk ? BulkTransferQuantity : TransferQuantity) > 0)
-                {
-                    Api.World.PlaySoundAt(StorageProps.PlaceRemoveSound.WithPathPrefixOnce("sounds/"), Pos.X + 0.5, Pos.InternalY, Pos.Z + 0.5, null, 0.88f + (float)Api.World.Rand.NextDouble() * 0.24f, 16);
-                    LightUpdate(invSlot.Itemstack);
-                }
+            bool newStorage = invSlot.Empty;
+            bool putBulk = player.Entity.Controls.CtrlKey;
 
-                Api.World.Logger.Audit("{0} Put {1}x{2} into new Ground storage at {3}.",
-                    player.PlayerName,
-                    TransferQuantity,
-                    invSlot.Itemstack.Collectible.Code,
-                    Pos
-                );
+            int quantityMoved = sourceSlot.TryPutInto(Api.World, invSlot, putBulk ? BulkTransferQuantity : TransferQuantity); //TEST temperature averaging
 
-                Api.World.BlockAccessor.TriggerNeighbourBlockUpdate(Pos);
-                regenCollisionSelectionBox();
-                return true;
-            }
+            if (quantityMoved <= 0) return false;
 
-            if (invSlot.Itemstack.Equals(Api.World, hotbarSlot.Itemstack, GlobalConstants.IgnoredStackAttributes))
-            {
-                bool putBulk = player.Entity.Controls.CtrlKey;
+            Api.World.Logger.Audit("{0} Put {1}x{2} into {3} Ground storage at {4}.",
+                player.PlayerName,
+                quantityMoved,
+                invSlot.Itemstack.Collectible.Code,
+                newStorage ? "new" : "",
+                Pos
+            );
 
-                int q = GameMath.Min(hotbarSlot.StackSize, putBulk ? BulkTransferQuantity : TransferQuantity, Capacity - TotalStackSize);
-
-                // add to the pile and average item temperatures
-                int oldSize = invSlot.Itemstack.StackSize;
-                invSlot.Itemstack.StackSize += q;
-                if (oldSize + q > 0)
-                {
-                    float tempPile = invSlot.Itemstack.Collectible.GetTemperature(Api.World, invSlot.Itemstack);
-                    float tempAdded = hotbarSlot.Itemstack.Collectible.GetTemperature(Api.World, hotbarSlot.Itemstack);
-                    invSlot.Itemstack.Collectible.SetTemperature(Api.World, invSlot.Itemstack, (tempPile * oldSize + tempAdded * q) / (oldSize + q), false);
-                }
-
-                if (player.WorldData.CurrentGameMode != EnumGameMode.Creative)
-                {
-                    hotbarSlot.TakeOut(q);
-                    hotbarSlot.OnItemSlotModified(null);
-                }
-
-                LightUpdate(invSlot.Itemstack);
-                Api.World.PlaySoundAt(StorageProps.PlaceRemoveSound.WithPathPrefixOnce("sounds/"), Pos.X + 0.5, Pos.InternalY, Pos.Z + 0.5, null, 0.88f + (float)Api.World.Rand.NextDouble() * 0.24f, 16);
-
-                Api.World.Logger.Audit("{0} Put {1}x{2} into Ground storage at {3}.",
-                    player.PlayerName,
-                    q,
-                    invSlot.Itemstack.Collectible.Code,
-                    Pos
-                );
-
-                Api.World.BlockAccessor.TriggerNeighbourBlockUpdate(Pos);
-                regenCollisionSelectionBox();
-
-                MarkDirty();
-
-                Cuboidf[] collBoxes = Api.World.BlockAccessor.GetBlock(Pos).GetCollisionBoxes(Api.World.BlockAccessor, Pos);
-                if (collBoxes != null && collBoxes.Length > 0 && CollisionTester.AabbIntersect(collBoxes[0], Pos.X, Pos.Y, Pos.Z, player.Entity.SelectionBox, player.Entity.Pos.XYZ))
-                {
-                    player.Entity.Pos.Y += collBoxes[0].Y2 - (player.Entity.Pos.Y - (int)player.Entity.Pos.Y);
-                }
-
-                return true;
-            }
-
-            return false;
+            return true;
         }
 
         public void LightUpdate(ItemStack itemstack)
@@ -1087,48 +1063,42 @@ namespace Vintagestory.GameContent
 
         public bool TryTakeItem(IPlayer player)
         {
-            bool takeBulk = player.Entity.Controls.CtrlKey;
-            int q = GameMath.Min(takeBulk ? BulkTransferQuantity : TransferQuantity, TotalStackSize);
+            int quantityMoved = 0;
 
             ItemStack stack = null;
             if (inventory[0]?.Itemstack != null)
             {
-                stack = inventory[0].TakeOut(q);
-                player.InventoryManager.TryGiveItemstack(stack);
+                bool takeBulk = player.Entity.Controls.CtrlKey;
 
-                if (stack.StackSize > 0)
+                stack = inventory[0].TakeOut(GameMath.Min(takeBulk ? BulkTransferQuantity : TransferQuantity, TotalStackSize));
+                quantityMoved = stack.StackSize;
+
+                if (!player.InventoryManager.TryGiveItemstack(stack))
                 {
                     Api.World.SpawnItemEntity(stack, Pos);
                 }
-
-                Api.World.Logger.Audit("{0} Took {1}x{2} from Ground storage at {3}.",
-                    player.PlayerName,
-                    q,
-                    stack.Collectible.Code,
-                    Pos
-                );
-
-                LightUpdate(stack);
             }
 
-            if (TotalStackSize == 0)
-            {
-                Api.World.BlockAccessor.SetBlock(0, Pos);
-                if (stack != null) Api.World.BlockAccessor.RemoveBlockLight(stack.Collectible.GetLightHsv(Api.World.BlockAccessor, null, stack), Pos);
-            }
-            else Api.World.BlockAccessor.TriggerNeighbourBlockUpdate(Pos);
+            if (quantityMoved <= 0) return false;
 
-            Api.World.PlaySoundAt(StorageProps.PlaceRemoveSound, Pos.X + 0.5, Pos.InternalY, Pos.Z + 0.5, null, 0.88f + (float)Api.World.Rand.NextDouble() * 0.24f, 16);
+            Api.World.Logger.Audit("{0} Took {1}x{2} from Ground storage at {3}.",
+                player.PlayerName,
+                quantityMoved,
+                stack.Collectible.Code,
+                Pos
+            );
 
-            MarkDirty();
-            regenCollisionSelectionBox();
-            (player as IClientPlayer)?.TriggerFpAnimation(EnumHandInteract.HeldItemInteract);
+            LightUpdate(stack);
+
+            removeIfEmpty();
 
             return true;
         }
 
         public bool putOrGetItemSingle(ItemSlot ourSlot, IPlayer player, BlockSelection bs)
         {
+            bool didMoveItem = false;
+
             lock (inventoryLock)
             {
                 if (ourSlot.Empty)
@@ -1137,7 +1107,8 @@ namespace Vintagestory.GameContent
 
                     if (hotbarSlot.Empty || !player.Entity.Controls.ShiftKey) return false;
 
-                    if (!inventory.Empty)
+                    bool newStorage = inventory.Empty;
+                    if (!newStorage)
                     {
                         var hotbarlayout = hotbarSlot.Itemstack.Collectible.GetBehavior<CollectibleBehaviorGroundStorable>()?.StorageProps.Layout;
                         bool layoutEqual = StorageProps.Layout == hotbarlayout;
@@ -1157,30 +1128,18 @@ namespace Vintagestory.GameContent
                         if (!layoutEqual) return false;
                     }
 
-                    if (player.WorldData.CurrentGameMode == EnumGameMode.Creative)
+                    ItemSlot sourceSlot = player.WorldData.CurrentGameMode == EnumGameMode.Creative ? new DummySlot(hotbarSlot.Itemstack.Clone()) : hotbarSlot;
+
+                    didMoveItem = sourceSlot.TryPutInto(Api.World, ourSlot, TransferQuantity) > 0;
+
+                    if (didMoveItem)
                     {
-                        ItemStack stack = hotbarSlot.Itemstack.Clone();
-                        stack.StackSize = 1;
-                        if (new DummySlot(stack).TryPutInto(Api.World, ourSlot, TransferQuantity) > 0) {
-                            Api.World.PlaySoundAt(StorageProps.PlaceRemoveSound, Pos.X + 0.5, Pos.InternalY, Pos.Z + 0.5, player, 0.88f + (float)Api.World.Rand.NextDouble() * 0.24f, 16);
-                            Api.World.Logger.Audit("{0} Put 1x{1} into Ground storage at {2}.",
-                                player.PlayerName,
-                                ourSlot.Itemstack.Collectible.Code,
-                                Pos
-                            );
-                            LightUpdate(stack);
-                        }
-                    } else {
-                        if (hotbarSlot.TryPutInto(Api.World, ourSlot, TransferQuantity) > 0)
-                        {
-                            Api.World.PlaySoundAt(StorageProps.PlaceRemoveSound, Pos.X + 0.5, Pos.InternalY, Pos.Z + 0.5, player, 0.88f + (float)Api.World.Rand.NextDouble() * 0.24f, 16);
-                            Api.World.Logger.Audit("{0} Put 1x{1} into Ground storage at {2}.",
-                                player.PlayerName,
-                                ourSlot.Itemstack.Collectible.Code,
-                                Pos
-                            );
-                            LightUpdate(ourSlot.Itemstack);
-                        }
+                        Api.World.Logger.Audit("{0} Put 1x{1} into {2} Ground storage at {3}.",
+                            player.PlayerName,
+                            ourSlot.Itemstack.Collectible.Code,
+                            newStorage ? "new" : "",
+                            Pos
+                        );
                     }
                 }
                 else
@@ -1190,21 +1149,19 @@ namespace Vintagestory.GameContent
                         Api.World.SpawnItemEntity(ourSlot.Itemstack, Pos);
                     }
 
-                    LightUpdate(ourSlot.Itemstack);
-
-                    Api.World.PlaySoundAt(StorageProps.PlaceRemoveSound, Pos.X + 0.5, Pos.InternalY, Pos.Z + 0.5, player, 0.88f + (float)Api.World.Rand.NextDouble() * 0.24f, 16);
-
                     Api.World.Logger.Audit("{0} Took 1x{1} from Ground storage at {2}.",
                         player.PlayerName,
                         ourSlot.Itemstack?.Collectible.Code,
                         Pos
                     );
+
                     ourSlot.Itemstack = null;
                     ourSlot.MarkDirty();
+                    didMoveItem = true;
                 }
             }
 
-            return true;
+            return didMoveItem;
         }
 
         public override void FromTreeAttributes(ITreeAttribute tree, IWorldAccessor worldForResolving)
@@ -1770,6 +1727,8 @@ namespace Vintagestory.GameContent
         {
             byte[] lighthsv = null;
 
+            // not exactly the correct way to merge lights, but it's only wrong when there's 3+ sources of 2+ types
+            // would be nice to have a ColorUtil.MergeLightHSV() equivalent for a list of HSVs
             foreach (var slot in inventory)
             {
                 if (slot.Empty) continue;

--- a/BlockEntity/BEGroundStorage.cs
+++ b/BlockEntity/BEGroundStorage.cs
@@ -299,7 +299,6 @@ namespace Vintagestory.GameContent
                 bh.FuelPos = Pos.Copy();
                 bh.OnFireDeath = _ => { Extinguish(); };
             }
-            UpdateIgnitable();
 
             DetermineStorageProperties(null);
 
@@ -407,11 +406,22 @@ namespace Vintagestory.GameContent
 
         private void UpdateIgnitable()
         {
-            var cbhgs = Inventory[0].Itemstack?.Collectible?.GetBehavior<CollectibleBehaviorGroundStorable>();
-            if (cbhgs != null)
+            switch (StorageProps.Layout)
             {
-                burnHoursPerItem = JsonObject.FromJson(cbhgs.propertiesAtString)["burnHoursPerItem"].AsFloat(burnHoursPerItem);
+                // currently only stacking layouts are ignitable
+                case EnumGroundStorageLayout.Messy12:
+                case EnumGroundStorageLayout.Stacking:
+                    var cbhgs = Inventory[0].Itemstack?.Collectible?.GetBehavior<CollectibleBehaviorGroundStorable>();
+                    if (cbhgs != null)
+                    {
+                        burnHoursPerItem = JsonObject.FromJson(cbhgs.propertiesAtString)["burnHoursPerItem"].AsFloat();
+                    }
+                    break;
+                default:
+                    burnHoursPerItem = 0;
+                    break;
             }
+
         }
 
         /// <summary>
@@ -638,7 +648,6 @@ namespace Vintagestory.GameContent
 
             (player as IClientPlayer)?.TriggerFpAnimation(EnumHandInteract.HeldItemInteract);
 
-            UpdateIgnitable();
             renderer?.UpdateTemps();
 
             return true;
@@ -758,6 +767,8 @@ namespace Vintagestory.GameContent
                 this.StorageProps = StorageProps.Clone();
                 this.StorageProps.Layout = (EnumGroundStorageLayout)overrideLayout;
             }
+
+            UpdateIgnitable();
 
             regenCollisionSelectionBox();
         }

--- a/BlockEntity/BEGroundStorage.cs
+++ b/BlockEntity/BEGroundStorage.cs
@@ -134,7 +134,8 @@ namespace Vintagestory.GameContent
 
         public int Capacity
         {
-            get {
+            get
+            {
                 if (StorageProps == null) return 1;
                 switch (StorageProps.Layout)
                 {
@@ -149,6 +150,22 @@ namespace Vintagestory.GameContent
             }
         }
 
+        public int StackHeight
+        {
+            get
+            {
+                int stackHeight = 1;
+                if (StorageProps.MaxStackingHeight > 0)
+                {
+                    BlockPos tempPos = Pos.Copy();
+                    while (Block.GetBlockEntity<BlockEntityGroundStorage>(tempPos.Down())?.inventory[0].Itemstack?.Equals(Api.World, inventory[0].Itemstack, GlobalConstants.IgnoredStackAttributes) == true)
+                    {
+                        stackHeight++;
+                    }
+                }
+                return stackHeight;
+            }
+        }
 
         public override InventoryBase Inventory
         {
@@ -631,23 +648,31 @@ namespace Vintagestory.GameContent
 
         public bool OnTryCreateKiln()
         {
-            ItemStack stack = inventory.FirstNonEmptySlot.Itemstack;
-            if (stack == null || StorageProps == null) return false;
+            return IsSuitableForKiln(true);
+        }
 
-            if (stack.StackSize > StorageProps.MaxFireable)
+        public bool IsSuitableForKiln(bool triggerIngameErrors = false)
+        {
+            if (StorageProps == null || inventory.Empty) return false;
+
+            foreach (ItemSlot slot in inventory)
             {
-                capi?.TriggerIngameError(this, "overfull", Lang.Get("Can only fire up to {0} at once.", StorageProps.MaxFireable));
-                return false;
+                ItemStack stack = slot.Itemstack;
+                if (stack == null) continue; // don't return false, as that would prevent building a pit kiln if some of the slots are empty
+
+                if (stack.StackSize > StorageProps.MaxFireable)
+                {
+                    if (triggerIngameErrors) capi?.TriggerIngameError(this, "overfull", Lang.Get("Can only fire up to {0} at once.", StorageProps.MaxFireable));
+                    return false;
+                }
+
+                CombustibleProperties combustibleProps = stack.Collectible.GetCombustibleProperties(Api.World, stack, null);
+                if (combustibleProps == null || combustibleProps.SmeltingType != EnumSmeltType.Fire)
+                {
+                    if (triggerIngameErrors) capi?.TriggerIngameError(this, "notfireable", Lang.Get("This is not a fireable block or item"));
+                    return false;
+                }
             }
-
-            CombustibleProperties combustibleProps = stack.Collectible.GetCombustibleProperties(Api.World, stack, null);
-            if (combustibleProps == null || combustibleProps.SmeltingType != EnumSmeltType.Fire)
-            {
-                capi?.TriggerIngameError(this, "notfireable", Lang.Get("This is not a fireable block or item", StorageProps.MaxFireable));
-                return false;
-            }
-
-
             return true;
         }
 
@@ -839,17 +864,7 @@ namespace Vintagestory.GameContent
                 {
                     if (!equalStack && bs.Face != BlockFacing.UP) return false;
 
-                    int stackHeight = 1;
-                    if (StorageProps.MaxStackingHeight > 0)
-                    {
-                        BlockPos tempPos = Pos.Copy();
-                        while (Block.GetBlockEntity<BlockEntityGroundStorage>(tempPos.Down())?.inventory[0].Itemstack?.Equals(Api.World, inventory[0].Itemstack, GlobalConstants.IgnoredStackAttributes) == true)
-                        {
-                            stackHeight++;
-                        }
-                    }
-
-                    if (StorageProps.MaxStackingHeight < 0 || stackHeight < StorageProps.MaxStackingHeight || !equalStack)
+                    if (StorageProps.MaxStackingHeight < 0 || StackHeight < StorageProps.MaxStackingHeight || !equalStack)
                     {
                         BlockGroundStorage bgs = pileblock as BlockGroundStorage;
                         var bsc = bs.Clone();

--- a/BlockEntity/BEGroundStorage.cs
+++ b/BlockEntity/BEGroundStorage.cs
@@ -345,8 +345,8 @@ namespace Vintagestory.GameContent
         {
             if (!clientsideFirstPlacement && Inventory.Empty)
             {
-                Api.World.BlockAccessor.SetBlock(0, Pos);
                 LightUpdate();
+                Api.World.BlockAccessor.SetBlock(0, Pos);
                 Api.World.BlockAccessor.TriggerNeighbourBlockUpdate(Pos);
                 return true;
             }

--- a/BlockEntity/BEGroundStorage.cs
+++ b/BlockEntity/BEGroundStorage.cs
@@ -157,23 +157,28 @@ namespace Vintagestory.GameContent
                 if (StorageProps == null) return false;
                 for (int slotId = 0; slotId < UsableSlots(StorageProps.Layout); slotId++)
                 {
-                    if (inventory[slotId].Empty) return false;
+                    if (inventory[slotId]?.Empty == true) return false;
                 }
                 switch (StorageProps.Layout)
                 {
                     case EnumGroundStorageLayout.SingleCenter:
                     case EnumGroundStorageLayout.Halves:
                     case EnumGroundStorageLayout.WallHalves:
-                    case EnumGroundStorageLayout.Quadrants: return true;
-                    case EnumGroundStorageLayout.Messy12: return inventory[0].StackSize >= 12;
+                    case EnumGroundStorageLayout.Quadrants:
+                        return true;
+
+                    case EnumGroundStorageLayout.Messy12:
+                        return TotalStackSize >= 12;
+
                     case EnumGroundStorageLayout.Stacking:
-                    {
                         if (TotalStackSize >= Capacity)
                         {
+                            if (!StorageProps.UpSolid) return true;
+
                             BlockPos abovePos = Pos.UpCopy();
-                            var beg = Block.GetBlockEntity<BlockEntityGroundStorage>(abovePos);
-                            if (StorageProps.UpSolid && beg != null && beg.StorageProps.Layout == EnumGroundStorageLayout.Stacking &&
-                                beg.inventory[0].Itemstack?.Equals(Api.World, inventory[0].Itemstack, GlobalConstants.IgnoredStackAttributes) == true)
+                            if (Block.GetBlockEntity<BlockEntityGroundStorage>(abovePos) is BlockEntityGroundStorage beg
+                                && beg.StorageProps?.Layout == EnumGroundStorageLayout.Stacking
+                                && beg.inventory[0].Itemstack?.Equals(Api.World, inventory[0].Itemstack, GlobalConstants.IgnoredStackAttributes) == true)
                             {
                                 return beg.IsFull;
                             }
@@ -182,12 +187,11 @@ namespace Vintagestory.GameContent
                             {
                                 return StackHeight >= StorageProps.MaxStackingHeight;
                             }
-
-                            return true;
                         }
                         return false;
-                    }
-                    default: return false;
+
+                    default:
+                        return false;
                 }
             }
         }

--- a/BlockEntity/BEGroundStorage.cs
+++ b/BlockEntity/BEGroundStorage.cs
@@ -62,6 +62,10 @@ namespace Vintagestory.GameContent
         protected virtual int invSlotCount => 4;
         protected Cuboidf[] colBoxes;
         protected Cuboidf[] selBoxes;
+        /// <summary>
+        /// used to push the player up after updating collision boxes when receiving a packet from the server
+        /// </summary>
+        protected Action clientCollisionCallback;
 
         ItemSlot isUsingSlot;
         /// <summary>
@@ -354,6 +358,19 @@ namespace Vintagestory.GameContent
             return false;
         }
 
+        protected void pushUpOnCollision(IPlayer player, Cuboidf colBox)
+        {
+            if (CollisionTester.AabbIntersect(
+                colBox,
+                Pos.X, Pos.Y, Pos.Z,
+                player.Entity.CollisionBox,
+                player.Entity.Pos.XYZ
+            ))
+            {
+                player.Entity.Pos.Y += colBox.Y2 - (player.Entity.Pos.Y - (int)player.Entity.Pos.Y);
+            }
+        }
+
         public void CoolNow(float amountRel, OnStackToCool onStackToCoolCallback)
         {
             if (!Inventory.Empty)
@@ -563,7 +580,7 @@ namespace Vintagestory.GameContent
 
             DetermineStorageProperties(hotbarSlot);
 
-            bool didMoveItems = false;
+            bool didMoveItems = false; // on the client side we don't move items so this is a prediction more than fact, on the server it's fully accurate
             ItemStack targetOrMovedStack = null; // a copy of the target stack (not nulled if the original gets taken out), or the stack which was put into the slot
 
             if (StorageProps != null)
@@ -615,38 +632,36 @@ namespace Vintagestory.GameContent
                 if (inventory[targetSlotId].Itemstack is ItemStack newStack) targetOrMovedStack = newStack;
             }
 
-            if (!didMoveItems) return false;
-
-            if (targetOrMovedStack != null)
+            if (targetOrMovedStack != null && didMoveItems)
             {
                 // take the sound from the moved item, not from the saved StorageProps which might contain a sound for a different item
                 AssetLocation placeRemoveSound = targetOrMovedStack.Collectible?.GetBehavior<CollectibleBehaviorGroundStorable>()?.StorageProps?.PlaceRemoveSound;
                 Api.World.PlaySoundAt(placeRemoveSound, Pos.X + 0.5, Pos.InternalY, Pos.Z + 0.5, player, 0.88f + (float)Api.World.Rand.NextDouble() * 0.24f, 16);
             }
 
-            if (!clientsideFirstPlacement && removeIfEmpty()) return true;
+            if (!clientsideFirstPlacement && removeIfEmpty()) return didMoveItems;
 
-            LightUpdate();
-            Api.World.BlockAccessor.TriggerNeighbourBlockUpdate(Pos);
+            if (!didMoveItems) return false;
 
             // Don't re-draw on client yet, that will be handled in FromTreeAttributes after we receive an updating packet from the server
             // Updating meshes here would have the wrong inventory contents, and also create a potential race condition
             MarkDirty();
 
-            regenCollisionSelectionBox();
-
-            Cuboidf colBox = colBoxes[colBoxes.Length > targetSlotId ? targetSlotId : 0];
-            if (CollisionTester.AabbIntersect(
-                colBox,
-                Pos.X, Pos.Y, Pos.Z,
-                player.Entity.CollisionBox,
-                player.Entity.Pos.XYZ
-            ))
+            // we don't move any items on the client side, so we can return early and update everything in FromTreeAttributes
+            if (Api.Side == EnumAppSide.Client)
             {
-                player.Entity.Pos.Y += colBox.Y2 - (player.Entity.Pos.Y - (int)player.Entity.Pos.Y);
+                (player as IClientPlayer)?.TriggerFpAnimation(EnumHandInteract.HeldItemInteract);
+
+                clientCollisionCallback += () => pushUpOnCollision(player, colBoxes[colBoxes.Length > targetSlotId ? targetSlotId : 0]);
+                return true;
             }
 
-            (player as IClientPlayer)?.TriggerFpAnimation(EnumHandInteract.HeldItemInteract);
+            LightUpdate();
+            Api.World.BlockAccessor.TriggerNeighbourBlockUpdate(Pos);
+
+            regenCollisionSelectionBox();
+
+            pushUpOnCollision(player, colBoxes[colBoxes.Length > targetSlotId ? targetSlotId : 0]);
 
             renderer?.UpdateTemps();
 
@@ -1013,6 +1028,20 @@ namespace Vintagestory.GameContent
 
                     if (StorageProps.MaxStackingHeight < 0 || StackHeight < StorageProps.MaxStackingHeight || !equalStack)
                     {
+                        // @MKMoose 05.08.2026
+                        // on the client side, don't create new storage and wait for server sync instead
+                        // it seems that creating new storage here sometimes causes desync that manifsests with a client-side BEGS in an air block
+                        // best guess is that it occurs when a client-side BGS gets created then removed but the server never realizes
+                        // so it leaves a client-side BEGS in an air block which doesn't get removed naturally, because it never existed on the server
+                        if (Api.Side == EnumAppSide.Client)
+                        {
+                            Api.World.Logger.Audit("{0} Tried creating new Ground storage at {1} - client side waits for the server here.",
+                                byPlayer.PlayerName,
+                                Pos
+                            );
+                            return true;
+                        }
+
                         BlockGroundStorage bgs = pileblock as BlockGroundStorage;
                         var bsc = bs.Clone();
                         bsc.Position = Pos;
@@ -1028,29 +1057,6 @@ namespace Vintagestory.GameContent
             {
                 return false;
             }
-
-            // @MKMoose 04.08.2026
-            // Frankly I don't know why this function returned early
-            // It caused animations and other stuff to run when no items were actually being moved
-            // But if it is actually needed to return early, then predicting whether anything can be done seems better than a blanket true return
-            // Also added auditing instead of a silent return
-
-            // if (Api.Side == EnumAppSide.Client)
-            // {
-            //     // try to predict whether anything can be added or taken to trigger sounds and animations more correctly
-            //     // better to return a false positive than a false negative here, as a false negative prevents the client from doing anything
-            //     bool canMoveItems = (!IsFull && sneaking) || (!newStorage && !sneaking);
-
-            //     if (canMoveItems)
-            //     {
-            //         Api.World.Logger.Audit("{0} Tried interacting with existing Ground storage at {1} - client side returns early here.",
-            //             byPlayer.PlayerName,
-            //             Pos
-            //         );
-            //     }
-
-            //     return canMoveItems;
-            // }
 
             lock (inventoryLock)
             {
@@ -1074,6 +1080,9 @@ namespace Vintagestory.GameContent
             if (hotbarSlot.Itemstack == null) return false;
 
             ItemSlot invSlot = inventory[0];
+
+            // return true to play sounds etc. on the client, but only move items on the server side
+            if (Api.Side == EnumAppSide.Client) return true;
 
             ItemSlot sourceSlot = player.WorldData.CurrentGameMode == EnumGameMode.Creative ? new DummySlot(hotbarSlot.Itemstack.Clone()) : hotbarSlot;
 
@@ -1127,6 +1136,9 @@ namespace Vintagestory.GameContent
             ItemStack stack = null;
             if (inventory[0]?.Itemstack != null)
             {
+                // return early on the client, but only move items on the server side
+                if (Api.Side == EnumAppSide.Client) return true;
+
                 bool takeBulk = player.Entity.Controls.CtrlKey;
 
                 stack = inventory[0].TakeOut(GameMath.Min(takeBulk ? BulkTransferQuantity : TransferQuantity, TotalStackSize));
@@ -1187,6 +1199,9 @@ namespace Vintagestory.GameContent
                         if (!layoutEqual) return false;
                     }
 
+                    // return early on the client, but only move items on the server side
+                    if (Api.Side == EnumAppSide.Client) return true;
+
                     ItemSlot sourceSlot = player.WorldData.CurrentGameMode == EnumGameMode.Creative ? new DummySlot(hotbarSlot.Itemstack.Clone()) : hotbarSlot;
 
                     didMoveItem = sourceSlot.TryPutInto(Api.World, ourSlot, TransferQuantity) > 0;
@@ -1203,6 +1218,9 @@ namespace Vintagestory.GameContent
                 }
                 else
                 {
+                    // return early on the client, but only move items on the server side
+                    if (Api.Side == EnumAppSide.Client) return true;
+
                     if (!player.InventoryManager.TryGiveItemstack(ourSlot.Itemstack, true))
                     {
                         Api.World.SpawnItemEntity(ourSlot.Itemstack, Pos);
@@ -1242,10 +1260,16 @@ namespace Vintagestory.GameContent
 
             if (Api != null)
             {
+                //? not sure
+                // CheckInventoryClearedMidTick();
+
                 DetermineStorageProperties(null);
 
                 LightUpdate();
             }
+
+            clientCollisionCallback?.Invoke();
+            clientCollisionCallback = null;
 
             MeshAngle = tree.GetFloat("meshAngle");
             AttachFace = BlockFacing.ALLFACES[tree.GetInt("attachFace")];

--- a/BlockEntity/BEGroundStorage.cs
+++ b/BlockEntity/BEGroundStorage.cs
@@ -987,11 +987,12 @@ namespace Vintagestory.GameContent
             bool equalStack = newStorage || !sneaking || (hotbarSlot.Itemstack?.Equals(Api.World, inventory[0].Itemstack, GlobalConstants.IgnoredStackAttributes) == true);
 
             BlockPos abovePos = Pos.UpCopy();
-            if (abovePos.Y >= Api.World.BlockAccessor.MapSizeY) return false;
 
             var beg = Block.GetBlockEntity<BlockEntityGroundStorage>(abovePos);
-            if (TotalStackSize >= Capacity && ((equalStack && beg?.StorageProps?.Layout == EnumGroundStorageLayout.Stacking) ||
-                (hotbarSlot.Empty && beg?.inventory[0].Itemstack?.Equals(Api.World, inventory[0].Itemstack, GlobalConstants.IgnoredStackAttributes) == true)))
+            if (TotalStackSize >= Capacity
+                && ((equalStack && beg?.StorageProps?.Layout == EnumGroundStorageLayout.Stacking)
+                    || (hotbarSlot.Empty && beg?.inventory[0].Itemstack?.Equals(Api.World, inventory[0].Itemstack, GlobalConstants.IgnoredStackAttributes) == true))
+                && (abovePos.Y < Api.World.BlockAccessor.MapSizeY))
             {
                 return beg.OnPlayerInteractStart(byPlayer, bs);
             }
@@ -1001,6 +1002,8 @@ namespace Vintagestory.GameContent
 
             if (sneaking && TotalStackSize >= Capacity)
             {
+                if (abovePos.Y >= Api.World.BlockAccessor.MapSizeY) return false;
+
                 Block pileblock = Api.World.BlockAccessor.GetBlock(Pos);
                 Block aboveblock = Api.World.BlockAccessor.GetBlock(abovePos);
 

--- a/BlockEntity/BEGroundStorage.cs
+++ b/BlockEntity/BEGroundStorage.cs
@@ -343,7 +343,7 @@ namespace Vintagestory.GameContent
 
         private bool removeIfEmpty()
         {
-            if (!clientsideFirstPlacement && Inventory.Empty)
+            if (Inventory.Empty)
             {
                 LightUpdate();
                 Api.World.BlockAccessor.SetBlock(0, Pos);
@@ -624,7 +624,7 @@ namespace Vintagestory.GameContent
                 Api.World.PlaySoundAt(placeRemoveSound, Pos.X + 0.5, Pos.InternalY, Pos.Z + 0.5, player, 0.88f + (float)Api.World.Rand.NextDouble() * 0.24f, 16);
             }
 
-            if (removeIfEmpty()) return true;
+            if (!clientsideFirstPlacement && removeIfEmpty()) return true;
 
             LightUpdate();
             Api.World.BlockAccessor.TriggerNeighbourBlockUpdate(Pos);

--- a/BlockEntity/BEGroundStorage.cs
+++ b/BlockEntity/BEGroundStorage.cs
@@ -11,8 +11,6 @@ using Vintagestory.API.MathTools;
 using Vintagestory.API.Util;
 using Vintagestory.Common.Collectible.Block;
 
-#nullable disable
-
 namespace Vintagestory.GameContent
 {
     public class BlockEntityGroundStorage : BlockEntityDisplay, IBlockEntityContainer, IRotatable, IHeatSource, ITemperatureSensitive, IExternalTickable
@@ -47,7 +45,7 @@ namespace Vintagestory.GameContent
         /// <summary>
         /// Properties of the ground storage - layout may be overridden, and other item-specific properties may not always be relevant
         /// </summary>
-        public GroundStorageProperties StorageProps { get; protected set; }
+        public GroundStorageProperties? StorageProps { get; protected set; }
         public bool forceStorageProps = false;
         protected EnumGroundStorageLayout? overrideLayout;
 
@@ -65,16 +63,16 @@ namespace Vintagestory.GameContent
         /// <summary>
         /// used to push the player up after updating collision boxes when receiving a packet from the server
         /// </summary>
-        protected Action clientCollisionCallback;
+        protected Action? clientCollisionCallback = null;
 
-        ItemSlot isUsingSlot;
+        ItemSlot? isUsingSlot = null;
         /// <summary>
         /// Needed to suppress client-side "set this block to air on empty inventory" functionality for newly placed blocks
         /// otherwise set block to air can be triggered e.g. by the second tick of a player's right-click block interaction client-side, before the first server packet arrived to set the inventory to non-empty (due to lag of any kind)
         /// </summary>
         public bool clientsideFirstPlacement = false;
 
-        private GroundStorageRenderer renderer;
+        private GroundStorageRenderer? renderer = null;
         public bool UseRenderer;
         public bool NeedsRetesselation;
 
@@ -86,7 +84,7 @@ namespace Vintagestory.GameContent
         /// <summary>
         /// used for custom scales when using GroundStorageRenderer
         /// </summary>
-        public ModelTransform[] ModelTransformsRenderer = new ModelTransform[4];
+        public ModelTransform?[] ModelTransformsRenderer = new ModelTransform[4];
 
         /// <summary>
         /// For Stacking layout only, cache each uploaded mesh so that it can be reused by the GroundStorageRenderer
@@ -96,7 +94,7 @@ namespace Vintagestory.GameContent
 
         private bool burning;
         private double burnStartTotalHours;
-        private ILoadedSound ambientSound;
+        private ILoadedSound? ambientSound = null;
         private long listenerId;
         private float burnHoursPerItem;
         private BlockFacing[] facings = (BlockFacing[])BlockFacing.ALLFACES.Clone();
@@ -207,7 +205,7 @@ namespace Vintagestory.GameContent
             get
             {
                 int stackHeight = 1;
-                if (StorageProps.MaxStackingHeight > 0)
+                if (StorageProps?.MaxStackingHeight > 0)
                 {
                     BlockPos tempPos = Pos.Copy();
                     while (Block.GetBlockEntity<BlockEntityGroundStorage>(tempPos.Down())?.inventory[0].Itemstack?.Equals(Api.World, inventory[0].Itemstack, GlobalConstants.IgnoredStackAttributes) == true)
@@ -232,7 +230,7 @@ namespace Vintagestory.GameContent
         public override string AttributeTransformCode => "groundStorageTransform";
 
         public float MeshAngle { get; set; }
-        public BlockFacing AttachFace { get; set; }
+        public BlockFacing AttachFace { get; set; } = BlockFacing.DOWN;
 
         public override TextureAtlasPosition this[string textureCode]
         {
@@ -252,7 +250,7 @@ namespace Vintagestory.GameContent
             }
         }
 
-        public bool CanAttachBlockAt(BlockFacing blockFace, Cuboidi attachmentArea)
+        public bool CanAttachBlockAt(BlockFacing blockFace, Cuboidi? attachmentArea)
         {
             if (StorageProps == null) return false;
             return blockFace == BlockFacing.UP && StorageProps.Layout == EnumGroundStorageLayout.Stacking && inventory[0].StackSize == Capacity && StorageProps.UpSolid;
@@ -273,12 +271,12 @@ namespace Vintagestory.GameContent
             selBoxes = new Cuboidf[] { new Cuboidf(0, 0, 0, 1, 0.25f, 1) };
         }
 
-        private ItemSlot GetAutoPullFromSlot(BlockFacing atBlockFace)
+        private ItemSlot? GetAutoPullFromSlot(BlockFacing atBlockFace)
         {
             return null;
         }
 
-        private ItemSlot GetAutoPushIntoSlot(BlockFacing atBlockFace, ItemSlot fromSlot)
+        private ItemSlot? GetAutoPushIntoSlot(BlockFacing atBlockFace, ItemSlot fromSlot)
         {
             return null;
         }
@@ -422,7 +420,7 @@ namespace Vintagestory.GameContent
 
         private void UpdateIgnitable()
         {
-            switch (StorageProps.Layout)
+            switch (StorageProps?.Layout)
             {
                 // currently only stacking layouts are ignitable
                 case EnumGroundStorageLayout.Messy12:
@@ -438,7 +436,6 @@ namespace Vintagestory.GameContent
                     burnHoursPerItem = 0;
                     break;
             }
-
         }
 
         /// <summary>
@@ -468,7 +465,7 @@ namespace Vintagestory.GameContent
                     return stack;
                 }
             }
-            return null;
+            return contents;
         }
 
         #region For trailer making
@@ -581,7 +578,7 @@ namespace Vintagestory.GameContent
             DetermineStorageProperties(hotbarSlot);
 
             bool didMoveItems = false; // on the client side we don't move items so this is a prediction more than fact, on the server it's fully accurate
-            ItemStack targetOrMovedStack = null; // a copy of the target stack (not nulled if the original gets taken out), or the stack which was put into the slot
+            ItemStack? targetOrMovedStack = null; // a copy of the target stack (not nulled if the original gets taken out), or the stack which was put into the slot
 
             if (StorageProps != null)
             {
@@ -626,7 +623,7 @@ namespace Vintagestory.GameContent
             if (targetOrMovedStack != null && didMoveItems)
             {
                 // take the sound from the moved item, not from the saved StorageProps which might contain a sound for a different item
-                AssetLocation placeRemoveSound = targetOrMovedStack.Collectible?.GetBehavior<CollectibleBehaviorGroundStorable>()?.StorageProps?.PlaceRemoveSound;
+                AssetLocation? placeRemoveSound = targetOrMovedStack.Collectible?.GetBehavior<CollectibleBehaviorGroundStorable>()?.StorageProps?.PlaceRemoveSound;
                 Api.World.PlaySoundAt(placeRemoveSound, Pos.X + 0.5, Pos.InternalY, Pos.Z + 0.5, player, 0.88f + (float)Api.World.Rand.NextDouble() * 0.24f, 16);
             }
 
@@ -731,7 +728,7 @@ namespace Vintagestory.GameContent
 
             for (int slotId = 0; slotId < UsableSlots(StorageProps.Layout); slotId++)
             {
-                ItemStack stack = inventory[slotId].Itemstack;
+                ItemStack? stack = inventory[slotId].Itemstack;
                 if (stack == null) continue; // don't return false, as that would prevent building a pit kiln if some of the slots are empty
 
                 if (stack.StackSize > StorageProps.MaxFireable)
@@ -750,28 +747,28 @@ namespace Vintagestory.GameContent
             return true;
         }
 
-        public virtual void DetermineStorageProperties(ItemSlot sourceSlot)
+        public virtual void DetermineStorageProperties(ItemSlot? sourceSlot)
         {
-            ItemStack sourceStack = inventory.FirstNonEmptySlot?.Itemstack ?? sourceSlot?.Itemstack;
+            ItemStack? sourceStack = inventory.FirstNonEmptySlot?.Itemstack ?? sourceSlot?.Itemstack;
 
-            var StorageProps = this.StorageProps;
+            GroundStorageProperties? candidateStorageProps = this.StorageProps;
             if (!forceStorageProps)
             {
-                if (StorageProps == null)
+                if (candidateStorageProps == null)
                 {
                     if (sourceStack == null) return;
 
-                    StorageProps = this.StorageProps = sourceStack.Collectible?.GetBehavior<CollectibleBehaviorGroundStorable>()?.StorageProps;
+                    candidateStorageProps = this.StorageProps = sourceStack.Collectible?.GetBehavior<CollectibleBehaviorGroundStorable>()?.StorageProps;
                 }
             }
 
-            if (StorageProps == null) return;  // Seems necessary to avoid crash with certain items placed in game version 1.15-pre.1?
+            if (candidateStorageProps == null) return;  // Seems necessary to avoid crash with certain items placed in game version 1.15-pre.1?
 
             UpdateLegacyStorageLayouts();
 
             if (overrideLayout != null)
             {
-                this.StorageProps = StorageProps.Clone();
+                this.StorageProps = candidateStorageProps.Clone();
                 this.StorageProps.Layout = (EnumGroundStorageLayout)overrideLayout;
             }
 
@@ -788,14 +785,21 @@ namespace Vintagestory.GameContent
             float meshAngleDegRounded = MathF.Round(MeshAngle / GameMath.PIHALF) * 90; // ideally, instead of rounding angle, boxes should be rotated and downscaled
             Vec3d centerOrigin = new(0.5, 0.5, 0.5);
 
+            if (StorageProps == null)
+            {
+                selBoxes = [new(0, 0, 0, 1, 0.125f, 1)];
+                colBoxes = [new(0, 0, 0, 1, 0, 1)];
+                return;
+            }
+
             for (int slotId = 0; slotId < UsableSlots(StorageProps.Layout); slotId++)
             {
-                ItemStack sourceStack = inventory[slotId]?.Itemstack;
+                ItemStack? sourceStack = inventory[slotId]?.Itemstack;
 
-                Cuboidf colBox = null;
-                Cuboidf selBox = null;
+                Cuboidf? colBox = null;
+                Cuboidf? selBox = null;
 
-                GroundStorageProperties stackStorageProps = sourceStack?.Collectible?.GetBehavior<CollectibleBehaviorGroundStorable>()?.StorageProps;
+                GroundStorageProperties? stackStorageProps = sourceStack?.Collectible?.GetBehavior<CollectibleBehaviorGroundStorable>()?.StorageProps;
 
                 if (stackStorageProps != null)
                 {
@@ -967,16 +971,16 @@ namespace Vintagestory.GameContent
 
         public static int UsableSlots(EnumGroundStorageLayout layout)
         {
-            switch (layout)
+            return layout switch
             {
-                case EnumGroundStorageLayout.SingleCenter: return 1;
-                case EnumGroundStorageLayout.Halves: return 2;
-                case EnumGroundStorageLayout.WallHalves: return 2;
-                case EnumGroundStorageLayout.Quadrants: return 4;
-                case EnumGroundStorageLayout.Messy12: return 1;
-                case EnumGroundStorageLayout.Stacking: return 1;
-                default: return 0;
-            }
+                EnumGroundStorageLayout.SingleCenter => 1,
+                EnumGroundStorageLayout.Halves => 2,
+                EnumGroundStorageLayout.WallHalves => 2,
+                EnumGroundStorageLayout.Quadrants => 4,
+                EnumGroundStorageLayout.Messy12 => 1,
+                EnumGroundStorageLayout.Stacking => 1,
+                _ => 0,
+            };
         }
 
         protected bool putOrGetItemStacking(IPlayer byPlayer, BlockSelection bs)
@@ -1030,7 +1034,7 @@ namespace Vintagestory.GameContent
                             return true;
                         }
 
-                        BlockGroundStorage bgs = pileblock as BlockGroundStorage;
+                        if (pileblock is not BlockGroundStorage bgs) return false;
                         var bsc = bs.Clone();
                         bsc.Position = Pos;
                         bsc.Face = BlockFacing.UP;
@@ -1086,7 +1090,7 @@ namespace Vintagestory.GameContent
             Api.World.Logger.Audit("{0} Put {1}x{2} into {3}Ground storage at {4}.",
                 player.PlayerName,
                 quantityMoved,
-                invSlot.Itemstack.Collectible.Code,
+                invSlot.Itemstack!.Collectible.Code,
                 isNewStorage ? "new " : "",
                 Pos
             );
@@ -1094,7 +1098,6 @@ namespace Vintagestory.GameContent
             return true;
         }
 
-#nullable enable
         public void LightUpdate(ItemStack? contextItemStack = null)
         {
             byte[] currentLightHsv = GetLightHsv();
@@ -1115,13 +1118,11 @@ namespace Vintagestory.GameContent
 
             lastLightHsv = currentLightHsv;
         }
-#nullable disable
 
         public bool TryTakeItem(IPlayer player)
         {
             int quantityMoved = 0;
 
-            ItemStack stack = null;
             if (inventory[0]?.Itemstack == null) return false;
 
             // return early on the client, only move items on the server side
@@ -1129,7 +1130,7 @@ namespace Vintagestory.GameContent
 
             bool takeBulk = player.Entity.Controls.CtrlKey;
 
-            stack = inventory[0].TakeOut(GameMath.Min(takeBulk ? BulkTransferQuantity : TransferQuantity, TotalStackSize));
+            ItemStack stack = inventory[0].TakeOut(GameMath.Min(takeBulk ? BulkTransferQuantity : TransferQuantity, TotalStackSize));
             quantityMoved = stack.StackSize;
 
             if (quantityMoved <= 0) return false;
@@ -1164,7 +1165,7 @@ namespace Vintagestory.GameContent
                     if (hotbarSlot.Empty || !player.Entity.Controls.ShiftKey) return false;
 
                     bool isNewStorage = inventory.Empty;
-                    if (!isNewStorage)
+                    if (!isNewStorage && StorageProps != null)
                     {
                         var hotbarlayout = hotbarSlot.Itemstack.Collectible.GetBehavior<CollectibleBehaviorGroundStorable>()?.StorageProps.Layout;
                         bool layoutEqual = StorageProps.Layout == hotbarlayout;
@@ -1195,7 +1196,7 @@ namespace Vintagestory.GameContent
 
                     Api.World.Logger.Audit("{0} Put 1x{1} into {2}Ground storage at {3}.",
                         player.PlayerName,
-                        ourSlot.Itemstack.Collectible.Code,
+                        ourSlot.Itemstack!.Collectible.Code,
                         isNewStorage ? "new " : "",
                         Pos
                     );
@@ -1292,11 +1293,11 @@ namespace Vintagestory.GameContent
             tree.SetBool("burning", burning);
             tree.SetDouble("lastTickTotalHours", burnStartTotalHours);
             tree.SetFloat("meshAngle", MeshAngle);
-            tree.SetInt("attachFace", AttachFace?.Index ?? 0);
+            tree.SetInt("attachFace", AttachFace.Index);
             tree.SetBool("isExternallyTicked", IsExternallyTicked);
         }
 
-        public override void OnBlockBroken(IPlayer byPlayer = null)
+        public override void OnBlockBroken(IPlayer? byPlayer = null)
         {
             // Handled by block.GetDrops()
             /*if (Api.World.Side == EnumAppSide.Server)
@@ -1309,21 +1310,19 @@ namespace Vintagestory.GameContent
 
         public virtual string GetBlockName()
         {
-            var props = StorageProps;
-            if (props == null || inventory.Empty) return Lang.Get("Empty pile");
+            if (StorageProps == null || inventory.Empty) return Lang.Get("Empty pile");
 
             string[] contentSummary = getContentSummary();
             if (contentSummary.Length == 1)
             {
                 var firstSlot = inventory.FirstNonEmptySlot;
 
-                ItemStack stack = firstSlot.Itemstack;
-                int sumQ = inventory.Sum(s => s.StackSize);
+                ItemStack stack = firstSlot.Itemstack!;
+                if (TotalStackSize == 1) return stack.GetName();
 
-                string name = firstSlot.Itemstack.Collectible.GetCollectibleInterface<IContainedCustomName>()?.GetContainedName(firstSlot, sumQ);
+                string? name = stack.Collectible.GetCollectibleInterface<IContainedCustomName>()?.GetContainedName(firstSlot, TotalStackSize);
+
                 if (name != null) return name;
-
-                if (sumQ == 1) return stack.GetName();
                 return contentSummary[0];
             }
 
@@ -1336,9 +1335,9 @@ namespace Vintagestory.GameContent
 
             string[] contentSummary = getContentSummary();
 
-            ItemStack stack = inventory.FirstNonEmptySlot.Itemstack;
+            ItemStack? stack = inventory.FirstNonEmptySlot.Itemstack;
             // Only add supplemental info for non-BlockEntities (otherwise it will be wrong or will get into a recursive loop, because right now this BEGroundStorage is the BlockEntity)
-            if (contentSummary.Length == 1 && stack.Collectible.GetCollectibleInterface<IContainedCustomName>() == null && stack.Class == EnumItemClass.Block && ((Block)stack.Collectible).EntityClass == null)
+            if (contentSummary.Length == 1 && stack?.Collectible.GetCollectibleInterface<IContainedCustomName>() == null && stack?.Class == EnumItemClass.Block && ((Block)stack.Collectible).EntityClass == null)
             {
                 string detailedInfo = stack.Block.GetPlacedBlockInfo(Api.World, Pos, forPlayer);
                 if (detailedInfo != null && detailedInfo.Length > 0) dsc.Append(detailedInfo);
@@ -1416,11 +1415,8 @@ namespace Vintagestory.GameContent
             {
                 capi.Event.EnqueueMainThreadTask(() =>
                 {
-                    if (renderer != null)
-                    {
-                        renderer.Dispose();
-                        renderer = null;
-                    }
+                    renderer?.Dispose();
+                    renderer = null;
                 }, "groundStorageRendererD");
             }
             NeedsRetesselation = false;
@@ -1430,7 +1426,7 @@ namespace Vintagestory.GameContent
             }
         }
 
-        protected Vec3f rotatedOffset(Vec3f offset, float radY)
+        protected static Vec3f rotatedOffset(Vec3f offset, float radY)
         {
             Matrixf mat = new Matrixf();
             mat.Translate(0.5f, 0.5f, 0.5f).RotateY(radY).Translate(-0.5f, -0.5f, -0.5f);
@@ -1503,9 +1499,13 @@ namespace Vintagestory.GameContent
             return (StorageProps?.Layout == EnumGroundStorageLayout.Messy12 ? "messy12-" : "") + ItemModelCount + "x" + base.getMeshCacheKey(slot);
         }
 
-        protected override MeshData getOrCreateMesh(ItemSlot slot, int index)
+        protected override MeshData? getOrCreateMesh(ItemSlot slot, int index)
         {
-            var stack = slot.Itemstack;
+            if (slot.Itemstack is not ItemStack stack)
+            {
+                return null;
+            }
+
             if (stack.Class == EnumItemClass.Block)
             {
                 if (stack.Block is IBlockMealContainer be and not BlockCrock) // Crocks don't render the actual meal mesh
@@ -1536,7 +1536,7 @@ namespace Vintagestory.GameContent
                 applyDefaultTranforms(stack, meshDataOne);
 
                 var meshData12 = meshDataOne.Clone().Clear();
-                var bgs = Block as BlockGroundStorage;
+                if (Block is not BlockGroundStorage bgs) return meshData12;
 
                 for (int i = 0; i < stack.StackSize; i++)
                 {
@@ -1561,8 +1561,9 @@ namespace Vintagestory.GameContent
 
                 if (mesh != null)
                 {
-                    if (UploadedMeshCache.TryGetValue(key, out MeshRefs[index]))
+                    if (UploadedMeshCache.TryGetValue(key, out MultiTextureMeshRef? meshRef))
                     {
+                        MeshRefs[index] = meshRef;
                         return mesh;
                     }
                     /// if the key is not in the cache, then we need to re-upload the mesh and re-populate MeshRefs
@@ -1619,14 +1620,16 @@ namespace Vintagestory.GameContent
             return meshData;
         }
 
-#nullable enable
         public virtual void GetOrCreateMealMesh(IBlockMealContainer be, ItemStack stack, int index)
         {
             var mealMeshCache = capi.ModLoader.GetModSystem<MealMeshCache>();
+            if (mealMeshCache == null) return;
             Vec3f? vec = be is BlockCookedContainer bc ? new Vec3f(0, bc.yoff / 16f, 0) : null;
-            MeshRefs[index] = mealMeshCache.GetOrCreateMealInContainerMeshRef(be, stack, vec);
+            if (mealMeshCache.GetOrCreateMealInContainerMeshRef(be, stack, vec) is MultiTextureMeshRef meshRef)
+            {
+                MeshRefs[index] = meshRef;
+            }
         }
-#nullable disable
 
         public void TryIgnite()
         {
@@ -1792,15 +1795,16 @@ namespace Vintagestory.GameContent
 
         public byte[] GetLightHsv()
         {
-            byte[] lighthsv = null;
+            byte[]? lighthsv = null;
 
-            // not exactly the correct way to merge lights, but it's only wrong when there's 3+ sources of 2+ types
+            // not exactly the correct way to merge lights, because it gives more weight to the last slots
+            // but it's only wrong when there's 3+ sources of 2+ different colors so it doesn't matter too much
             // would be nice to have a ColorUtil.MergeLightHSV() equivalent for a list of HSVs
             foreach (var slot in inventory)
             {
-                if (slot.Empty) continue;
-                var stacklighthsv = slot.Itemstack?.Collectible?.GetLightHsv(Api.World.BlockAccessor, null, slot.Itemstack);
-                if (lighthsv == null) lighthsv = (byte[])stacklighthsv?.Clone();
+                if (slot.Itemstack?.Collectible?.GetLightHsv(Api.World.BlockAccessor, null, slot.Itemstack) is not byte[] stacklighthsv) continue;
+
+                if (lighthsv == null) lighthsv = (byte[])stacklighthsv.Clone();
                 else lighthsv = ColorUtil.MergeLightHSV(lighthsv, stacklighthsv);
             }
 
@@ -1815,7 +1819,7 @@ namespace Vintagestory.GameContent
 
             AttachFace = BlockFacing.ALLFACES[tree.GetInt("attachFace")];
             AttachFace = AttachFace.FaceWhenRotatedBy(0, -degreeRotation * GameMath.DEG2RAD, 0);
-            tree.SetInt("attachFace", AttachFace?.Index ?? 0);
+            tree.SetInt("attachFace", AttachFace.Index);
         }
 
         public override void OnBlockUnloaded()
@@ -1841,7 +1845,7 @@ namespace Vintagestory.GameContent
         {
             if (capi == null) return; // we're server side then
 
-            Dictionary<string, MultiTextureMeshRef> UploadedMeshCache = ObjectCacheUtil.TryGet<Dictionary<string, MultiTextureMeshRef>>(capi, "groundStorageUMC");
+            Dictionary<string, MultiTextureMeshRef>? UploadedMeshCache = ObjectCacheUtil.TryGet<Dictionary<string, MultiTextureMeshRef>>(capi, "groundStorageUMC");
             if (UploadedMeshCache != null)
             {
                 foreach (var mesh in UploadedMeshCache.Values)

--- a/BlockEntity/BEGroundStorage.cs
+++ b/BlockEntity/BEGroundStorage.cs
@@ -800,10 +800,19 @@ namespace Vintagestory.GameContent
                     {
                         selBox = stackStorageProps.SelectionBox.Clone();
                     }
+
+                    if (colBox == null && selBox == null && sourceStack?.Block != null && stackStorageProps.Layout == EnumGroundStorageLayout.SingleCenter)
+                    {
+                        colBox = sourceStack.Block.CollisionBoxes[0].Clone();
+                        selBox = sourceStack.Block.SelectionBoxes[0].Clone();
+                    }
                 }
 
+                bool usesCustomBoxes = colBox != null || selBox != null;
+
                 // different default height for WallHalves is just because current JSON definitions overwhelmingly favor it for WallHalves for some reason
-                selBox ??= colBox?.Clone() ?? new(0, 0, 0, 1, StorageProps.Layout == EnumGroundStorageLayout.WallHalves ? 0.1f : 0.125f, 1);
+                float height = StorageProps.Layout == EnumGroundStorageLayout.WallHalves ? 0.1f : 0.125f;
+                selBox ??= colBox?.Clone() ?? new(0, 0, 0, 1, height, 1);
                 colBox ??= new(0, 0, 0, 1, 0, 1);
 
                 switch (StorageProps.Layout)
@@ -821,9 +830,14 @@ namespace Vintagestory.GameContent
                         transformCuboidForQuadrants(selBox, slotId);
                         break;
                     }
-                    case EnumGroundStorageLayout.SingleCenter when stackStorageProps?.Layout == EnumGroundStorageLayout.Quadrants:
+                    case EnumGroundStorageLayout.SingleCenter:
                     {
                         float scale = 0.5f;
+                        if (stackStorageProps?.Layout == EnumGroundStorageLayout.SingleCenter)
+                        {
+                            if (usesCustomBoxes) break;
+                            scale = 0.8f;
+                        }
                         transformCuboidForSingleCenter(colBox, scale);
                         transformCuboidForSingleCenter(selBox, scale);
                         break;

--- a/BlockEntity/BEGroundStorage.cs
+++ b/BlockEntity/BEGroundStorage.cs
@@ -346,8 +346,8 @@ namespace Vintagestory.GameContent
         {
             if (!clientsideFirstPlacement && Inventory.Empty)
             {
-                // all slots are null, we need to destroy this GroundStorage BlockEntity
                 Api.World.BlockAccessor.SetBlock(0, Pos);
+                LightUpdate();
                 Api.World.BlockAccessor.TriggerNeighbourBlockUpdate(Pos);
                 return true;
             }
@@ -528,7 +528,7 @@ namespace Vintagestory.GameContent
             return colBoxes;
         }
 
-        byte[] lastLightHsv;
+        byte[] lastLightHsv = new byte[3];
 
         public virtual bool OnPlayerInteractStart(IPlayer player, BlockSelection bs)
         {
@@ -554,6 +554,7 @@ namespace Vintagestory.GameContent
             DetermineStorageProperties(hotbarSlot);
 
             bool didMoveItems = false;
+            ItemStack targetOrMovedStack = null; // a copy of the target stack (not nulled if the original gets taken out), or the stack which was put into the slot
 
             if (StorageProps != null)
             {
@@ -584,6 +585,8 @@ namespace Vintagestory.GameContent
                 targetSlotId = GetSlotIdAt(bs); // refresh the slot id in case StorageProps changed
                 ItemSlot targetSlot = inventory[targetSlotId];
 
+                targetOrMovedStack = targetSlot.Itemstack?.Clone();
+
                 switch (StorageProps.Layout)
                 {
                     case EnumGroundStorageLayout.Messy12:
@@ -598,16 +601,29 @@ namespace Vintagestory.GameContent
                         break;
                     }
                 }
+
+                if (inventory[targetSlotId].Itemstack is ItemStack newStack) targetOrMovedStack = newStack;
             }
 
             if (!didMoveItems) return false;
 
-            Api.World.BlockAccessor.TriggerNeighbourBlockUpdate(Pos);
-            Api.World.PlaySoundAt(StorageProps.PlaceRemoveSound, Pos.X + 0.5, Pos.InternalY, Pos.Z + 0.5, player, 0.88f + (float)Api.World.Rand.NextDouble() * 0.24f, 16);
+            if (targetOrMovedStack != null)
+            {
+                // take the sound from the moved item, not from the saved StorageProps which might contain a sound for a different item
+                AssetLocation placeRemoveSound = targetOrMovedStack.Collectible?.GetBehavior<CollectibleBehaviorGroundStorable>()?.StorageProps?.PlaceRemoveSound;
+                Api.World.PlaySoundAt(placeRemoveSound, Pos.X + 0.5, Pos.InternalY, Pos.Z + 0.5, player, 0.88f + (float)Api.World.Rand.NextDouble() * 0.24f, 16);
+            }
 
-            // Don't re-draw on client yet, that will be handled in FromTreeAttributes after we receive an updating packet from the server,
+            if (removeIfEmpty()) return true;
+
+            LightUpdate();
+            Api.World.BlockAccessor.TriggerNeighbourBlockUpdate(Pos);
+
+            // Don't re-draw on client yet, that will be handled in FromTreeAttributes after we receive an updating packet from the server
             // Updating meshes here would have the wrong inventory contents, and also create a potential race condition
             MarkDirty();
+
+            regenCollisionSelectionBox();
 
             Cuboidf colBox = colBoxes[colBoxes.Length > targetSlotId ? targetSlotId : 0];
             if (CollisionTester.AabbIntersect(
@@ -622,18 +638,8 @@ namespace Vintagestory.GameContent
 
             (player as IClientPlayer)?.TriggerFpAnimation(EnumHandInteract.HeldItemInteract);
 
-            if (removeIfEmpty()) return true;
-
-            regenCollisionSelectionBox();
-
             UpdateIgnitable();
             renderer?.UpdateTemps();
-
-            var lshv = GetLightHsv();
-            if ((lastLightHsv != null && lastLightHsv[2] > 0) && (lshv == null || lshv[2] == 0))
-            {
-                Api.World.BlockAccessor.RemoveBlockLight((byte[])lastLightHsv.Clone(), Pos);
-            }
 
             return true;
         }
@@ -1055,11 +1061,28 @@ namespace Vintagestory.GameContent
             return true;
         }
 
-        public void LightUpdate(ItemStack itemstack)
+#nullable enable
+        public void LightUpdate(ItemStack? contextItemStack = null)
         {
-            lastLightHsv = itemstack.Collectible.GetLightHsv(Api.World.BlockAccessor, null, itemstack);
-            if (lastLightHsv != null && lastLightHsv[2] > 0) Api.World.BlockAccessor.ExchangeBlock(Block.Id, Pos); // Forces a lighting update
+            byte[] currentLightHsv = GetLightHsv();
+
+            if (currentLightHsv.SequenceEqual(lastLightHsv)) return;
+
+            // the provided stack should normally be unnecessary, but we can use it just in case
+            byte[] removeLightHsv = contextItemStack?.Collectible?.GetLightHsv(Api.World.BlockAccessor, null, contextItemStack) ?? new byte[3];
+
+            // pick the light with the highest radius to ensure that the full light radius gets updated
+            if (currentLightHsv[2] > removeLightHsv[2]) removeLightHsv = currentLightHsv;
+            if (lastLightHsv[2] > removeLightHsv[2]) removeLightHsv = lastLightHsv;
+
+            Api.World.BlockAccessor.RemoveBlockLight((byte[])removeLightHsv.Clone(), Pos);
+
+            // force a lighting update
+            Api.World.BlockAccessor.ExchangeBlock(Block.Id, Pos);
+
+            lastLightHsv = currentLightHsv;
         }
+#nullable disable
 
         public bool TryTakeItem(IPlayer player)
         {

--- a/BlockEntity/BEGroundStorage.cs
+++ b/BlockEntity/BEGroundStorage.cs
@@ -845,6 +845,12 @@ namespace Vintagestory.GameContent
                 auxSelBoxes.Add(selBox.RotatedCopy(0, meshAngleDegRounded, 0, centerOrigin));
             }
 
+            // block interaction help Y offset only seems to be refreshed when hovering over a different block
+            // different offsets for blocks of the same type don't seem like they're currently possible
+            // float maxHeight = auxSelBoxes.Max(cuboid => cuboid.Y2);
+            // (Block as BlockGroundStorage)?.InteractionHelpYOffset = maxHeight * 0.5f + 0.45f; // has to be less than 1
+
+
             colBoxes = [.. auxColBoxes];
             selBoxes = [.. auxSelBoxes];
         }
@@ -964,11 +970,13 @@ namespace Vintagestory.GameContent
 
             bool sneaking = byPlayer.Entity.Controls.ShiftKey;
 
-            bool equalStack = newStorage || !sneaking || (hotbarSlot.Itemstack != null && hotbarSlot.Itemstack.Equals(Api.World, inventory[0].Itemstack, GlobalConstants.IgnoredStackAttributes));
+            bool equalStack = newStorage || !sneaking || (hotbarSlot.Itemstack?.Equals(Api.World, inventory[0].Itemstack, GlobalConstants.IgnoredStackAttributes) == true);
 
             BlockPos abovePos = Pos.UpCopy();
+            if (abovePos.Y >= Api.World.BlockAccessor.MapSizeY) return false;
+
             var beg = Block.GetBlockEntity<BlockEntityGroundStorage>(abovePos);
-            if (TotalStackSize >= Capacity && ((beg != null && equalStack && beg.StorageProps.Layout == EnumGroundStorageLayout.Stacking) ||
+            if (TotalStackSize >= Capacity && ((equalStack && beg?.StorageProps?.Layout == EnumGroundStorageLayout.Stacking) ||
                 (hotbarSlot.Empty && beg?.inventory[0].Itemstack?.Equals(Api.World, inventory[0].Itemstack, GlobalConstants.IgnoredStackAttributes) == true)))
             {
                 return beg.OnPlayerInteractStart(byPlayer, bs);
@@ -981,8 +989,6 @@ namespace Vintagestory.GameContent
             {
                 Block pileblock = Api.World.BlockAccessor.GetBlock(Pos);
                 Block aboveblock = Api.World.BlockAccessor.GetBlock(abovePos);
-
-                if (abovePos.Y >= Api.World.BlockAccessor.MapSizeY) return false;
 
                 if (aboveblock.IsReplacableBy(pileblock))
                 {

--- a/BlockEntity/BEGroundStorage.cs
+++ b/BlockEntity/BEGroundStorage.cs
@@ -178,23 +178,22 @@ namespace Vintagestory.GameContent
                         return TotalStackSize >= 12;
 
                     case EnumGroundStorageLayout.Stacking:
-                        if (TotalStackSize >= Capacity)
+                        if (TotalStackSize < Capacity) return false;
+                        if (!StorageProps.UpSolid) return true;
+
+                        BlockPos abovePos = Pos.UpCopy();
+                        if (Block.GetBlockEntity<BlockEntityGroundStorage>(abovePos) is BlockEntityGroundStorage beg
+                            && beg.StorageProps?.Layout == EnumGroundStorageLayout.Stacking
+                            && beg.inventory[0].Itemstack?.Equals(Api.World, inventory[0].Itemstack, GlobalConstants.IgnoredStackAttributes) == true)
                         {
-                            if (!StorageProps.UpSolid) return true;
-
-                            BlockPos abovePos = Pos.UpCopy();
-                            if (Block.GetBlockEntity<BlockEntityGroundStorage>(abovePos) is BlockEntityGroundStorage beg
-                                && beg.StorageProps?.Layout == EnumGroundStorageLayout.Stacking
-                                && beg.inventory[0].Itemstack?.Equals(Api.World, inventory[0].Itemstack, GlobalConstants.IgnoredStackAttributes) == true)
-                            {
-                                return beg.IsFull;
-                            }
-
-                            if (StorageProps.MaxStackingHeight > 0)
-                            {
-                                return StackHeight >= StorageProps.MaxStackingHeight;
-                            }
+                            return beg.IsFull;
                         }
+
+                        if (StorageProps.MaxStackingHeight > 0)
+                        {
+                            return StackHeight >= StorageProps.MaxStackingHeight;
+                        }
+
                         return false;
 
                     default:
@@ -434,6 +433,7 @@ namespace Vintagestory.GameContent
                         burnHoursPerItem = JsonObject.FromJson(cbhgs.propertiesAtString)["burnHoursPerItem"].AsFloat();
                     }
                     break;
+
                 default:
                     burnHoursPerItem = 0;
                     break;
@@ -614,20 +614,11 @@ namespace Vintagestory.GameContent
 
                 targetOrMovedStack = targetSlot.Itemstack?.Clone();
 
-                switch (StorageProps.Layout)
+                didMoveItems = StorageProps.Layout switch
                 {
-                    case EnumGroundStorageLayout.Messy12:
-                    case EnumGroundStorageLayout.Stacking:
-                    {
-                        didMoveItems = putOrGetItemStacking(player, bs);
-                        break;
-                    }
-                    default:
-                    {
-                        didMoveItems = putOrGetItemSingle(targetSlot, player, bs);
-                        break;
-                    }
-                }
+                    EnumGroundStorageLayout.Messy12 or EnumGroundStorageLayout.Stacking => putOrGetItemStacking(player, bs),
+                    _ => putOrGetItemSingle(targetSlot, player, bs),
+                };
 
                 if (inventory[targetSlotId].Itemstack is ItemStack newStack) targetOrMovedStack = newStack;
             }
@@ -835,19 +826,16 @@ namespace Vintagestory.GameContent
                 {
                     case EnumGroundStorageLayout.Halves:
                     case EnumGroundStorageLayout.WallHalves:
-                    {
                         transformCuboidForHalves(colBox, slotId);
                         transformCuboidForHalves(selBox, slotId);
                         break;
-                    }
+
                     case EnumGroundStorageLayout.Quadrants:
-                    {
                         transformCuboidForQuadrants(colBox, slotId);
                         transformCuboidForQuadrants(selBox, slotId);
                         break;
-                    }
+
                     case EnumGroundStorageLayout.SingleCenter:
-                    {
                         float scale = 0.5f;
                         if (stackStorageProps?.Layout == EnumGroundStorageLayout.SingleCenter)
                         {
@@ -857,17 +845,16 @@ namespace Vintagestory.GameContent
                         transformCuboidForSingleCenter(colBox, scale);
                         transformCuboidForSingleCenter(selBox, scale);
                         break;
-                    }
+
                     case EnumGroundStorageLayout.Stacking:
-                    {
                         if (StorageProps.CbScaleYByLayer != 0)
                         {
-                            float scale = (int)Math.Ceiling(StorageProps.CbScaleYByLayer * sourceStack?.StackSize ?? 1);
-                            colBox.Y2 *= scale;
-                            selBox.Y2 *= scale;
+                            float heightMultiple = (int)Math.Ceiling(StorageProps.CbScaleYByLayer * sourceStack?.StackSize ?? 1);
+                            colBox.Y2 *= heightMultiple;
+                            selBox.Y2 *= heightMultiple;
                         }
                         break;
-                    }
+
                     default: break;
                 }
 
@@ -994,13 +981,13 @@ namespace Vintagestory.GameContent
 
         protected bool putOrGetItemStacking(IPlayer byPlayer, BlockSelection bs)
         {
-            bool newStorage = inventory[0].Empty;
+            bool isNewStorage = inventory[0].Empty;
 
             ItemSlot hotbarSlot = byPlayer.InventoryManager.ActiveHotbarSlot;
 
             bool sneaking = byPlayer.Entity.Controls.ShiftKey;
 
-            bool equalStack = newStorage || !sneaking || (hotbarSlot.Itemstack?.Equals(Api.World, inventory[0].Itemstack, GlobalConstants.IgnoredStackAttributes) == true);
+            bool equalStack = isNewStorage || !sneaking || (hotbarSlot.Itemstack?.Equals(Api.World, inventory[0].Itemstack, GlobalConstants.IgnoredStackAttributes) == true);
 
             BlockPos abovePos = Pos.UpCopy();
 
@@ -1082,12 +1069,12 @@ namespace Vintagestory.GameContent
 
             if (hotbarSlot.Itemstack == null) return false;
 
-            // return true to play sounds etc. on the client, but only move items on the server side
+            // return early on the client, only move items on the server side
             if (Api.Side == EnumAppSide.Client) return true;
 
             ItemSlot sourceSlot = player.WorldData.CurrentGameMode == EnumGameMode.Creative ? new DummySlot(hotbarSlot.Itemstack.Clone()) : hotbarSlot;
 
-            bool newStorage = invSlot.Empty;
+            bool isNewStorage = invSlot.Empty;
             bool putBulk = player.Entity.Controls.CtrlKey;
 
             int quantityToMove = putBulk ? BulkTransferQuantity : TransferQuantity;
@@ -1096,11 +1083,11 @@ namespace Vintagestory.GameContent
 
             if (quantityMoved <= 0) return false;
 
-            Api.World.Logger.Audit("{0} Put {1}x{2} into {3} Ground storage at {4}.",
+            Api.World.Logger.Audit("{0} Put {1}x{2} into {3}Ground storage at {4}.",
                 player.PlayerName,
                 quantityMoved,
                 invSlot.Itemstack.Collectible.Code,
-                newStorage ? "new" : "",
+                isNewStorage ? "new " : "",
                 Pos
             );
 
@@ -1137,7 +1124,7 @@ namespace Vintagestory.GameContent
             ItemStack stack = null;
             if (inventory[0]?.Itemstack == null) return false;
 
-            // return true to play sounds etc. on the client, but only move items on the server side
+            // return early on the client, only move items on the server side
             if (Api.Side == EnumAppSide.Client) return true;
 
             bool takeBulk = player.Entity.Controls.CtrlKey;
@@ -1176,8 +1163,8 @@ namespace Vintagestory.GameContent
 
                     if (hotbarSlot.Empty || !player.Entity.Controls.ShiftKey) return false;
 
-                    bool newStorage = inventory.Empty;
-                    if (!newStorage)
+                    bool isNewStorage = inventory.Empty;
+                    if (!isNewStorage)
                     {
                         var hotbarlayout = hotbarSlot.Itemstack.Collectible.GetBehavior<CollectibleBehaviorGroundStorable>()?.StorageProps.Layout;
                         bool layoutEqual = StorageProps.Layout == hotbarlayout;
@@ -1197,7 +1184,7 @@ namespace Vintagestory.GameContent
                         if (!layoutEqual) return false;
                     }
 
-                    // return early on the client, but only move items on the server side
+                    // return early on the client, only move items on the server side
                     if (Api.Side == EnumAppSide.Client) return true;
 
                     ItemSlot sourceSlot = player.WorldData.CurrentGameMode == EnumGameMode.Creative ? new DummySlot(hotbarSlot.Itemstack.Clone()) : hotbarSlot;
@@ -1206,10 +1193,10 @@ namespace Vintagestory.GameContent
 
                     if (!didMoveItem) return false;
 
-                    Api.World.Logger.Audit("{0} Put 1x{1} into {2} Ground storage at {3}.",
+                    Api.World.Logger.Audit("{0} Put 1x{1} into {2}Ground storage at {3}.",
                         player.PlayerName,
                         ourSlot.Itemstack.Collectible.Code,
-                        newStorage ? "new" : "",
+                        isNewStorage ? "new " : "",
                         Pos
                     );
 
@@ -1217,7 +1204,7 @@ namespace Vintagestory.GameContent
                 }
                 else
                 {
-                    // return early on the client, but only move items on the server side
+                    // return early on the client, only move items on the server side
                     if (Api.Side == EnumAppSide.Client) return true;
 
                     if (!player.InventoryManager.TryGiveItemstack(ourSlot.Itemstack, true))

--- a/BlockEntity/BEGroundStorage.cs
+++ b/BlockEntity/BEGroundStorage.cs
@@ -345,7 +345,7 @@ namespace Vintagestory.GameContent
             removeIfEmpty();
         }
 
-        private bool removeIfEmpty()
+        protected bool removeIfEmpty()
         {
             if (Inventory.Empty)
             {
@@ -708,6 +708,7 @@ namespace Vintagestory.GameContent
             if (StorageProps == null) return 0;
 
             int selBoxId = bs.SelectionBoxIndex;
+
             if (bs.Block is not BlockGroundStorage || UsableSlots(StorageProps.Layout) < selBoxId)
             {
                 // by selection box is more robust, but by hit position is still a useful fallback (e.g. on initial placement)
@@ -737,9 +738,9 @@ namespace Vintagestory.GameContent
         {
             if (StorageProps == null || inventory.Empty) return false;
 
-            foreach (ItemSlot slot in inventory)
+            for (int slotId = 0; slotId < UsableSlots(StorageProps.Layout); slotId++)
             {
-                ItemStack stack = slot.Itemstack;
+                ItemStack stack = inventory[slotId].Itemstack;
                 if (stack == null) continue; // don't return false, as that would prevent building a pit kiln if some of the slots are empty
 
                 if (stack.StackSize > StorageProps.MaxFireable)
@@ -1073,13 +1074,13 @@ namespace Vintagestory.GameContent
 
         public virtual bool TryPutItem(IPlayer player)
         {
-            if (TotalStackSize >= Capacity) return false;
+            ItemSlot invSlot = inventory[0];
+
+            if (invSlot.StackSize >= Capacity) return false;
 
             ItemSlot hotbarSlot = player.InventoryManager.ActiveHotbarSlot;
 
             if (hotbarSlot.Itemstack == null) return false;
-
-            ItemSlot invSlot = inventory[0];
 
             // return true to play sounds etc. on the client, but only move items on the server side
             if (Api.Side == EnumAppSide.Client) return true;
@@ -1134,23 +1135,22 @@ namespace Vintagestory.GameContent
             int quantityMoved = 0;
 
             ItemStack stack = null;
-            if (inventory[0]?.Itemstack != null)
-            {
-                // return early on the client, but only move items on the server side
-                if (Api.Side == EnumAppSide.Client) return true;
+            if (inventory[0]?.Itemstack == null) return false;
 
-                bool takeBulk = player.Entity.Controls.CtrlKey;
+            // return true to play sounds etc. on the client, but only move items on the server side
+            if (Api.Side == EnumAppSide.Client) return true;
 
-                stack = inventory[0].TakeOut(GameMath.Min(takeBulk ? BulkTransferQuantity : TransferQuantity, TotalStackSize));
-                quantityMoved = stack.StackSize;
+            bool takeBulk = player.Entity.Controls.CtrlKey;
 
-                if (!player.InventoryManager.TryGiveItemstack(stack))
-                {
-                    Api.World.SpawnItemEntity(stack, Pos);
-                }
-            }
+            stack = inventory[0].TakeOut(GameMath.Min(takeBulk ? BulkTransferQuantity : TransferQuantity, TotalStackSize));
+            quantityMoved = stack.StackSize;
 
             if (quantityMoved <= 0) return false;
+
+            if (!player.InventoryManager.TryGiveItemstack(stack))
+            {
+                Api.World.SpawnItemEntity(stack, Pos);
+            }
 
             Api.World.Logger.Audit("{0} Took {1}x{2} from Ground storage at {3}.",
                 player.PlayerName,
@@ -1159,17 +1159,15 @@ namespace Vintagestory.GameContent
                 Pos
             );
 
-            LightUpdate(stack);
+            if (removeIfEmpty()) return true;
 
-            removeIfEmpty();
+            LightUpdate(stack);
 
             return true;
         }
 
         public bool putOrGetItemSingle(ItemSlot ourSlot, IPlayer player, BlockSelection bs)
         {
-            bool didMoveItem = false;
-
             lock (inventoryLock)
             {
                 if (ourSlot.Empty)
@@ -1204,17 +1202,18 @@ namespace Vintagestory.GameContent
 
                     ItemSlot sourceSlot = player.WorldData.CurrentGameMode == EnumGameMode.Creative ? new DummySlot(hotbarSlot.Itemstack.Clone()) : hotbarSlot;
 
-                    didMoveItem = sourceSlot.TryPutInto(Api.World, ourSlot, TransferQuantity) > 0;
+                    bool didMoveItem = sourceSlot.TryPutInto(Api.World, ourSlot, TransferQuantity) > 0;
 
-                    if (didMoveItem)
-                    {
-                        Api.World.Logger.Audit("{0} Put 1x{1} into {2} Ground storage at {3}.",
-                            player.PlayerName,
-                            ourSlot.Itemstack.Collectible.Code,
-                            newStorage ? "new" : "",
-                            Pos
-                        );
-                    }
+                    if (!didMoveItem) return false;
+
+                    Api.World.Logger.Audit("{0} Put 1x{1} into {2} Ground storage at {3}.",
+                        player.PlayerName,
+                        ourSlot.Itemstack.Collectible.Code,
+                        newStorage ? "new" : "",
+                        Pos
+                    );
+
+                    return true;
                 }
                 else
                 {
@@ -1234,11 +1233,10 @@ namespace Vintagestory.GameContent
 
                     ourSlot.Itemstack = null;
                     ourSlot.MarkDirty();
-                    didMoveItem = true;
+
+                    return true;
                 }
             }
-
-            return didMoveItem;
         }
 
         public override void FromTreeAttributes(ITreeAttribute tree, IWorldAccessor worldForResolving)
@@ -1260,9 +1258,6 @@ namespace Vintagestory.GameContent
 
             if (Api != null)
             {
-                //? not sure
-                // CheckInventoryClearedMidTick();
-
                 DetermineStorageProperties(null);
 
                 LightUpdate();

--- a/BlockEntity/BEGroundStorage.cs
+++ b/BlockEntity/BEGroundStorage.cs
@@ -1046,7 +1046,9 @@ namespace Vintagestory.GameContent
             bool newStorage = invSlot.Empty;
             bool putBulk = player.Entity.Controls.CtrlKey;
 
-            int quantityMoved = sourceSlot.TryPutInto(Api.World, invSlot, putBulk ? BulkTransferQuantity : TransferQuantity); //TEST temperature averaging
+            int quantityToMove = putBulk ? BulkTransferQuantity : TransferQuantity;
+            ItemStackMoveOperation op = new(Api.World, EnumMouseButton.Left, 0, EnumMergePriority.DirectMerge, quantityToMove);
+            int quantityMoved = sourceSlot.TryPutInto(invSlot, ref op);
 
             if (quantityMoved <= 0) return false;
 

--- a/BlockEntity/BEGroundStorage.cs
+++ b/BlockEntity/BEGroundStorage.cs
@@ -44,6 +44,9 @@ namespace Vintagestory.GameContent
 
         protected InventoryGeneric inventory;
 
+        /// <summary>
+        /// Properties of the ground storage - layout may be overridden, and other item-specific properties may not always be relevant
+        /// </summary>
         public GroundStorageProperties StorageProps { get; protected set; }
         public bool forceStorageProps = false;
         protected EnumGroundStorageLayout? overrideLayout;
@@ -520,8 +523,8 @@ namespace Vintagestory.GameContent
 
         public virtual bool OnPlayerInteractStart(IPlayer player, BlockSelection bs)
         {
-            isUsingSlot = null;
-            if (GetSlotAt(bs) is ItemSlot ourSlot && !ourSlot.Empty)
+            int targetSlotId = GetSlotIdAt(bs);
+            if (inventory[targetSlotId] is ItemSlot ourSlot && !ourSlot.Empty)
             {
                 var collIci = ourSlot.Itemstack.Collectible.GetCollectibleInterface<IContainedInteractable>();
                 if (collIci?.OnContainedInteractStart(this, ourSlot, player, bs) == true)
@@ -546,12 +549,12 @@ namespace Vintagestory.GameContent
             {
                 if (!hotbarSlot.Empty && StorageProps.CtrlKey && !player.Entity.Controls.CtrlKey) return false;
 
-                // fix RAD rotation being CCW - since n=0, e=-PiHalf, s=Pi, w=PiHalf so we swap east and west by inverting sign
-                // changed since > 1.18.1 since east west on WE rotation was broken, to allow upgrading/downgrading without issues we invert the sign for all* usages instead of saving new value
-                var hitPos = rotatedOffset(bs.HitPosition.ToVec3f(), -MeshAngle);
-
                 if (StorageProps.Layout == EnumGroundStorageLayout.Quadrants && inventory.Empty)
                 {
+                    // fix RAD rotation being CCW - since n=0, e=-PiHalf, s=Pi, w=PiHalf so we swap east and west by inverting sign
+                    // changed since > 1.18.1 since east west on WE rotation was broken, to allow upgrading/downgrading without issues we invert the sign for all* usages instead of saving new value
+                    var hitPos = rotatedOffset(bs.HitPosition.ToVec3f(), -MeshAngle);
+
                     double dx = Math.Abs(hitPos.X - 0.5);
                     double dz = Math.Abs(hitPos.Z - 0.5);
                     if (dx < 2 / 16f && dz < 2 / 16f)
@@ -561,40 +564,29 @@ namespace Vintagestory.GameContent
                     }
                 }
 
+                if (StorageProps.Layout == EnumGroundStorageLayout.SingleCenter && StorageProps.RandomizeCenterRotation)
+                {
+                    double randomX = Api.World.Rand.NextDouble() * 6.28 - 3.14;
+                    double randomZ = Api.World.Rand.NextDouble() * 6.28 - 3.14;
+                    MeshAngle = (float)Math.Atan2(randomX, randomZ);
+                }
+
+                targetSlotId = GetSlotIdAt(bs); // refresh the slot id in case StorageProps changed
+                ItemSlot targetSlot = inventory[targetSlotId];
+
                 switch (StorageProps.Layout)
                 {
-                    case EnumGroundStorageLayout.SingleCenter:
-                        if (StorageProps.RandomizeCenterRotation)
-                        {
-                            double randomX = Api.World.Rand.NextDouble() * 6.28 - 3.14;
-                            double randomZ = Api.World.Rand.NextDouble() * 6.28 - 3.14;
-                            MeshAngle = (float)Math.Atan2(randomX, randomZ);
-                        }
-                        ok = putOrGetItemSingle(inventory[0], player, bs);
-                        break;
-
-
-                    case EnumGroundStorageLayout.WallHalves:
-                    case EnumGroundStorageLayout.Halves:
-                        if (hitPos.X < 0.5)
-                        {
-                            ok = putOrGetItemSingle(inventory[0], player, bs);
-                        }
-                        else
-                        {
-                            ok = putOrGetItemSingle(inventory[1], player, bs);
-                        }
-                        break;
-
-                    case EnumGroundStorageLayout.Quadrants:
-                        int pos = ((hitPos.X > 0.5) ? 2 : 0) + ((hitPos.Z > 0.5) ? 1 : 0);
-                        ok = putOrGetItemSingle(inventory[pos], player, bs);
-                        break;
-
                     case EnumGroundStorageLayout.Messy12:
                     case EnumGroundStorageLayout.Stacking:
+                    {
                         ok = putOrGetItemStacking(player, bs);
                         break;
+                    }
+                    default:
+                    {
+                        ok = putOrGetItemSingle(GetSlotAt(bs), player, bs);
+                        break;
+                    }
                 }
             }
             UpdateIgnitable();
@@ -604,6 +596,19 @@ namespace Vintagestory.GameContent
             {
                 MarkDirty();    // Don't re-draw on client yet, that will be handled in FromTreeAttributes after we receive an updating packet from the server  (updating meshes here would have the wrong inventory contents, and also create a potential race condition)
             }
+
+            Cuboidf colBox = colBoxes[colBoxes.Length > targetSlotId ? targetSlotId : 0];
+            if (CollisionTester.AabbIntersect(
+                colBox,
+                Pos.X, Pos.Y, Pos.Z,
+                player.Entity.CollisionBox,
+                player.Entity.Pos.XYZ
+            ))
+            {
+                player.Entity.Pos.Y += colBox.Y2 - (player.Entity.Pos.Y - (int)player.Entity.Pos.Y);
+            }
+
+            (player as IClientPlayer)?.TriggerFpAnimation(EnumHandInteract.HeldItemInteract);
 
             if (inventory.Empty && !clientsideFirstPlacement)
             {
@@ -660,36 +665,29 @@ namespace Vintagestory.GameContent
             return true;
         }
 
-        public ItemSlot GetSlotAt(BlockSelection bs)
+        public int GetSlotIdAt(BlockSelection bs)
         {
-            if (StorageProps == null) return null;
-            var hitPos = rotatedOffset(bs.HitPosition.ToVec3f(), -MeshAngle);
+            if (StorageProps == null) return 0;
 
-            switch (StorageProps.Layout)
+            int selBoxId = bs.SelectionBoxIndex;
+            if (bs.Block is not BlockGroundStorage || UsableSlots(StorageProps.Layout) < selBoxId)
             {
-                case EnumGroundStorageLayout.Halves:
-                case EnumGroundStorageLayout.WallHalves:
-                    if (hitPos.X < 0.5)
-                    {
-                        return inventory[0];
-                    }
-                    else
-                    {
-                        return inventory[1];
-                    }
-
-                case EnumGroundStorageLayout.Quadrants:
-                    int pos = ((hitPos.X > 0.5) ? 2 : 0) + ((hitPos.Z > 0.5) ? 1 : 0);
-                    return inventory[pos];
-
-
-                case EnumGroundStorageLayout.SingleCenter:
-                case EnumGroundStorageLayout.Messy12:
-                case EnumGroundStorageLayout.Stacking:
-                    return inventory[0];
+                // by selection box is more robust, but by hit position is still a useful fallback (e.g. on initial placement)
+                var hitPos = rotatedOffset(bs.HitPosition.ToVec3f(), -MeshAngle);
+                selBoxId = StorageProps.Layout switch
+                {
+                    EnumGroundStorageLayout.Halves or EnumGroundStorageLayout.WallHalves => hitPos.X > 0.5 ? 1 : 0,
+                    EnumGroundStorageLayout.Quadrants => ((hitPos.X > 0.5) ? 2 : 0) + ((hitPos.Z > 0.5) ? 1 : 0),
+                    _ => 0,
+                };
             }
 
-            return null;
+            return selBoxId;
+        }
+
+        public ItemSlot GetSlotAt(BlockSelection bs)
+        {
+            return inventory[GetSlotIdAt(bs)];
         }
 
         public bool OnTryCreateKiln()
@@ -752,43 +750,102 @@ namespace Vintagestory.GameContent
 
         private void regenCollisionSelectionBox()
         {
-            ItemStack sourceStack = inventory.FirstNonEmptySlot?.Itemstack;
+            List<Cuboidf> auxColBoxes = [];
+            List<Cuboidf> auxSelBoxes = [];
 
-            Cuboidf colBox, selBox;
-            if (StorageProps.CollisionBox != null)
+            float meshAngleDegRounded = MathF.Round(MeshAngle / GameMath.PIHALF) * 90;
+            Vec3d centerOrigin = new(0.5, 0.5, 0.5);
+
+            for (int slotId = 0; slotId < UsableSlots(StorageProps.Layout); slotId++)
             {
-                colBox = selBox = StorageProps.CollisionBox.Clone();
-            }
-            else
-            {
-                if (sourceStack?.Block != null)
+                ItemStack sourceStack = inventory[slotId]?.Itemstack;
+
+                Cuboidf colBox = null;
+                Cuboidf selBox = null;
+
+                GroundStorageProperties stackStorageProps = sourceStack?.Collectible?.GetBehavior<CollectibleBehaviorGroundStorable>()?.StorageProps;
+
+                if (stackStorageProps != null)
                 {
-                    colBox = selBox = sourceStack.Block.CollisionBoxes[0].Clone();
+                    if (stackStorageProps.CollisionBox != null)
+                    {
+                        colBox = stackStorageProps.CollisionBox.Clone();
+                    }
+                    if (stackStorageProps.SelectionBox != null)
+                    {
+                        selBox = stackStorageProps.SelectionBox.Clone();
+                    }
                 }
-                else colBox = selBox = null;
+
+                // different default height for WallHalves is just because current JSON definitions overwhelmingly favor it for WallHalves for some reason
+                selBox ??= colBox?.Clone() ?? new(0, 0, 0, 1, StorageProps.Layout == EnumGroundStorageLayout.WallHalves ? 0.1f : 0.125f, 1);
+                colBox ??= new(0, 0, 0, 1, 0, 1);
+
+                switch (StorageProps.Layout)
+                {
+                    case EnumGroundStorageLayout.Halves:
+                    case EnumGroundStorageLayout.WallHalves:
+                    {
+                        transformCuboidForHalves(colBox, slotId);
+                        transformCuboidForHalves(selBox, slotId);
+                        break;
+                    }
+                    case EnumGroundStorageLayout.Quadrants:
+                    {
+                        transformCuboidForQuadrants(colBox, slotId);
+                        transformCuboidForQuadrants(selBox, slotId);
+                        break;
+                    }
+                    case EnumGroundStorageLayout.SingleCenter when stackStorageProps?.Layout == EnumGroundStorageLayout.Quadrants:
+                    {
+                        float scale = 0.5f;
+                        transformCuboidForSingleCenter(colBox, scale);
+                        transformCuboidForSingleCenter(selBox, scale);
+                        break;
+                    }
+                    case EnumGroundStorageLayout.Stacking:
+                    {
+                        if (StorageProps.CbScaleYByLayer != 0)
+                        {
+                            float scale = (int)Math.Ceiling(StorageProps.CbScaleYByLayer * sourceStack?.StackSize ?? 1);
+                            colBox.Y2 *= scale;
+                            selBox.Y2 *= scale;
+                        }
+                        break;
+                    }
+                    default: break;
+                }
+
+                auxColBoxes.Add(colBox.RotatedCopy(0, meshAngleDegRounded, 0, centerOrigin));
+                auxSelBoxes.Add(selBox.RotatedCopy(0, meshAngleDegRounded, 0, centerOrigin));
             }
 
-            if (StorageProps.SelectionBox != null)
-            {
-                selBox = StorageProps.SelectionBox.Clone();
-            }
+            colBoxes = [.. auxColBoxes];
+            selBoxes = [.. auxSelBoxes];
+        }
 
-            if (StorageProps.CbScaleYByLayer != 0)
-            {
-                colBox = colBox.Clone();
-                colBox.Y2 *= ((int)Math.Ceiling(StorageProps.CbScaleYByLayer * inventory[0].StackSize) * 8) / 8;
-
-                selBox = colBox;
-            }
-
-            if (colBox != null)
-            {
-                colBoxes[0] = colBox;
-            }
-            if (selBox != null)
-            {
-                selBoxes[0] = selBox;
-            }
+        private static void transformCuboidForHalves(Cuboidf cuboid, int slotId)
+        {
+            cuboid.X1 *= 0.5f;
+            cuboid.X2 *= 0.5f;
+            cuboid.Translate(halvesCenterOffsets[slotId] + new Vec3f(0.25f, 0, 0));
+        }
+        private static void transformCuboidForQuadrants(Cuboidf cuboid, int slotId)
+        {
+            cuboid.X1 *= 0.5f;
+            cuboid.X2 *= 0.5f;
+            cuboid.Z1 *= 0.5f;
+            cuboid.Z2 *= 0.5f;
+            cuboid.Translate(quadrantsCenterOffsets[slotId] + new Vec3f(0.25f, 0, 0.25f));
+        }
+        private static void transformCuboidForSingleCenter(Cuboidf cuboid, float scale = 1.0f)
+        {
+            cuboid.X1 *= scale;
+            cuboid.X2 *= scale;
+            cuboid.Z1 *= scale;
+            cuboid.Z2 *= scale;
+            float offset = (1 - scale) / 2;
+            cuboid.Translate(offset, 0, offset);
         }
 
         /// <summary>
@@ -860,7 +917,7 @@ namespace Vintagestory.GameContent
             }
         }
 
-        public int UsableSlots(EnumGroundStorageLayout layout)
+        public static int UsableSlots(EnumGroundStorageLayout layout)
         {
             switch (layout)
             {
@@ -1384,6 +1441,17 @@ namespace Vintagestory.GameContent
             return tfMatrices;
         }
 
+        private static readonly Vec3f[] halvesCenterOffsets = [
+            new(-0.25f, 0, 0),
+            new(0.25f, 0, 0),
+        ];
+        private static readonly Vec3f[] quadrantsCenterOffsets = [
+            new(-0.25f, 0, -0.25f),
+            new(-0.25f, 0, 0.25f),
+            new(0.25f, 0, -0.25f),
+            new(0.25f, 0, 0.25f),
+        ];
+
         public void GetLayoutOffset(Vec3f[] offs)
         {
             if (StorageProps == null) return;
@@ -1397,21 +1465,11 @@ namespace Vintagestory.GameContent
 
                 case EnumGroundStorageLayout.Halves:
                 case EnumGroundStorageLayout.WallHalves:
-                    // Left
-                    offs[0] = new Vec3f(-0.25f, 0, 0);
-                    // Right
-                    offs[1] = new Vec3f(0.25f, 0, 0);
+                    for (int i = 0; i < 2; i++) offs[i] = halvesCenterOffsets[i];
                     break;
 
                 case EnumGroundStorageLayout.Quadrants:
-                    // Top left
-                    offs[0] = new Vec3f(-0.25f, 0, -0.25f);
-                    // Top right
-                    offs[1] = new Vec3f(-0.25f, 0, 0.25f);
-                    // Bot left
-                    offs[2] = new Vec3f(0.25f, 0, -0.25f);
-                    // Bot right
-                    offs[3] = new Vec3f(0.25f, 0, 0.25f);
+                    for (int i = 0; i < 4; i++) offs[i] = quadrantsCenterOffsets[i];
                     break;
             }
         }

--- a/CollectibleBehavior/BehaviorGroundStorable.cs
+++ b/CollectibleBehavior/BehaviorGroundStorable.cs
@@ -99,10 +99,7 @@ namespace Vintagestory.GameContent
 
     public class CollectibleBehaviorGroundStorable : CollectibleBehavior
     {
-        public GroundStorageProperties StorageProps { 
-            get; 
-            protected set; 
-        }
+        public GroundStorageProperties StorageProps { get; protected set; }
 
         public CollectibleBehaviorGroundStorable(CollectibleObject collObj) : base(collObj)
         {
@@ -140,7 +137,7 @@ namespace Vintagestory.GameContent
             {
                 new WorldInteraction
                 {
-                    HotKeyCodes = StorageProps.CtrlKey ? new string[] {"ctrl", "shift" } : new string[] {"shift"},
+                    HotKeyCodes = StorageProps.CtrlKey ? ["ctrl", "shift"] : ["shift"],
                     ActionLangCode = "heldhelp-place",
                     MouseButton = EnumMouseButton.Right
                 }

--- a/CollectibleBehavior/BehaviorGroundStorable.cs
+++ b/CollectibleBehavior/BehaviorGroundStorable.cs
@@ -5,8 +5,6 @@ using Vintagestory.API.Common;
 using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
 
-#nullable disable
-
 namespace Vintagestory.GameContent
 {
     public enum EnumGroundStorageLayout
@@ -42,10 +40,10 @@ namespace Vintagestory.GameContent
     {
         public EnumGroundStorageLayout Layout = EnumGroundStorageLayout.SingleCenter;
         public int WallOffY = 1;
-        public AssetLocation PlaceRemoveSound = new AssetLocation("sounds/player/build");
+        public AssetLocation PlaceRemoveSound = new("sounds/player/build");
         public bool RandomizeSoundPitch;
         public bool RandomizeCenterRotation;
-        public AssetLocation StackingModel;
+        public AssetLocation StackingModel = null!;
 
         public int CuboidsPerModel = 1;
         public int ItemsPerModel = 1;
@@ -53,7 +51,7 @@ namespace Vintagestory.GameContent
         [Obsolete("Use CuboidsPerModel and ItemsPerModel instead")]
         public float ModelItemsToStackSizeRatio = 1;
 
-        public Dictionary<string, AssetLocation> StackingTextures;
+        public Dictionary<string, AssetLocation> StackingTextures = [];
         public int MaxStackingHeight = -1;
         public int StackingCapacity = 1;
         public int TransferQuantity = 1;
@@ -63,8 +61,8 @@ namespace Vintagestory.GameContent
         public bool SprintKey;
         public bool UpSolid = false;
 
-        public Cuboidf CollisionBox;
-        public Cuboidf SelectionBox;
+        public Cuboidf CollisionBox = null!;
+        public Cuboidf SelectionBox = null!;
         public float CbScaleYByLayer = 0;
 
         public int MaxFireable = 9999;
@@ -99,7 +97,7 @@ namespace Vintagestory.GameContent
 
     public class CollectibleBehaviorGroundStorable : CollectibleBehavior
     {
-        public GroundStorageProperties StorageProps { get; protected set; }
+        public GroundStorageProperties StorageProps { get; protected set; } = new();
 
         public CollectibleBehaviorGroundStorable(CollectibleObject collObj) : base(collObj)
         {
@@ -109,7 +107,7 @@ namespace Vintagestory.GameContent
         {
             base.Initialize(properties);
 
-            StorageProps = properties.AsObject<GroundStorageProperties>(null, collObj.Code.Domain);
+            StorageProps = properties.AsObject<GroundStorageProperties>(new(), collObj.Code.Domain);
             if (!properties["itemsPerModel"].Exists)
             {
                 StorageProps.ItemsPerModel = StorageProps.TransferQuantity;
@@ -133,28 +131,28 @@ namespace Vintagestory.GameContent
         public override WorldInteraction[] GetHeldInteractionHelp(ItemSlot inSlot, ref EnumHandling handling)
         {
             handling = EnumHandling.PassThrough;
-            return new WorldInteraction[]
-            {
+            return
+            [
                 new WorldInteraction
                 {
                     HotKeyCodes = StorageProps.CtrlKey ? ["ctrl", "shift"] : ["shift"],
                     ActionLangCode = "heldhelp-place",
                     MouseButton = EnumMouseButton.Right
                 }
-            };
+            ];
         }
 
 
 
         public static void Interact(ItemSlot itemslot, EntityAgent byEntity, BlockSelection blockSel, EntitySelection entitySel, bool firstEvent, ref EnumHandHandling handHandling, ref EnumHandling handling)
         {
-            IWorldAccessor world = byEntity?.World;
+            IWorldAccessor? world = byEntity?.World;
 
-            if (blockSel == null || world == null || !byEntity.Controls.ShiftKey) return;
+            if (blockSel == null || world == null || !byEntity!.Controls.ShiftKey) return;
 
 
-            IPlayer byPlayer = null;
-            if (byEntity is EntityPlayer) byPlayer = world.PlayerByUid(((EntityPlayer)byEntity).PlayerUID);
+            IPlayer? byPlayer = null;
+            if (byEntity is EntityPlayer player) byPlayer = world.PlayerByUid(player.PlayerUID);
             if (byPlayer == null) return;
 
             if (!world.Claims.TryAccess(byPlayer, blockSel.Position, EnumBlockAccessFlags.BuildOrBreak))
@@ -164,14 +162,13 @@ namespace Vintagestory.GameContent
                 return;
             }
 
-            BlockGroundStorage blockgs = world.GetBlock(new AssetLocation("groundstorage")) as BlockGroundStorage;
-            if (blockgs == null) return;
+            if (world.GetBlock(new AssetLocation("groundstorage")) is not BlockGroundStorage blockgs) return;
 
             BlockEntity be = world.BlockAccessor.GetBlockEntity(blockSel.Position);
             BlockEntity beAbove = world.BlockAccessor.GetBlockEntity(blockSel.Position.UpCopy());
             if (be is BlockEntityGroundStorage || beAbove is BlockEntityGroundStorage)
             {
-                if (((be as BlockEntityGroundStorage) ?? (beAbove as BlockEntityGroundStorage)).OnPlayerInteractStart(byPlayer, blockSel))
+                if (((be as BlockEntityGroundStorage) ?? (beAbove as BlockEntityGroundStorage))?.OnPlayerInteractStart(byPlayer, blockSel) == true)
                 {
                     handHandling = EnumHandHandling.PreventDefault;
                 }


### PR DESCRIPTION
## Description

A collection of well over a dozen tweaks and fixes, as well as general refactoring including enabling nullable context, for the primary components of the ground storage system (behavior, block and BE), as well as a couple fixes related to pit kilns - see the list of some of the most important changes below. Naturally, I’m open to making further adjustments if necessary.

While the sheer number of changes is pretty massive, it is difficult to disentangle some of them, as quite a few changes relied on each other and were done in tandem. I hope that this bulk format is fine, but if necessary I could try to isolate a couple of the most important fixes for priority integration.

## Tweaks

- Tweak:  Separate the collision and selection box for the `Halves`, `WallHalves` and  `Quadrants` layouts appropriately into two or four smaller cuboids.
  - Clone and transform cuboids separately for each inventory slot whenever possible.
  - The current full-block cuboids get scaled along the X and/or Z axis as needed, so this doesn’t require any JSON changes.
  - Also changes recognition of which inventory slot is targeted to be based on the targeted selection box, not by hit position. When no box is selected, defaults back to hit position.
  - Also fixes an issue where the height of the selection box would depend on the first non-empty slot only.
  - The selection boxes currently all appear together at once, and I’m not certain how to make only one appear at a time. That said, I’m also not certain whether that would even be desirable, because having them all highlighted together communicates that they are treated as one whole and may prevent other confusion.
  - This also required adding hitboxes to `WallHalves` which didn't have them at all. It arguably looks odd in some cases, primarily for small items like knives. Reverting or some selection box adjustments could be reasonable for this.
  - <details> <summary>Relevant images. </summary> <img width="583" height="360" alt="image" src="https://github.com/user-attachments/assets/1dc4fd85-415d-42de-9bfd-be0ebf19cf42" /><img width="637" height="397" alt="image" src="https://github.com/user-attachments/assets/ef2836c2-c148-40c5-8f32-d365400b8e6d" /><img width="627" height="458" alt="image" src="https://github.com/user-attachments/assets/cc5e19f4-6215-4e46-943b-966e5b2658aa" /><img width="597" height="403" alt="image" src="https://github.com/user-attachments/assets/d3755e09-c5af-4e5e-9418-d858dee7b3c6" />
  </details>
- Tweak: Add interaction help for constructing a firepit with grass, shown only when the ground storage contains suitable items.
  - Would largely address [#9061](https://github.com/anegostudios/VintageStory-Issues/issues/9061) and [#9446](https://github.com/anegostudios/VintageStory-Issues/issues/9446).
  <img width="671" height="252" alt="image" src="https://github.com/user-attachments/assets/e1d65542-e74a-4ef2-ab8c-c1e142664164" />
- Tweak: Remove interaction help for adding more items to ground storage if an item definitely can’t be put in, when the ground storage is full.
  - For `Halves`, `WallHalves` and  `Quadrants`, this is checked separately for each slot.
  <img width="671" height="244" alt="image" src="https://github.com/user-attachments/assets/cc4f5862-320f-48eb-9832-727810280d4d" />
- Tweak: Reduce the collision and selection box size for items that normally use the `Quadrants` layout when placed in `SingleCenter`, as well as the default size of of `SingleCenter` items (this latter change doesn't affect the vanilla game as far as I can tell).
- Tweak: Allow picking a block to use the currently targeted slot in multi-slot storage instead of always returning the first non-empty slot.
- Tweak: Allow picking up items more freely from ground storage, even with an item in hand. This is also more consistent with block interaction help suggesting that items can be picked up with RMB-only, without the requirement of a free slot.
  - Fixes [#9643](https://github.com/anegostudios/VintageStory-Issues/issues/9643).
- Tweak: Reorder the interaction help for “add many”, so that it’s next to “add one” rather than after “remove one”.
  - It may be somewhat subjective, but it seems to me that it’s much more readable this way.
  <img width="737" height="199" alt="image" src="https://github.com/user-attachments/assets/10083e41-3e47-4546-bda9-5877e6c39683" />

## Fixes

Fixes [#1170](https://github.com/anegostudios/VintageStory-Issues/issues/1170):
- Issue: Pit kiln can be built with items that can’t be fired in certain scenarios, because only the first non-empty inventory slot is tested.
  - Fix: Test all inventory slots when checking whether a pit kiln can be created, not just the first non-empty slot.

Fixes [#8686](https://github.com/anegostudios/VintageStory-Issues/issues/8686):
- Issue: Light was only updated on the client when interacting with ground storage.
  - Fix: Trigger a light update in `FromTreeAttributes()`.

Fixes other issues related to ground storage and pit kilns:
- Issue: `BlockPitkiln` interaction help suggests that material be added with `“shift”`, despite no hotkey restrictions being implemented for it.
  - Fix: Remove the `“shift”` hotkey from block interaction help (no changes to functionality).
- Issue: The `WallHalves` and `Messy12` layouts have no block interaction help.
  - Fix: Add the missing interaction help.
  - There is a chance that this was intentional in some capacity, especially for `WallHalves`, but it was nonetheless an inconsistency.
- Issue: Items with a `Quadrants` layout placed in a `SingleCenter` layout can’t be picked up with RMB while holding an item in hand.
  - Fix: Add a special case to assume the layouts are equal in this scenario.
- Issue: The collision and selection boxes for items stored in SingleCenter aren’t correctly rotated. Most notable on raw clay anvil molds.
  - Fix: Rotate the boxes.
- Issue: Removing a light source from ground storage with other different light sources doesn’t update the light correctly (leaves a ring of light).
  - Reproduce: Place an oil lamp in ground storage, add a small lantern, remove the lantern.
  - Fix: Use the maximum available light radius for light updates whenever necessary after moving any items.
- Issue: Ignitable items in newly-created ground storage can’t actually be ignited until the ground storage is reloaded or updated.
  - Fix: Call `UpdateIgnitable()` in `DetermineStorageProperties()` (which gets called in `FromTreeAttributes()`, ensuring proper synchronization).

## Other

There's also some tweaks, fixes and refactoring that I haven’t documented as much. Mostly small, miscellaneous stuff, but notably I reworked parts of the logic surrounding taking and putting items out of and into ground storage and tweaked when animations and sounds play in a way which hopefully makes things easier to read and maintain.

I've tried looking into [#9080](https://github.com/anegostudios/VintageStory-Issues/issues/9080), but I was unable to reproduce it myself. It seems like the symptom of the issue a server-side ground storage block that the client is unaware of. There is a small chance that this PR addresses the issue, possibly by moving the early client-side return to just before moving items and thereby marking the entire ground sotrage column as dirty, but I can't say that confidently since I don't know the actual root cause.

An additional tweak that I wanted to implement but haven’t managed to do so is making the interaction help Y offset depend on the highest selection box size for the ground storage, so that it is placed closer to where it generally should be placed. This didn’t work for two reasons which seems well out of scope:
- the interaction help Y offset wouldn’t update properly when hovering over new blocks, as if it only updated when hovering over a different block type,
- when the interaction help Y offset was at least 1.0f, it didn’t seem like it updated at all in some cases when moving the cursor up.

There is a related issue that this PR does not or cannot fix - some items incorrectly have a `ctrlKey: true` property in their `GroundStorable` behavior.
- Affected items:
  - `honeycomb` (`honeycomb.json`),
  - `rope` (`rope.json`),
  - `seeds` (`seeds.json`),
  - `coralchunk` (`stone-coral.json`),
  - `stone` (`stone.json`).
- As a general rule, none of those items should have the `ctrlKey: true` property on a design level, but there are two cases where removing it might cause issues.
  - For `stone`, removing that property makes it impossible to knap with stones. Maybe some additional change could make it work somewhat. There are also miscellaneous conflicts with placing down stones as a block, throwing them, and drawing cave paintings.
  - For `rope`, this somewhat conflicts with the code comment in `ItemRope.cs` which states that RMB + sneak (Ctrl by default) should be used for attaching rope (despite no such restriction being currently implemented - the functionality seems like it's identical regardless of inputs and only gets an early return with both Ctrl and Shift). It seems like this shouldn't cause issues given that rope probably can't be attached to flat surfaces or ground storage, but it seems worth mentioning regardless.
  - For other items, I've not found any problems that this could cause.
- This `ctrlKey: true` property causes a bunch of inconsistencies and conflicts including overlap with bulk transfer, and it should be either removed entirely or hardcoded for the `WallHalves` layout, because having the option to force different keybinds for the same functionality on different items doesn't seem like it has any real purpose besides as a bandaid to other problems like with knapping stones.
- Because of this, it could also be argued that the game needs a separate keybind for knapping, or for ground storage, or both, or some other redesign, because having multiple behaviors fighting for the same keybinds is an easy way to create unnecessary problems.
- Also, block interaction help for items with `ctrlKey: true` does not always show the correct hotkeys. A full fix for this seems to be out of scope of this PR because changing the active hotbar slot currently just does not update block interaction help.