### PR TITLE
Add IBlockMealContainer.CanAcceptMealServings to prevent pies and sealed crocks from taking servings

### DIFF
--- a/Block/BlockCookedContainerBase.cs
+++ b/Block/BlockCookedContainerBase.cs
@@ -17,9 +17,25 @@ namespace Vintagestory.GameContent
 
             ObjectCacheUtil.GetOrCreate<ItemStack[]>(api, "mealcontainers", () =>
             {
-                return [.. api.World.Collectibles.Where(obj => obj.Attributes?.IsTrue("mealContainer") == true)
+                return [.. api.World.Collectibles.Where(obj => IsMealContainer(new ItemStack(obj)))
                                                  .SelectMany(obj => obj.GetHandBookStacks(api as ICoreClientAPI) ?? [])];
             });
+        }
+
+        /// <summary>
+        /// Can this ItemStack accept meal servings?
+        ///
+        /// Used to prevent items like pies and sealed crocks from trying to take servings.
+        /// </summary>
+        public static bool IsMealContainer(ItemStack containerStack)
+        {
+            return containerStack.ItemAttributes?.IsTrue("mealContainer") == true
+                || (containerStack.Collectible as IBlockMealContainer)?.CanAcceptMealServings(containerStack) == true;
+        }
+
+        public virtual bool CanAcceptMealServings(ItemStack containerStack)
+        {
+            return true;
         }
 
         public void SetContents(string? recipeCode, float servings, ItemStack containerStack, ItemStack[] stacks)
@@ -161,7 +177,8 @@ namespace Vintagestory.GameContent
         public override int GetMergableQuantity(ItemStack sinkStack, ItemStack sourceStack, EnumMergePriority priority)
         {
             if (priority != EnumMergePriority.AutoMerge &&
-                (sourceStack?.Block is IBlockMealContainer || (sourceStack?.Collectible?.Attributes?.IsTrue("mealContainer") ?? false)) &&
+                sourceStack != null &&
+                IsMealContainer(sourceStack) &&
                 GetServings(api.World, sinkStack) > 0)
                 return Math.Max(1, Math.Min(MaxStackSize - sinkStack.StackSize, sourceStack.StackSize));
 
@@ -170,7 +187,7 @@ namespace Vintagestory.GameContent
 
         public override void TryMergeStacks(ItemStackMergeOperation op)
         {
-            if (op.SourceSlot.Itemstack!.Block is IBlockMealContainer || op.SourceSlot.Itemstack.Collectible.Attributes?.IsTrue("mealContainer") == true)
+            if (!op.SourceSlot.Empty && IsMealContainer(op.SourceSlot.Itemstack))
             {
                 if (op.CurrentPriority != EnumMergePriority.DirectMerge)
                 {
@@ -404,7 +421,7 @@ namespace Vintagestory.GameContent
             var targetSlot = byPlayer.InventoryManager.ActiveHotbarSlot;
             if (targetSlot.Empty) return false;
 
-            if ((targetSlot.Itemstack.Collectible.Attributes?.IsTrue("mealContainer") == true || targetSlot.Itemstack.Block is IBlockMealContainer) && GetServings(api.World, slot.Itemstack) > 0)
+            if (IsMealContainer(targetSlot.Itemstack) && GetServings(api.World, slot.Itemstack) > 0)
             {
                 bool served = false;
                 if (targetSlot.StackSize > 1)

--- a/Block/BlockCrock.cs
+++ b/Block/BlockCrock.cs
@@ -45,6 +45,11 @@ namespace Vintagestory.GameContent
             });
         }
 
+        public override bool CanAcceptMealServings(ItemStack containerStack)
+        {
+            return containerStack.Attributes?.GetBool("sealed") == false;
+        }
+
         public override float GetContainingTransitionModifierContained(IWorldAccessor world, ItemSlot inSlot, EnumTransitionType transType)
         {
             float mul = 1;
@@ -302,7 +307,7 @@ namespace Vintagestory.GameContent
             Block block = api.World.BlockAccessor.GetBlock(blockSel.Position);
             float quantityServings = (float)crockStack.Attributes.GetDecimal("quantityServings");
 
-            if (block?.Attributes?.IsTrue("mealContainer") == true)
+            if (IsMealContainer(new ItemStack(block)))
             {
                 if (!byEntity.Controls.ShiftKey) return;
                 if (quantityServings > 0)
@@ -322,7 +327,7 @@ namespace Vintagestory.GameContent
                     return;
                 }
 
-                if (gsslot.Itemstack.ItemAttributes?.IsTrue("mealContainer") == true)
+                if (IsMealContainer(gsslot.Itemstack))
                 {
                     if (quantityServings > 0)
                     {
@@ -426,7 +431,7 @@ namespace Vintagestory.GameContent
         {
             ItemSlot hotbarSlot = byPlayer.InventoryManager.ActiveHotbarSlot;
 
-            if (!hotbarSlot.Empty && hotbarSlot.Itemstack.Collectible.Attributes?.IsTrue("mealContainer") == true && (!(hotbarSlot.Itemstack.Collectible is BlockCrock) || hotbarSlot.StackSize == 1))
+            if (!hotbarSlot.Empty && IsMealContainer(hotbarSlot.Itemstack) && (hotbarSlot.Itemstack.Collectible is not BlockCrock || hotbarSlot.StackSize == 1))
             {
                 if (world.BlockAccessor.GetBlockEntity(blockSel.Position) is not BlockEntityCrock bec) return false;
 

--- a/Block/BlockFirepit.cs
+++ b/Block/BlockFirepit.cs
@@ -276,7 +276,7 @@ namespace Vintagestory.GameContent
                         }
                     }
 
-                    if (stack.Collectible.Attributes?.IsTrue("mealContainer") == true && !activated)
+                    if (BlockCookedContainerBase.IsMealContainer(stack) == true && !activated)
                     {
                         ItemSlot potSlot = null;
                         if (bef.inputStack?.Collectible is BlockCookedContainer)

--- a/Block/BlockPie.cs
+++ b/Block/BlockPie.cs
@@ -27,6 +27,11 @@ namespace Vintagestory.GameContent
         public string State => Variant["state"];
         protected override bool PlacedBlockEating => false;
 
+        public override bool CanAcceptMealServings(ItemStack containerStack)
+        {
+            return false;
+        }
+
         public EnumShelvableLayout? GetShelvableType(ItemStack stack)
         {
             return stack.Attributes.GetAsInt("pieSize") switch

--- a/Block/BlockShelf.cs
+++ b/Block/BlockShelf.cs
@@ -23,7 +23,7 @@ namespace Vintagestory.GameContent
 
                 foreach (var obj in api.World.Collectibles)
                 {
-                    if (obj?.Attributes?["mealContainer"]?.AsBool() == true || obj is IContainedInteractable or IBlockMealContainer ||
+                    if (BlockCookedContainerBase.IsMealContainer(new ItemStack(obj)) || obj is IContainedInteractable ||
                         obj?.Attributes?["canSealCrock"]?.AsBool() == true)
                     {
                         usableItemStacklist.Add(new ItemStack(obj));

--- a/BlockEntity/BEShelf.cs
+++ b/BlockEntity/BEShelf.cs
@@ -115,7 +115,7 @@ namespace Vintagestory.GameContent
 
                 invColl = inv[i].Itemstack.Collectible;
 
-                if (obj?.Attributes?["mealContainer"]?.AsBool() == true || obj is IContainedInteractable or IBlockMealContainer)
+                if (BlockCookedContainerBase.IsMealContainer(stack) || obj is IContainedInteractable)
                 {
                     return invColl is BlockCookedContainerBase;
                 }

--- a/Systems/Cooking/BlockCookedContainer.cs
+++ b/Systems/Cooking/BlockCookedContainer.cs
@@ -58,7 +58,7 @@ namespace Vintagestory.GameContent
 
                 foreach (CollectibleObject obj in api.World.Collectibles)
                 {
-                    if (obj.Attributes?.IsTrue("mealContainer") == true)
+                    if (IsMealContainer(new ItemStack(obj)))
                     {
                         List<ItemStack> stacks = obj.GetHandBookStacks(capi);
                         if (stacks != null) fillableStacklist.AddRange(stacks);
@@ -374,7 +374,7 @@ namespace Vintagestory.GameContent
         {
             ItemSlot hotbarSlot = byPlayer.InventoryManager.ActiveHotbarSlot;
 
-            if (!hotbarSlot.Empty && hotbarSlot.Itemstack.Collectible.Attributes?.IsTrue("mealContainer") == true)
+            if (!hotbarSlot.Empty && IsMealContainer(hotbarSlot.Itemstack))
             {
                 return (world.BlockAccessor.GetBlockEntity(blockSel.Position) as BlockEntityCookedContainer)?.ServeInto(byPlayer, hotbarSlot) ?? false;
             }
@@ -411,7 +411,7 @@ namespace Vintagestory.GameContent
                 }
 
                 Block selectedBlock = byEntity.World.BlockAccessor.GetBlock(blockSel.Position);
-                if (selectedBlock?.Attributes?.IsTrue("mealContainer") == true)
+                if (IsMealContainer(new ItemStack(selectedBlock)))
                 {
                     if (!byEntity.Controls.ShiftKey) return;
                     ServeIntoBowl(selectedBlock, blockSel.Position, slot, byEntity.World);
@@ -429,7 +429,7 @@ namespace Vintagestory.GameContent
                         return;
                     }
 
-                    if (gsslot.Itemstack.ItemAttributes?.IsTrue("mealContainer") == true)
+                    if (IsMealContainer(gsslot.Itemstack))
                     {
                         if (quantityServings > 0)
                         {

--- a/Systems/Cooking/BlockMeal.cs
+++ b/Systems/Cooking/BlockMeal.cs
@@ -24,6 +24,15 @@ namespace Vintagestory.GameContent
         void SetQuantityServings(IWorldAccessor world, ItemStack containerStack, float quantityServings);
         public CookingRecipe? GetCookingRecipe(IWorldAccessor world, ItemStack? containerStack);
 
+        /// <summary>
+        /// Can this container actually accept a meal serving?
+        ///
+        /// Used to prevent items like pie slices from vanishing when trying to
+        /// </summary>
+        public bool CanAcceptMealServings(ItemStack containerStack)
+        {
+            return true;
+        }
     }
 
     public interface IBlockEntityMealContainer
@@ -748,7 +757,10 @@ namespace Vintagestory.GameContent
             return api.GetCookingRecipe(recipecode);
         }
 
-
+        public virtual bool CanAcceptMealServings(ItemStack containerStack)
+        {
+            return true;
+        }
 
         public override void OnBeforeRender(ICoreClientAPI capi, ItemStack itemstack, EnumItemRenderTarget target, ref ItemRenderInfo renderinfo)
         {


### PR DESCRIPTION
Fixes https://github.com/anegostudios/VintageStory-Issues/issues/7214.

Requires removing the `mealContainer` attribute from crocks so that the `BlockCookedContainerBase.IsMealContainer()` check does not always succeed.